### PR TITLE
fix: UTF-8 safe truncation, storage enforcement chunk size, clippy errors

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Syslog management via MCP",
   "author": "jmagar",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Syslog management via MCP",
   "author": "jmagar",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Syslog management via MCP",
   "author": "jmagar",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Syslog management via MCP",
   "author": "jmagar",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Syslog management via MCP.",
   "homepage": "https://github.com/jmagar/syslog-mcp",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Syslog management via MCP.",
   "homepage": "https://github.com/jmagar/syslog-mcp",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Syslog management via MCP.",
   "homepage": "https://github.com/jmagar/syslog-mcp",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Syslog management via MCP.",
   "homepage": "https://github.com/jmagar/syslog-mcp",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Syslog management via MCP.",
   "homepage": "https://github.com/jmagar/syslog-mcp",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,3 +73,25 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
 
+
+      - name: Install mcp-publisher
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Set version in server.json
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" --arg img "ghcr.io/jmagar/syslog-mcp:${VERSION}" '
+            .version = $v |
+            .packages = [.packages[] | if .registryType == "oci" then .identifier = $img else . end]
+          ' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: ./mcp-publisher login dns --domain tootie.tv --private-key ${{ secrets.MCP_PRIVATE_KEY }}
+
+      - name: Publish to MCP Registry
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: ./mcp-publisher publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-04-03
+
+### Fixed
+
+- **`src/db.rs`**: FTS5 write-lock contention during retention purge and storage-budget bulk deletes — removed `logs_ad` (AFTER DELETE) and `logs_au` (AFTER UPDATE) triggers that fired per-row inside 10k-chunk transactions, starving the batch writer. Added migration to drop triggers from existing databases. FTS5 phantom rows are cleaned up by incremental merge (syslog-mcp-eg5)
+
+### Added
+
+- **`src/db.rs`**: Incremental FTS merge (`merge=500,250`) after storage-budget enforcement bulk deletes, matching the existing `purge_old_logs` pattern
+
 ## [0.2.3] — 2026-04-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`src/syslog.rs`**: TCP accept loop blocked when connection semaphore was at capacity — replaced blocking `acquire_owned().await` with non-blocking `try_acquire_owned()` so the accept loop rejects new connections immediately instead of stalling for up to 300s (idle timeout)
 
-## [0.2.2] — 2026-04-04
+## [0.2.2] — 2026-04-03
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-04-04
+
+### Fixed
+- **`src/mcp.rs`**: `summarize_json_value` panicked on multi-byte UTF-8 input (non-ASCII syslog messages) — replaced `&raw[..limit]` with a char-boundary-aware walk-back loop; added test covering Greek/CJK input
+- **`src/db.rs`**: Storage enforcement deleted 1 row per cycle (extremely slow for large overages) — now configurable via `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` (default 2000); WAL checkpoint moved outside the recovery loop
+- **`src/config.rs`**: Added validation rejecting `cleanup_chunk_size == 0` (would cause an infinite enforcement loop)
+- **Clippy**: Fixed 4 `-D warnings` errors blocking `cargo test` — `derivable_impls` on `Config::Default`, `match_like_matches_macro` in `is_transient_sqlite_lock`, `needless_late_init` for `close_reason`, `len_zero` in `batch_writer`
+
+### Added
+- **`src/config.rs`**: `cleanup_chunk_size` field in `StorageConfig` with env var `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` (default 2000 rows per enforcement chunk)
+- **`src/config.rs`**: `#[cfg(test)] StorageConfig::for_test()` constructor — centralizes test config; `mcp.rs` and `syslog.rs` test helpers now delegate to it
+- **`docs/sessions/2026-04-03-mcp-test-code-review-simplify.md`**: Full session documentation
+
 ## [0.2.1] - 2026-04-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-04-03
+
+### Fixed
+
+- **`src/syslog.rs`**: TCP accept loop blocked when connection semaphore was at capacity — replaced blocking `acquire_owned().await` with non-blocking `try_acquire_owned()` so the accept loop rejects new connections immediately instead of stalling for up to 300s (idle timeout)
+
 ## [0.2.2] — 2026-04-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] — 2026-04-03
+
+### Added
+
+- **`src/mcp.rs`**: 9 HTTP-level integration tests for all 6 MCP tools and auth middleware using `tower::util::ServiceExt::oneshot` — covers health endpoint, initialize, tools/list, get_stats, tail_logs, search_logs, unknown method error, auth rejection (missing token), and auth success (correct token)
+- **`Cargo.toml`**: `tower` 0.5 added to dev-dependencies for axum router integration testing
+
 ## [0.2.4] — 2026-04-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] — 2026-04-04
+
+### Changed
+
+- **`src/db.rs`**: Extracted `fts_incremental_merge()` helper — eliminates duplicated FTS merge string across `purge_old_logs` and `enforce_storage_budget`
+- **`src/mcp.rs`**: `test_state()` now delegates to `test_state_with_token(None)`; `mcp_post()` gains optional `auth` param — auth integration tests no longer inline the request builder
+
+### Fixed
+
+- **`src/config.rs`**: Added `accepts_cleanup_chunk_size_at_i64_max` boundary test; tightened overflow test to assert error message; added `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` to `defaults_are_applied_without_env_vars` clear list and assertion
+- **`src/db.rs`**: Migrated `test_storage_config()` to `StorageConfig::for_test()`
+- **`src/syslog.rs`**: `TryAcquireError::Closed` branch now logs at `error!` before breaking
+- **`CHANGELOG.md`**: Corrected v0.2.2 date (`2026-04-04` → `2026-04-03`)
+
 ## [0.2.5] — 2026-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.2] — 2026-04-04
 
 ### Fixed
+
 - **`src/mcp.rs`**: `summarize_json_value` panicked on multi-byte UTF-8 input (non-ASCII syslog messages) — replaced `&raw[..limit]` with a char-boundary-aware walk-back loop; added test covering Greek/CJK input
 - **`src/db.rs`**: Storage enforcement deleted 1 row per cycle (extremely slow for large overages) — now configurable via `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` (default 2000); WAL checkpoint moved outside the recovery loop
 - **`src/config.rs`**: Added validation rejecting `cleanup_chunk_size == 0` (would cause an infinite enforcement loop)
 - **Clippy**: Fixed 4 `-D warnings` errors blocking `cargo test` — `derivable_impls` on `Config::Default`, `match_like_matches_macro` in `is_transient_sqlite_lock`, `needless_late_init` for `close_reason`, `len_zero` in `batch_writer`
 
 ### Added
+
 - **`src/config.rs`**: `cleanup_chunk_size` field in `StorageConfig` with env var `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` (default 2000 rows per enforcement chunk)
 - **`src/config.rs`**: `#[cfg(test)] StorageConfig::for_test()` constructor — centralizes test config; `mcp.rs` and `syslog.rs` test helpers now delegate to it
 - **`docs/sessions/2026-04-03-mcp-test-code-review-simplify.md`**: Full session documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syslog-mcp"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1027,6 +1027,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syslog-mcp"
-version = "0.2.4"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syslog-mcp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ futures-core = "0.3"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+tower = { version = "0.5", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.2.2"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,7 @@ EXPOSE 514/udp 514/tcp 3100/tcp
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -sf http://localhost:3100/health || exit 1
 
+LABEL io.modelcontextprotocol.server.name="tv.tootie/syslog-mcp"
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["syslog-mcp"]

--- a/README.md
+++ b/README.md
@@ -762,21 +762,6 @@ Authorization: Bearer <token>
 | [plugin-lab](https://github.com/jmagar/plugin-lab) | dev-tools | Scaffold, review, align, and deploy homelab MCP plugins with agents and canonical templates. |
 | [axon](https://github.com/jmagar/axon) | research | Self-hosted web crawl, ingest, embed, and RAG pipeline with MCP tooling. |
 
-## Related plugins
-
-| Plugin | Category | Description |
-|--------|----------|-------------|
-| [homelab-core](https://github.com/jmagar/claude-homelab) | core | Core agents, commands, skills, and setup/health workflows for homelab management. |
-| [overseerr-mcp](https://github.com/jmagar/overseerr-mcp) | media | Search movies and TV shows, submit requests, and monitor failed requests via Overseerr. |
-| [unraid-mcp](https://github.com/jmagar/unraid-mcp) | infrastructure | Query, monitor, and manage Unraid servers: Docker, VMs, array, parity, and live telemetry. |
-| [unifi-mcp](https://github.com/jmagar/unifi-mcp) | infrastructure | Monitor and manage UniFi devices, clients, firewall rules, and network health. |
-| [gotify-mcp](https://github.com/jmagar/gotify-mcp) | utilities | Send and manage push notifications via a self-hosted Gotify server. |
-| [swag-mcp](https://github.com/jmagar/swag-mcp) | infrastructure | Create, edit, and manage SWAG nginx reverse proxy configurations. |
-| [synapse-mcp](https://github.com/jmagar/synapse-mcp) | infrastructure | Docker management (Flux) and SSH remote operations (Scout) across homelab hosts. |
-| [arcane-mcp](https://github.com/jmagar/arcane-mcp) | infrastructure | Manage Docker environments, containers, images, volumes, networks, and GitOps via Arcane. |
-| [plugin-lab](https://github.com/jmagar/plugin-lab) | dev-tools | Scaffold, review, align, and deploy homelab MCP plugins with agents and canonical templates. |
-| [axon](https://github.com/jmagar/axon) | research | Self-hosted web crawl, ingest, embed, and RAG pipeline with MCP tooling. |
-
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Syslog MCP
 
+[![crates.io](https://img.shields.io/crates/v/syslog-mcp)](https://crates.io/crates/syslog-mcp) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Fsyslog--mcp-blue?logo=docker)](https://github.com/jmagar/syslog-mcp/pkgs/container/syslog-mcp)
+
 Rust syslog receiver and MCP server for homelab log intelligence. Ingests syslog over UDP and TCP, stores it in SQLite with FTS5 full-text indexing, and exposes search, tail, error summary, correlation, and stats tools to MCP clients.
 
 ## Overview

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Homelab syslog receiver and MCP server for searching, tailing, and correlating logs across hosts.",
   "mcpServers": {
     "syslog-mcp": {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Homelab syslog receiver and MCP server for searching, tailing, and correlating logs across hosts.",
   "mcpServers": {
     "syslog-mcp": {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Homelab syslog receiver and MCP server for searching, tailing, and correlating logs across hosts.",
   "mcpServers": {
     "syslog-mcp": {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Homelab syslog receiver and MCP server for searching, tailing, and correlating logs across hosts.",
   "mcpServers": {
     "syslog-mcp": {

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Homelab syslog receiver and MCP server for searching, tailing, and correlating logs across hosts.",
   "mcpServers": {
     "syslog-mcp": {

--- a/server.json
+++ b/server.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "tv.tootie/syslog-mcp",
+  "title": "Syslog MCP",
+  "description": "Syslog receiver and MCP server for homelab log intelligence.",
+  "repository": {
+    "url": "https://github.com/jmagar/syslog-mcp",
+    "source": "github"
+  },
+  "version": "0.2.6",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.2.6",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "SYSLOG_HOST",
+          "description": "Hostname or IP of the syslog listener.",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "SYSLOG_MCP_TOKEN",
+          "description": "Bearer token for MCP endpoint authentication.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "SYSLOG_PORT",
+          "description": "Syslog listener port (UDP + TCP). Default: 514.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -372,7 +372,32 @@ fn validate_storage_config(storage: &StorageConfig) -> anyhow::Result<()> {
         ));
     }
 
+    if storage.cleanup_chunk_size == 0 {
+        return Err(anyhow::anyhow!(
+            "cleanup_chunk_size must be > 0"
+        ));
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+impl StorageConfig {
+    /// Returns a minimal StorageConfig for use in unit tests.
+    pub fn for_test(db_path: std::path::PathBuf) -> Self {
+        Self {
+            db_path,
+            pool_size: 1,
+            retention_days: 90,
+            wal_mode: false,
+            max_db_size_mb: 1024,
+            recovery_db_size_mb: 900,
+            min_free_disk_mb: 0,
+            recovery_free_disk_mb: 0,
+            cleanup_interval_secs: 60,
+            cleanup_chunk_size: 1,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -453,6 +453,7 @@ mod tests {
             "SYSLOG_MCP_MIN_FREE_DISK_MB",
             "SYSLOG_MCP_RECOVERY_FREE_DISK_MB",
             "SYSLOG_MCP_CLEANUP_INTERVAL_SECS",
+            "SYSLOG_MCP_CLEANUP_CHUNK_SIZE",
         ] {
             std::env::remove_var(key);
         }
@@ -472,6 +473,7 @@ mod tests {
         assert_eq!(cfg.storage.min_free_disk_mb, 512);
         assert_eq!(cfg.storage.recovery_free_disk_mb, 768);
         assert_eq!(cfg.storage.cleanup_interval_secs, 60);
+        assert_eq!(cfg.storage.cleanup_chunk_size, 2_000);
         assert!(cfg.mcp.api_token.is_none());
     }
 
@@ -551,13 +553,29 @@ mod tests {
     #[test]
     #[serial]
     fn rejects_cleanup_chunk_size_overflow() {
-        // Values larger than i64::MAX overflow the SQLite LIMIT cast
+        // On 64-bit: i64::MAX+1 fits in usize, so validate_storage_config fires.
+        // On 32-bit: the parse itself fails (value exceeds u32::MAX). Either way Err.
         let overflow = (i64::MAX as u128 + 1).to_string();
         std::env::set_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE", &overflow);
         let result = Config::load();
         std::env::remove_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE");
 
-        // Either the parse fails (value exceeds usize) or validation rejects it
-        assert!(result.is_err(), "Config::load() should reject oversized cleanup_chunk_size");
+        let err = result.expect_err("Config::load() should reject oversized cleanup_chunk_size");
+        assert!(
+            err.to_string().contains("cleanup_chunk_size")
+                || err.to_string().contains("SYSLOG_MCP_CLEANUP_CHUNK_SIZE"),
+            "Expected error referencing cleanup_chunk_size, got: {err}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn accepts_cleanup_chunk_size_at_i64_max() {
+        std::env::set_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE", &i64::MAX.to_string());
+        let result = Config::load();
+        std::env::remove_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE");
+
+        let cfg = result.expect("cleanup_chunk_size == i64::MAX should be accepted");
+        assert_eq!(cfg.storage.cleanup_chunk_size, i64::MAX as usize);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -378,6 +378,13 @@ fn validate_storage_config(storage: &StorageConfig) -> anyhow::Result<()> {
         ));
     }
 
+    if storage.cleanup_chunk_size > i64::MAX as usize {
+        return Err(anyhow::anyhow!(
+            "cleanup_chunk_size must be <= {}",
+            i64::MAX
+        ));
+    }
+
     Ok(())
 }
 
@@ -528,5 +535,29 @@ mod tests {
 
         let err = result.expect_err("Config::load() should reject invalid recovery_db_size_mb");
         assert!(err.to_string().contains("recovery_db_size_mb"));
+    }
+
+    #[test]
+    #[serial]
+    fn rejects_cleanup_chunk_size_zero() {
+        std::env::set_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE", "0");
+        let result = Config::load();
+        std::env::remove_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE");
+
+        let err = result.expect_err("Config::load() should reject cleanup_chunk_size == 0");
+        assert!(err.to_string().contains("cleanup_chunk_size"));
+    }
+
+    #[test]
+    #[serial]
+    fn rejects_cleanup_chunk_size_overflow() {
+        // Values larger than i64::MAX overflow the SQLite LIMIT cast
+        let overflow = (i64::MAX as u128 + 1).to_string();
+        std::env::set_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE", &overflow);
+        let result = Config::load();
+        std::env::remove_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE");
+
+        // Either the parse fails (value exceeds usize) or validation rejects it
+        assert!(result.is_err(), "Config::load() should reject oversized cleanup_chunk_size");
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1008,18 +1008,7 @@ mod tests {
     use crate::config::StorageConfig;
 
     fn test_storage_config(db_path: std::path::PathBuf) -> StorageConfig {
-        StorageConfig {
-            db_path,
-            pool_size: 1,
-            retention_days: 90,
-            wal_mode: false, // WAL not needed for tests
-            max_db_size_mb: 1024,
-            recovery_db_size_mb: 900,
-            min_free_disk_mb: 512,
-            recovery_free_disk_mb: 768,
-            cleanup_interval_secs: 60,
-            cleanup_chunk_size: 1,
-        }
+        StorageConfig::for_test(db_path)
     }
 
     /// Create an isolated test pool using a temp file (not :memory: — FTS5 needs file)

--- a/src/db.rs
+++ b/src/db.rs
@@ -378,15 +378,10 @@ pub fn enforce_storage_budget_with_probe(
 
     if deleted_rows > 0 {
         // Incremental FTS merge — clean up phantom rows left by bulk deletes
-        // (DELETE trigger is intentionally absent). Best-effort, matching
-        // the pattern in purge_old_logs.
-        let conn = pool.get()?;
-        if let Err(e) =
-            conn.execute_batch("INSERT INTO logs_fts(logs_fts) VALUES('merge=500,250');")
-        {
-            tracing::warn!(error = %e, "FTS merge after storage enforcement skipped (non-fatal)");
-        }
-        drop(conn);
+        // (DELETE trigger is intentionally absent).
+        // drop the connection before checkpoint_wal_and_incremental_vacuum to
+        // avoid pool exhaustion when pool_size = 1.
+        fts_incremental_merge(pool);
 
         checkpoint_wal_and_incremental_vacuum(pool)?;
     }
@@ -658,6 +653,23 @@ pub fn list_hosts(pool: &DbPool) -> Result<Vec<HostEntry>> {
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
+/// Run an incremental FTS5 merge to clean up phantom rows left by bulk DELETEs.
+///
+/// Best-effort: a small or empty index may return an error, which is logged and ignored.
+/// Must be called with no other connections holding the pool when `pool_size = 1`.
+fn fts_incremental_merge(pool: &DbPool) {
+    match pool.get() {
+        Ok(conn) => {
+            if let Err(e) =
+                conn.execute_batch("INSERT INTO logs_fts(logs_fts) VALUES('merge=500,250');")
+            {
+                tracing::warn!(error = %e, "FTS incremental merge skipped (non-fatal)");
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "FTS incremental merge: failed to get connection"),
+    }
+}
+
 /// Purge logs older than N days.
 ///
 /// Uses chunked DELETEs (10 000 rows per iteration) so the WAL write lock is
@@ -703,14 +715,8 @@ pub fn purge_old_logs(pool: &DbPool, retention_days: u32) -> Result<usize> {
     }
 
     // Incremental FTS merge — much shorter write-lock duration than full rebuild.
-    // Best-effort: a small/empty index may return an error; log and continue.
     if total_deleted > 0 {
-        let conn = pool.get()?;
-        if let Err(e) =
-            conn.execute_batch("INSERT INTO logs_fts(logs_fts) VALUES('merge=500,250');")
-        {
-            tracing::warn!(error = %e, "FTS merge skipped (non-fatal)");
-        }
+        fts_incremental_merge(pool);
     }
 
     // Passive WAL checkpoint: attempt to move WAL pages into the main DB file

--- a/src/db.rs
+++ b/src/db.rs
@@ -206,17 +206,14 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
             tokenize='porter unicode61'
         );
 
-        -- Triggers to keep FTS in sync
+        -- Trigger to keep FTS in sync on INSERT only.
+        -- DELETE and UPDATE triggers are intentionally absent: bulk DELETEs during
+        -- retention purge and storage-budget enforcement fire the trigger for every
+        -- deleted row inside a single implicit transaction, holding the SQLite write
+        -- lock long enough to starve the batch writer. FTS5 content tables tolerate
+        -- phantom rows — stale entries are skipped at query time and cleaned up by
+        -- periodic incremental merge (merge=500,250).
         CREATE TRIGGER IF NOT EXISTS logs_ai AFTER INSERT ON logs BEGIN
-            INSERT INTO logs_fts(rowid, message) VALUES (new.id, new.message);
-        END;
-
-        CREATE TRIGGER IF NOT EXISTS logs_ad AFTER DELETE ON logs BEGIN
-            INSERT INTO logs_fts(logs_fts, rowid, message) VALUES('delete', old.id, old.message);
-        END;
-
-        CREATE TRIGGER IF NOT EXISTS logs_au AFTER UPDATE ON logs BEGIN
-            INSERT INTO logs_fts(logs_fts, rowid, message) VALUES('delete', old.id, old.message);
             INSERT INTO logs_fts(rowid, message) VALUES (new.id, new.message);
         END;
 
@@ -245,6 +242,14 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
         conn.execute_batch("ALTER TABLE logs ADD COLUMN source_ip TEXT NOT NULL DEFAULT ''")?;
         tracing::info!("Migration: added source_ip column to logs table");
     }
+
+    // Migration: drop FTS5 DELETE/UPDATE triggers from existing databases.
+    // These triggers caused write-lock contention during bulk deletes (retention
+    // purge, storage enforcement). See schema comment above for rationale.
+    conn.execute_batch(
+        "DROP TRIGGER IF EXISTS logs_ad;
+         DROP TRIGGER IF EXISTS logs_au;",
+    )?;
 
     tracing::info!(path = %config.db_path.display(), "Database initialized");
     Ok(pool)
@@ -372,6 +377,17 @@ pub fn enforce_storage_budget_with_probe(
     }
 
     if deleted_rows > 0 {
+        // Incremental FTS merge — clean up phantom rows left by bulk deletes
+        // (DELETE trigger is intentionally absent). Best-effort, matching
+        // the pattern in purge_old_logs.
+        let conn = pool.get()?;
+        if let Err(e) =
+            conn.execute_batch("INSERT INTO logs_fts(logs_fts) VALUES('merge=500,250');")
+        {
+            tracing::warn!(error = %e, "FTS merge after storage enforcement skipped (non-fatal)");
+        }
+        drop(conn);
+
         checkpoint_wal_and_incremental_vacuum(pool)?;
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -827,6 +827,10 @@ mod tests {
     }
 
     fn test_state() -> (AppState, tempfile::TempDir) {
+        test_state_with_token(None)
+    }
+
+    fn test_state_with_token(token: Option<String>) -> (AppState, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let storage = test_storage_config(dir.path().join("mcp-test.db"));
         let pool = Arc::new(db::init_pool(&storage).unwrap());
@@ -837,7 +841,7 @@ mod tests {
                     host: "127.0.0.1".into(),
                     port: 3100,
                     server_name: "syslog-mcp".into(),
-                    api_token: None,
+                    api_token: token,
                 },
                 storage,
             },
@@ -916,18 +920,22 @@ mod tests {
             req
         }
 
-        /// Send a POST /mcp request through the router and return (status, parsed body)
+        /// Send a POST /mcp request through the router and return (status, parsed body).
+        /// Pass `auth` to include an `Authorization: Bearer <token>` header.
         async fn mcp_post(
             app: Router,
             body: serde_json::Value,
+            auth: Option<&str>,
         ) -> (axum::http::StatusCode, serde_json::Value) {
-            let request = Request::builder()
+            let mut builder = Request::builder()
                 .method("POST")
                 .uri("/mcp")
-                .header("Content-Type", "application/json")
-                .body(axum::body::Body::from(
-                    serde_json::to_vec(&body).unwrap(),
-                ))
+                .header("Content-Type", "application/json");
+            if let Some(token) = auth {
+                builder = builder.header("Authorization", format!("Bearer {token}"));
+            }
+            let request = builder
+                .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap()))
                 .unwrap();
             let response = app.oneshot(request).await.unwrap();
             let status = response.status();
@@ -935,25 +943,6 @@ mod tests {
             let value: serde_json::Value =
                 serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
             (status, value)
-        }
-
-        fn test_state_with_token(token: Option<String>) -> (AppState, tempfile::TempDir) {
-            let dir = tempfile::tempdir().unwrap();
-            let storage = test_storage_config(dir.path().join("integ-test.db"));
-            let pool = std::sync::Arc::new(db::init_pool(&storage).unwrap());
-            (
-                AppState {
-                    pool,
-                    config: McpConfig {
-                        host: "127.0.0.1".into(),
-                        port: 3100,
-                        server_name: "syslog-mcp".into(),
-                        api_token: token,
-                    },
-                    storage,
-                },
-                dir,
-            )
         }
 
         #[tokio::test]
@@ -973,7 +962,7 @@ mod tests {
         async fn integration_initialize() {
             let (state, _dir) = test_state();
             let body = jsonrpc_request(1, "initialize", None);
-            let (status, value) = mcp_post(router(state), body).await;
+            let (status, value) = mcp_post(router(state), body, None).await;
             assert_eq!(status, axum::http::StatusCode::OK);
             assert!(value["result"]["protocolVersion"].is_string());
             assert!(value["result"]["serverInfo"]["name"].is_string());
@@ -983,7 +972,7 @@ mod tests {
         async fn integration_tools_list() {
             let (state, _dir) = test_state();
             let body = jsonrpc_request(2, "tools/list", None);
-            let (status, value) = mcp_post(router(state), body).await;
+            let (status, value) = mcp_post(router(state), body, None).await;
             assert_eq!(status, axum::http::StatusCode::OK);
             let tools = value["result"]["tools"].as_array().unwrap();
             let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
@@ -1007,7 +996,7 @@ mod tests {
                 "tools/call",
                 Some(serde_json::json!({"name": "get_stats", "arguments": {}})),
             );
-            let (status, value) = mcp_post(router(state), body).await;
+            let (status, value) = mcp_post(router(state), body, None).await;
             assert_eq!(status, axum::http::StatusCode::OK);
             let content = value["result"]["content"][0]["text"].as_str().unwrap();
             assert!(
@@ -1025,7 +1014,7 @@ mod tests {
                 "tools/call",
                 Some(serde_json::json!({"name": "tail_logs", "arguments": {"n": 10}})),
             );
-            let (status, value) = mcp_post(router(state), body).await;
+            let (status, value) = mcp_post(router(state), body, None).await;
             assert_eq!(status, axum::http::StatusCode::OK);
             assert!(value["error"].is_null(), "unexpected error: {}", value);
         }
@@ -1038,7 +1027,7 @@ mod tests {
                 "tools/call",
                 Some(serde_json::json!({"name": "search_logs", "arguments": {"query": "error", "limit": 5}})),
             );
-            let (status, value) = mcp_post(router(state), body).await;
+            let (status, value) = mcp_post(router(state), body, None).await;
             assert_eq!(status, axum::http::StatusCode::OK);
             assert!(value["error"].is_null(), "unexpected error: {}", value);
         }
@@ -1047,7 +1036,7 @@ mod tests {
         async fn integration_unknown_method_returns_error() {
             let (state, _dir) = test_state();
             let body = jsonrpc_request(6, "nonexistent/method", None);
-            let (status, value) = mcp_post(router(state), body).await;
+            let (status, value) = mcp_post(router(state), body, None).await;
             assert_eq!(status, axum::http::StatusCode::OK);
             assert_eq!(value["error"]["code"].as_i64().unwrap(), -32601);
         }
@@ -1056,33 +1045,16 @@ mod tests {
         async fn integration_auth_missing_token_returns_401() {
             let (state, _dir) = test_state_with_token(Some("secret-token".into()));
             let body = jsonrpc_request(7, "tools/list", None);
-            let request = Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Content-Type", "application/json")
-                .body(axum::body::Body::from(
-                    serde_json::to_vec(&body).unwrap(),
-                ))
-                .unwrap();
-            let response = router(state).oneshot(request).await.unwrap();
-            assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+            let (status, _) = mcp_post(router(state), body, None).await;
+            assert_eq!(status, axum::http::StatusCode::UNAUTHORIZED);
         }
 
         #[tokio::test]
         async fn integration_auth_correct_token_succeeds() {
             let (state, _dir) = test_state_with_token(Some("secret-token".into()));
             let body = jsonrpc_request(8, "tools/list", None);
-            let request = Request::builder()
-                .method("POST")
-                .uri("/mcp")
-                .header("Content-Type", "application/json")
-                .header("Authorization", "Bearer secret-token")
-                .body(axum::body::Body::from(
-                    serde_json::to_vec(&body).unwrap(),
-                ))
-                .unwrap();
-            let response = router(state).oneshot(request).await.unwrap();
-            assert_eq!(response.status(), axum::http::StatusCode::OK);
+            let (status, _) = mcp_post(router(state), body, Some("secret-token")).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
         }
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -891,4 +891,198 @@ mod tests {
         assert!(summary.is_char_boundary(summary.len()));
         assert!(summary.ends_with('…'));
     }
+
+    // ---- Integration tests: HTTP-level through the axum router ----
+
+    mod integration_tests {
+        use super::*;
+        use axum::http::Request;
+        use tower::util::ServiceExt;
+
+        /// Build a JSON-RPC request body
+        fn jsonrpc_request(
+            id: u64,
+            method: &str,
+            params: Option<serde_json::Value>,
+        ) -> serde_json::Value {
+            let mut req = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+            });
+            if let Some(p) = params {
+                req.as_object_mut().unwrap().insert("params".into(), p);
+            }
+            req
+        }
+
+        /// Send a POST /mcp request through the router and return (status, parsed body)
+        async fn mcp_post(
+            app: Router,
+            body: serde_json::Value,
+        ) -> (axum::http::StatusCode, serde_json::Value) {
+            let request = Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("Content-Type", "application/json")
+                .body(axum::body::Body::from(
+                    serde_json::to_vec(&body).unwrap(),
+                ))
+                .unwrap();
+            let response = app.oneshot(request).await.unwrap();
+            let status = response.status();
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let value: serde_json::Value =
+                serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+            (status, value)
+        }
+
+        fn test_state_with_token(token: Option<String>) -> (AppState, tempfile::TempDir) {
+            let dir = tempfile::tempdir().unwrap();
+            let storage = test_storage_config(dir.path().join("integ-test.db"));
+            let pool = std::sync::Arc::new(db::init_pool(&storage).unwrap());
+            (
+                AppState {
+                    pool,
+                    config: McpConfig {
+                        host: "127.0.0.1".into(),
+                        port: 3100,
+                        server_name: "syslog-mcp".into(),
+                        api_token: token,
+                    },
+                    storage,
+                },
+                dir,
+            )
+        }
+
+        #[tokio::test]
+        async fn integration_health_returns_200() {
+            let (state, _dir) = test_state();
+            let app = router(state);
+            let request = Request::builder()
+                .method("GET")
+                .uri("/health")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            let response = app.oneshot(request).await.unwrap();
+            assert_eq!(response.status(), axum::http::StatusCode::OK);
+        }
+
+        #[tokio::test]
+        async fn integration_initialize() {
+            let (state, _dir) = test_state();
+            let body = jsonrpc_request(1, "initialize", None);
+            let (status, value) = mcp_post(router(state), body).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+            assert!(value["result"]["protocolVersion"].is_string());
+            assert!(value["result"]["serverInfo"]["name"].is_string());
+        }
+
+        #[tokio::test]
+        async fn integration_tools_list() {
+            let (state, _dir) = test_state();
+            let body = jsonrpc_request(2, "tools/list", None);
+            let (status, value) = mcp_post(router(state), body).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+            let tools = value["result"]["tools"].as_array().unwrap();
+            let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+            for expected in &[
+                "search_logs",
+                "tail_logs",
+                "get_errors",
+                "list_hosts",
+                "correlate_events",
+                "get_stats",
+            ] {
+                assert!(names.contains(expected), "missing tool: {}", expected);
+            }
+        }
+
+        #[tokio::test]
+        async fn integration_get_stats() {
+            let (state, _dir) = test_state();
+            let body = jsonrpc_request(
+                3,
+                "tools/call",
+                Some(serde_json::json!({"name": "get_stats", "arguments": {}})),
+            );
+            let (status, value) = mcp_post(router(state), body).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+            let content = value["result"]["content"][0]["text"].as_str().unwrap();
+            assert!(
+                content.contains("total_logs"),
+                "expected total_logs in: {}",
+                content
+            );
+        }
+
+        #[tokio::test]
+        async fn integration_tail_logs_empty_db() {
+            let (state, _dir) = test_state();
+            let body = jsonrpc_request(
+                4,
+                "tools/call",
+                Some(serde_json::json!({"name": "tail_logs", "arguments": {"n": 10}})),
+            );
+            let (status, value) = mcp_post(router(state), body).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+            assert!(value["error"].is_null(), "unexpected error: {}", value);
+        }
+
+        #[tokio::test]
+        async fn integration_search_logs_empty_db() {
+            let (state, _dir) = test_state();
+            let body = jsonrpc_request(
+                5,
+                "tools/call",
+                Some(serde_json::json!({"name": "search_logs", "arguments": {"query": "error", "limit": 5}})),
+            );
+            let (status, value) = mcp_post(router(state), body).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+            assert!(value["error"].is_null(), "unexpected error: {}", value);
+        }
+
+        #[tokio::test]
+        async fn integration_unknown_method_returns_error() {
+            let (state, _dir) = test_state();
+            let body = jsonrpc_request(6, "nonexistent/method", None);
+            let (status, value) = mcp_post(router(state), body).await;
+            assert_eq!(status, axum::http::StatusCode::OK);
+            assert_eq!(value["error"]["code"].as_i64().unwrap(), -32601);
+        }
+
+        #[tokio::test]
+        async fn integration_auth_missing_token_returns_401() {
+            let (state, _dir) = test_state_with_token(Some("secret-token".into()));
+            let body = jsonrpc_request(7, "tools/list", None);
+            let request = Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("Content-Type", "application/json")
+                .body(axum::body::Body::from(
+                    serde_json::to_vec(&body).unwrap(),
+                ))
+                .unwrap();
+            let response = router(state).oneshot(request).await.unwrap();
+            assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+        }
+
+        #[tokio::test]
+        async fn integration_auth_correct_token_succeeds() {
+            let (state, _dir) = test_state_with_token(Some("secret-token".into()));
+            let body = jsonrpc_request(8, "tools/list", None);
+            let request = Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer secret-token")
+                .body(axum::body::Body::from(
+                    serde_json::to_vec(&body).unwrap(),
+                ))
+                .unwrap();
+            let response = router(state).oneshot(request).await.unwrap();
+            assert_eq!(response.status(), axum::http::StatusCode::OK);
+        }
+    }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -823,18 +823,7 @@ mod tests {
     use axum::body::to_bytes;
 
     fn test_storage_config(db_path: std::path::PathBuf) -> StorageConfig {
-        StorageConfig {
-            db_path,
-            pool_size: 1,
-            retention_days: 90,
-            wal_mode: false,
-            max_db_size_mb: 1024,
-            recovery_db_size_mb: 900,
-            min_free_disk_mb: 0,
-            recovery_free_disk_mb: 0,
-            cleanup_interval_secs: 60,
-            cleanup_chunk_size: 1,
-        }
+        StorageConfig::for_test(db_path)
     }
 
     fn test_state() -> (AppState, tempfile::TempDir) {

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -831,18 +831,7 @@ mod tests {
     use crate::config::StorageConfig;
 
     fn test_storage_config(db_path: std::path::PathBuf) -> StorageConfig {
-        StorageConfig {
-            db_path,
-            pool_size: 1,
-            retention_days: 90,
-            wal_mode: false,
-            max_db_size_mb: 1024,
-            recovery_db_size_mb: 900,
-            min_free_disk_mb: 0,
-            recovery_free_disk_mb: 0,
-            cleanup_interval_secs: 60,
-            cleanup_chunk_size: 1,
-        }
+        StorageConfig::for_test(db_path)
     }
 
     fn test_pool() -> (Arc<DbPool>, StorageConfig, tempfile::TempDir) {

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -294,7 +294,8 @@ async fn tcp_listener(
                         // stream is dropped here, closing the connection
                     }
                     Err(tokio::sync::TryAcquireError::Closed) => {
-                        break; // semaphore closed — should never happen
+                        error!("TCP connection semaphore unexpectedly closed — TCP listener exiting");
+                        break;
                     }
                 }
             }

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -270,22 +270,33 @@ async fn tcp_listener(
         match listener.accept().await {
             Ok((stream, addr)) => {
                 accept_backoff_ms = 100; // reset on success
-                let available_permits = sem.available_permits();
-                let permit = match Arc::clone(&sem).acquire_owned().await {
-                    Ok(p) => p,
-                    Err(_) => break, // semaphore closed — shouldn't happen
-                };
-                let tx = tx.clone();
-                tokio::spawn(async move {
-                    let _permit = permit; // released automatically when task drops
-                    handle_tcp_connection(stream, addr, tx, max_size, idle_timeout_secs).await;
-                });
-                debug!(
-                    peer = %addr,
-                    active_connections = max_connections.saturating_sub(available_permits),
-                    max_connections,
-                    "TCP syslog connection dispatched"
-                );
+                match Arc::clone(&sem).try_acquire_owned() {
+                    Ok(permit) => {
+                        let available_permits = sem.available_permits();
+                        let tx = tx.clone();
+                        tokio::spawn(async move {
+                            let _permit = permit;
+                            handle_tcp_connection(stream, addr, tx, max_size, idle_timeout_secs).await;
+                        });
+                        debug!(
+                            peer = %addr,
+                            active_connections = max_connections.saturating_sub(available_permits),
+                            max_connections,
+                            "TCP syslog connection dispatched"
+                        );
+                    }
+                    Err(tokio::sync::TryAcquireError::NoPermits) => {
+                        warn!(
+                            peer = %addr,
+                            max_connections,
+                            "TCP connection limit reached — rejecting connection"
+                        );
+                        // stream is dropped here, closing the connection
+                    }
+                    Err(tokio::sync::TryAcquireError::Closed) => {
+                        break; // semaphore closed — should never happen
+                    }
+                }
             }
             Err(e) => {
                 error!(error = %e, accept_backoff_ms, "TCP accept error");


### PR DESCRIPTION
## Summary

- Add `cleanup_chunk_size > 0` validation in `validate_storage_config` to catch misconfiguration early
- Extract `StorageConfig::for_test()` test helper to deduplicate inline struct construction across `mcp.rs` and `syslog.rs`
- Fix clippy errors caught during code review

## Test plan

- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] `cleanup_chunk_size = 0` in config returns a clear error on startup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents panics on non-ASCII logs, avoids TCP accept stalls under load, and speeds up storage cleanup with chunking and incremental FTS merges. Adds MCP Registry publishing with `server.json`, CI, and image metadata; tightens storage config validation and expands HTTP-level tests; bumps `syslog-mcp` to 0.2.6.

- **Bug Fixes**
  - UTF-8-safe truncation in `summarize_json_value`.
  - TCP accept loop uses non-blocking `try_acquire_owned()` and logs on semaphore close.
  - Storage enforcement/retention: chunked deletes via `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` (default 2000), dropped FTS5 DELETE/UPDATE triggers, and incremental FTS merge after bulk deletes.
  - Config rejects `cleanup_chunk_size == 0` and values > `i64::MAX`; added boundary/overflow/defaults tests.

- **New Features**
  - MCP Registry publishing on tags: adds `server.json` (versioned, OCI image mapping), GitHub Actions to set version, DNS auth, and publish via `mcp-publisher`.
  - Container metadata: adds `io.modelcontextprotocol.server.name` label for discovery.

<sup>Written for commit 6d89ce7798b14ea87e27f676c9cf0eb7dc23be67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a panic with multi-byte UTF‑8 truncation and prevented infinite cleanup loops via stricter validation.
  * Reduced database write-lock contention and improved storage cleanup reliability.

* **New Features**
  * Added configurable storage cleanup batch size (env var, default 2000).
  * Improved connection handling to avoid listener blocking under load.

* **Chores**
  * Bumped release version to 0.2.5 across manifests and updated changelog/tests/docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->