### PR TITLE
docs: add full documentation structure

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.6",
+  "version": "0.3.2",
   "description": "Syslog management via MCP",
   "author": "jmagar",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.6",
+  "version": "0.3.2",
   "description": "Syslog management via MCP.",
   "homepage": "https://github.com/jmagar/syslog-mcp",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] — 2026-04-04
+
+### Fixed
+
+- **Version sync**: Aligned `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `gemini-extension.json` from 0.2.6 to 0.3.2 to match `Cargo.toml`
+
+### Added
+
+- **`tests/TEST_COVERAGE.md`**: Test coverage documentation
+- **`tests/mcporter/`**: MCPorter test infrastructure
+- **Full documentation structure**: Added plugin-lab template docs (README, CLAUDE.md, references, runbooks)
+
 ## [0.3.1] — 2026-04-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] — 2026-04-04
+
+### Fixed
+
+- **`src/config.rs`**: `cleanup_chunk_size` upper bound replaced from `i64::MAX` with operational limit of `1_000_000`; values above this hold the SQLite write lock indefinitely. Error message now explains why the limit exists.
+
 ## [0.3.0] — 2026-04-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "syslog-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -1,0 +1,59 @@
+# Plugin Checklist -- syslog-mcp
+
+Pre-release and quality checklist. Complete all items before tagging a release.
+
+## Version and metadata
+
+- [ ] All version-bearing files in sync: `Cargo.toml`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `gemini-extension.json`, `server.json`
+- [ ] `CHANGELOG.md` has an entry for the new version
+- [ ] README version badge is correct
+
+## Configuration
+
+- [ ] `.env.example` documents every environment variable the server reads
+- [ ] `.env.example` has no actual secrets -- only placeholders
+- [ ] `.env` is in `.gitignore` and `.dockerignore`
+
+## Documentation
+
+- [ ] `CLAUDE.md` is current and matches repo structure
+- [ ] `README.md` has up-to-date tool reference and environment variable table
+- [ ] `skills/syslog/SKILL.md` has correct frontmatter and tool descriptions
+- [ ] Setup instructions work from a clean clone
+
+## Security
+
+- [ ] No credentials in code, docs, or git history
+- [ ] `.gitignore` includes `.env`, `*.secret`, credentials files
+- [ ] `.dockerignore` includes `.env`, `.git/`, `*.secret`
+- [ ] Hooks enforce permissions: `sync-env.sh`, `fix-env-perms.sh`, `ensure-ignore-files.sh`
+- [ ] `/health` endpoint is unauthenticated; `/mcp` and `/sse` require bearer auth when `SYSLOG_MCP_API_TOKEN` is set
+- [ ] Container runs as non-root (UID 1000)
+- [ ] No baked environment variables in Docker image
+- [ ] Bearer token comparison uses constant-time equality (`subtle::ConstantTimeEq`)
+
+## Build and test
+
+- [ ] Docker image builds: `just docker-build`
+- [ ] Docker healthcheck passes: `just health`
+- [ ] CI pipeline passes: `just lint && just test`
+- [ ] Live smoke test passes: `just test-live`
+- [ ] `cargo clippy -- -D warnings` produces zero warnings
+
+## Deployment
+
+- [ ] `docker-compose.yml` uses correct ports (1514 UDP/TCP, 3100 TCP)
+- [ ] `entrypoint.sh` is executable
+- [ ] SWAG reverse proxy config tested (see `docs/syslog.subdomain.conf`)
+
+## Registry (if publishing)
+
+- [ ] `server.json` for MCP registry is valid JSON with correct version
+- [ ] OCI image published to `ghcr.io/jmagar/syslog-mcp`
+- [ ] Crate published to crates.io (if applicable)
+- [ ] DNS verification for `tv.tootie/syslog-mcp`
+
+## Marketplace (if applicable)
+
+- [ ] Entry in `claude-homelab` marketplace manifest
+- [ ] Plugin installs correctly: `/plugin marketplace add jmagar/claude-homelab`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,144 @@
+# Configuration Reference -- syslog-mcp
+
+Complete configuration reference. syslog-mcp uses a three-layer config system: compiled defaults, `config.toml` overlay, environment variable overrides.
+
+## Configuration precedence
+
+Precedence (highest to lowest):
+1. Environment variables (always win)
+2. `config.toml` in the working directory (partial configs supported -- missing fields keep defaults)
+3. Compiled defaults in `src/config.rs`
+
+## config.toml
+
+The TOML config file at the repo root is used for local development. It is **not** copied into the Docker image -- container deployments use defaults + env vars exclusively.
+
+```toml
+[syslog]
+host = "0.0.0.0"
+port = 1514
+max_message_size = 8192
+
+[storage]
+db_path = "/data/syslog.db"
+pool_size = 4
+retention_days = 90
+wal_mode = true
+max_db_size_mb = 1024
+recovery_db_size_mb = 900
+min_free_disk_mb = 512
+recovery_free_disk_mb = 768
+cleanup_interval_secs = 60
+
+[mcp]
+host = "0.0.0.0"
+port = 3100
+server_name = "syslog-mcp"
+```
+
+## Environment variables
+
+### Syslog listener (`SYSLOG_*`)
+
+| Variable | Required | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_HOST` | no | `0.0.0.0` | no | Listen host for UDP+TCP syslog (no port -- use separate setting) |
+| `SYSLOG_PORT` | no | `1514` | no | Listen port shared by UDP and TCP syslog listeners |
+| `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | no | Max message size in bytes per syslog frame |
+| `SYSLOG_BATCH_SIZE` | no | `100` | no | Entries per batch flush to SQLite |
+| `SYSLOG_FLUSH_INTERVAL` | no | `500` | no | Batch flush interval in milliseconds |
+
+### MCP server (`SYSLOG_MCP_*`)
+
+| Variable | Required | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_MCP_HOST` | no | `0.0.0.0` | no | HTTP listen host for MCP endpoint |
+| `SYSLOG_MCP_PORT` | no | `3100` | no | HTTP listen port for MCP endpoint |
+| `SYSLOG_MCP_API_TOKEN` | no | (none) | **yes** | Bearer token for `/mcp` and `/sse` auth. Generate: `openssl rand -hex 32`. When unset, auth is disabled. |
+
+### Storage (`SYSLOG_MCP_*`)
+
+| Variable | Required | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_MCP_DB_PATH` | no | `/data/syslog.db` | no | Path to SQLite database file |
+| `SYSLOG_MCP_POOL_SIZE` | no | `4` | no | SQLite connection pool size (must be > 0) |
+| `SYSLOG_MCP_RETENTION_DAYS` | no | `90` | no | Days to retain logs before automatic hourly purge (0 = keep forever) |
+
+### Storage budget (`SYSLOG_MCP_*`)
+
+| Variable | Required | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_MCP_MAX_DB_SIZE_MB` | no | `1024` | no | Soft limit for logical DB size in MB (0 = disable) |
+| `SYSLOG_MCP_RECOVERY_DB_SIZE_MB` | no | `900` | no | Cleanup target after DB-size breach (must be < max) |
+| `SYSLOG_MCP_MIN_FREE_DISK_MB` | no | `512` | no | Minimum free disk space in MB (0 = disable) |
+| `SYSLOG_MCP_RECOVERY_FREE_DISK_MB` | no | `768` | no | Cleanup target after free-disk breach (must be > min) |
+| `SYSLOG_MCP_CLEANUP_INTERVAL_SECS` | no | `60` | no | Storage budget enforcement interval in seconds (minimum 5) |
+| `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` | no | `2000` | no | Rows deleted per chunk during enforcement (1 to 1,000,000) |
+
+### Logging
+
+| Variable | Required | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `RUST_LOG` | no | `info` | no | Rust tracing filter directive. Examples: `debug`, `syslog_mcp=debug,tower_http=info`, `trace` |
+
+### Docker / container
+
+| Variable | Required | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_UID` | no | `1000` | no | Container user ID |
+| `SYSLOG_GID` | no | `1000` | no | Container group ID |
+| `SYSLOG_PORT` | no | `1514` | no | Host-side syslog port mapping |
+| `SYSLOG_MCP_PORT` | no | `3100` | no | Host-side MCP port mapping |
+| `SYSLOG_MCP_DATA_VOLUME` | no | `syslog-mcp-data` | no | Named Docker volume for `/data` |
+| `DOCKER_NETWORK` | no | `syslog-mcp` | no | External Docker network name |
+
+## Storage budget behavior
+
+The storage budget is a two-threshold system with hysteresis to prevent oscillation:
+
+1. **Trigger threshold**: When logical DB size exceeds `max_db_size_mb` or free disk drops below `min_free_disk_mb`, enforcement begins.
+2. **Recovery target**: Oldest logs are deleted in chunks until logical DB size drops below `recovery_db_size_mb` and free disk rises above `recovery_free_disk_mb`.
+3. **Write blocking**: If cleanup cannot recover enough space (e.g., no more logs to delete), the batch writer blocks new writes until storage becomes healthy.
+4. **Enforcement interval**: Checked every `cleanup_interval_secs` seconds (default 60).
+
+Set both `max_db_size_mb` and `min_free_disk_mb` to 0 to disable all storage enforcement.
+
+## Validation rules
+
+- `SYSLOG_MCP_POOL_SIZE` must be > 0
+- `recovery_db_size_mb` must be > 0 and < `max_db_size_mb` when DB size guard is enabled
+- `recovery_free_disk_mb` must be > 0 and > `min_free_disk_mb` when free-disk guard is enabled
+- `cleanup_interval_secs` must be >= 5
+- `cleanup_chunk_size` must be between 1 and 1,000,000
+- Host fields must not contain a colon (port is a separate setting)
+
+## Plugin userConfig
+
+When installed as a Claude Code plugin, credentials are managed via `userConfig` in `.claude-plugin/plugin.json`:
+
+```json
+{
+  "userConfig": {
+    "SYSLOG_MCP_URL": {
+      "type": "string",
+      "title": "Syslog MCP URL",
+      "description": "Base URL of the syslog-mcp server (e.g. http://localhost:3100)",
+      "sensitive": false,
+      "default": "https://syslog.tootie.tv/mcp"
+    },
+    "SYSLOG_MCP_API_TOKEN": {
+      "type": "string",
+      "title": "API Token",
+      "description": "Bearer token for authenticating MCP requests (leave empty if auth is disabled)",
+      "sensitive": true
+    }
+  }
+}
+```
+
+## .env.example conventions
+
+- Group variables by section with comment headers
+- Required variables first within each group
+- No actual secrets -- use descriptive placeholders
+- See `.env.example` at the repo root for the full template

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -1,0 +1,147 @@
+# Security Guardrails -- syslog-mcp
+
+Safety and security patterns enforced across syslog-mcp.
+
+## Credential management
+
+### Storage
+
+- All credentials in `.env` with `chmod 600` permissions
+- Never commit `.env` or any file containing secrets
+- Use `.env.example` as a tracked template with placeholder values only
+- Generate tokens with `openssl rand -hex 32`
+
+### Ignore files
+
+`.gitignore` and `.dockerignore` must include:
+
+```
+.env
+*.secret
+credentials.*
+*.pem
+*.key
+```
+
+### Hook enforcement
+
+Pre-commit hooks verify security invariants:
+
+| Hook | Purpose |
+| --- | --- |
+| `sync-env.sh` | Ensures `.env.example` documents all variables read by the server |
+| `fix-env-perms.sh` | Sets `.env` to `chmod 600` if present |
+| `ensure-ignore-files.sh` | Verifies `.gitignore` and `.dockerignore` contain required patterns |
+
+### Credential rotation
+
+1. Generate new token: `openssl rand -hex 32`
+2. Update `.env` with the new `SYSLOG_MCP_API_TOKEN` value
+3. Restart the server: `just restart`
+4. Update MCP client configuration with new token
+5. Verify: `just health`
+
+## Authentication
+
+syslog-mcp has a single authentication boundary: MCP clients authenticating to the MCP HTTP server.
+
+### Bearer token
+
+When `SYSLOG_MCP_API_TOKEN` is set, all requests to `/mcp` and `/sse` require:
+
+```
+Authorization: Bearer {SYSLOG_MCP_API_TOKEN}
+```
+
+Token comparison uses `subtle::ConstantTimeEq` to prevent timing attacks.
+
+### Unauthenticated by default
+
+When `SYSLOG_MCP_API_TOKEN` is not set, all endpoints are open. This is acceptable for LAN-only deployments but not recommended when exposed via reverse proxy.
+
+### Health endpoint
+
+`/health` is always unauthenticated -- required for Docker HEALTHCHECK, docker-compose probes, and SWAG liveness checks.
+
+## Docker security
+
+### Non-root execution
+
+The container runs as non-root (UID/GID 1000):
+
+```dockerfile
+RUN groupadd --gid 1000 syslog && \
+    useradd --uid 1000 --gid syslog --no-create-home --shell /sbin/nologin syslog
+USER 1000:1000
+```
+
+Override with `SYSLOG_UID` and `SYSLOG_GID` in `docker-compose.yml`.
+
+### No baked environment
+
+The Docker image contains only two non-sensitive defaults:
+
+```dockerfile
+ENV RUST_LOG=info
+ENV SYSLOG_MCP_DB_PATH=/data/syslog.db
+```
+
+No credentials are baked into the image. Verify with:
+
+```bash
+docker inspect syslog-mcp:latest | jq '.[0].Config.Env'
+```
+
+### Resource limits
+
+The compose file sets memory and CPU limits:
+
+```yaml
+deploy:
+  resources:
+    limits:
+      memory: 512M
+      cpus: '1.0'
+```
+
+## Network security
+
+### CORS restriction
+
+CORS is restricted to `localhost:3100` and `127.0.0.1:3100`. MCP CLI clients (mcporter, curl) are not browser-based and ignore CORS entirely. This prevents malicious webpages from exfiltrating the log database via cross-origin browser fetch.
+
+### Port 1514 vs 514
+
+syslog-mcp listens on port 1514 (not 514) to avoid needing root or `CAP_NET_BIND_SERVICE`. Use iptables PREROUTING to redirect 514 to 1514 for devices that cannot be reconfigured:
+
+```bash
+sudo iptables -t nat -A PREROUTING -p udp --dport 514 -j REDIRECT --to-port 1514
+sudo iptables -t nat -A PREROUTING -p tcp --dport 514 -j REDIRECT --to-port 1514
+```
+
+### SWAG reverse proxy
+
+When exposing MCP over HTTPS via SWAG:
+- Add auth at the proxy layer or set `SYSLOG_MCP_API_TOKEN`
+- SSE requires: `proxy_buffering off`, `chunked_transfer_encoding off`, `proxy_http_version 1.1`
+- See `docs/syslog.subdomain.conf` for a working nginx config
+
+## Input handling
+
+### Syslog message trust boundary
+
+Syslog content (hostname, message, app_name) is untrusted user-controlled data. Any LAN host can UDP-spoof an arbitrary hostname. The `source_ip` field records the actual network sender address and is the only trustworthy network identity for a log entry.
+
+### FTS5 query injection
+
+`search_logs` passes user queries to SQLite FTS5. FTS5 query syntax is its own DSL (not SQL), so SQL injection is not possible via the query parameter. Invalid FTS5 syntax returns a database error, not a security vulnerability.
+
+### SQL parameterization
+
+All SQL queries use parameterized bindings (`params![]` and `named_params![]`). No user input is interpolated into SQL strings.
+
+## Logging
+
+- Never log credentials, tokens, or API keys
+- Auth failure logs include method and path but never the submitted token value
+- `RUST_LOG=debug` and `RUST_LOG=trace` are safe for development -- no secrets are emitted at any log level

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -1,0 +1,139 @@
+# Component Inventory -- syslog-mcp
+
+Complete listing of all plugin components.
+
+## MCP tools
+
+syslog-mcp uses a flat tool pattern (7 independent tools) rather than the action/subaction router pattern.
+
+| Tool | Description | Destructive |
+| --- | --- | --- |
+| `search_logs` | Full-text search across syslog messages with FTS5 syntax, host/severity/app/time filters | no |
+| `tail_logs` | Get N most recent log entries, optionally filtered by host and/or application | no |
+| `get_errors` | Error/warning summary grouped by hostname and severity level with counts | no |
+| `list_hosts` | List all hosts with first/last seen timestamps and total log counts | no |
+| `correlate_events` | Cross-host event correlation within a time window around a reference timestamp | no |
+| `get_stats` | Database statistics: total logs, hosts, time range, DB size, free disk, write-block status | no |
+| `syslog_help` | Returns markdown documentation for all tools | no |
+
+All tools are read-only. syslog-mcp exposes no destructive operations via MCP.
+
+## MCP resources
+
+| URI | Description | MIME type |
+| --- | --- | --- |
+| -- | No resources exposed | -- |
+
+## Environment variables
+
+| Variable | Required | Default | Sensitive |
+| --- | --- | --- | --- |
+| `SYSLOG_HOST` | no | `0.0.0.0` | no |
+| `SYSLOG_PORT` | no | `1514` | no |
+| `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | no |
+| `SYSLOG_BATCH_SIZE` | no | `100` | no |
+| `SYSLOG_FLUSH_INTERVAL` | no | `500` | no |
+| `SYSLOG_MCP_HOST` | no | `0.0.0.0` | no |
+| `SYSLOG_MCP_PORT` | no | `3100` | no |
+| `SYSLOG_MCP_API_TOKEN` | no | (none) | yes |
+| `SYSLOG_MCP_DB_PATH` | no | `/data/syslog.db` | no |
+| `SYSLOG_MCP_POOL_SIZE` | no | `4` | no |
+| `SYSLOG_MCP_RETENTION_DAYS` | no | `90` | no |
+| `SYSLOG_MCP_MAX_DB_SIZE_MB` | no | `1024` | no |
+| `SYSLOG_MCP_RECOVERY_DB_SIZE_MB` | no | `900` | no |
+| `SYSLOG_MCP_MIN_FREE_DISK_MB` | no | `512` | no |
+| `SYSLOG_MCP_RECOVERY_FREE_DISK_MB` | no | `768` | no |
+| `SYSLOG_MCP_CLEANUP_INTERVAL_SECS` | no | `60` | no |
+| `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` | no | `2000` | no |
+| `RUST_LOG` | no | `info` | no |
+
+## Plugin surfaces
+
+| Surface | Present | Path |
+| --- | --- | --- |
+| Skills | yes | `skills/syslog/SKILL.md` |
+| Agents | no | -- |
+| Commands | no | -- |
+| Hooks | yes | `hooks/` |
+| Channels | no | -- |
+| Output styles | no | -- |
+| Schedules | no | -- |
+
+## Network ports
+
+| Port | Protocol | Purpose |
+| --- | --- | --- |
+| 1514 | UDP + TCP | Syslog receiver (RFC 3164/5424) |
+| 3100 | TCP | MCP HTTP endpoint (JSON-RPC 2.0) |
+
+## HTTP endpoints
+
+| Endpoint | Method | Auth required | Description |
+| --- | --- | --- | --- |
+| `/mcp` | POST | yes (when token set) | MCP JSON-RPC 2.0 endpoint |
+| `/sse` | GET | yes (when token set) | Server-Sent Events (legacy transport) |
+| `/health` | GET | no | Health check -- verifies DB connectivity |
+
+## Docker
+
+| Component | Value |
+| --- | --- |
+| Image | `ghcr.io/jmagar/syslog-mcp:latest` |
+| Syslog port | `1514/udp`, `1514/tcp` |
+| MCP port | `3100/tcp` |
+| Health endpoint | `GET /health` (unauthenticated) |
+| Compose file | `docker-compose.yml` |
+| Entrypoint | `entrypoint.sh` |
+| User | `1000:1000` |
+| Data volume | `/data` (SQLite database) |
+
+## CI/CD workflows
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `ci.yml` | push, PR | Lint (clippy), check, test |
+| `docker-publish.yml` | tag push | Build and publish Docker image to GHCR |
+| `publish-crates.yml` | tag push | Publish to crates.io |
+| `codex-plugin-scanner.yml` | PR | Validate Codex plugin manifest |
+
+## Scripts
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/smoke-test.sh` | Live smoke test -- all 7 MCP tools via mcporter (25 assertions) |
+| `scripts/backup.sh` | WAL-safe SQLite backup (checkpoint + `.backup` method) |
+| `scripts/reset-db.sh` | WAL-safe backup + destructive DB reset for dev recovery |
+| `scripts/lint-plugin.sh` | Validate plugin manifests and contract compliance |
+| `scripts/check-docker-security.sh` | Verify Docker security practices |
+| `scripts/check-no-baked-env.sh` | Verify no credentials baked into Docker image |
+| `scripts/check-outdated-deps.sh` | Check for outdated cargo dependencies |
+| `scripts/ensure-ignore-files.sh` | Verify .gitignore and .dockerignore patterns |
+
+## Dependencies
+
+### Runtime
+
+| Crate | Purpose |
+| --- | --- |
+| `tokio` | Async runtime (full features) |
+| `axum` | HTTP framework for MCP server |
+| `tower-http` | CORS and tracing middleware |
+| `rusqlite` | SQLite driver (bundled, with FTS5) |
+| `r2d2` / `r2d2_sqlite` | Connection pooling |
+| `syslog_loose` | RFC 3164/5424 syslog parsing |
+| `serde` / `serde_json` | Serialization |
+| `chrono` | Timestamps |
+| `toml` | Config file parsing |
+| `tracing` / `tracing-subscriber` | Structured logging |
+| `anyhow` | Error handling |
+| `subtle` | Constant-time token comparison |
+| `rustix` | Filesystem stats (free disk space) |
+| `tokio-stream` / `futures-core` | SSE support |
+
+### Development
+
+| Crate | Purpose |
+| --- | --- |
+| `tempfile` | Temporary directories for test databases |
+| `serial_test` | Serialized test execution for env var tests |
+| `tower` | HTTP testing utilities |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# Syslog MCP Documentation
+
+Complete documentation for `syslog-mcp` -- a Rust syslog receiver and MCP server for homelab log intelligence.
+
+## Directory index
+
+### Root-level docs (this directory)
+
+| File | Purpose |
+| --- | --- |
+| `README.md` | This file -- documentation index |
+| `SETUP.md` | Step-by-step setup guide -- clone, build, configure, deploy, verify |
+| `CONFIG.md` | Configuration reference -- config.toml, env vars, storage budget |
+| `CHECKLIST.md` | Pre-release quality checklist -- version sync, security, CI, registry |
+| `GUARDRAILS.md` | Security guardrails -- credentials, Docker, auth, input handling |
+| `INVENTORY.md` | Component inventory -- tools, env vars, surfaces, dependencies |
+
+### Subdirectories
+
+| Directory | Scope |
+| --- | --- |
+| `mcp/` | MCP server docs: auth, transport, tools, resources, testing, deployment |
+| `plugin/` | Plugin system docs: manifests, hooks, skills, commands, channels |
+| `repo/` | Repository docs: git conventions, scripts, memory, rules |
+| `stack/` | Technology stack docs: prerequisites, architecture, Rust dependencies |
+| `upstream/` | Upstream service docs (syslog-mcp is self-contained -- no external API) |
+
+### Preserved directories
+
+| Directory | Scope |
+| --- | --- |
+| `plans/` | Engineering plans and design docs |
+| `runbooks/` | Operational runbooks (deploy, maintenance) |
+| `sessions/` | Development session notes |
+| `superpowers/` | Superpowers plans (storage budget guardrail, etc.) |
+
+## Cross-references
+
+- [CLAUDE.md](../CLAUDE.md) -- project instructions for Claude Code sessions
+- [README.md](../README.md) -- user-facing project overview
+- [SETUP.md](../SETUP.md) -- host configuration guide (rsyslog, UniFi, ATT router)
+- [CHANGELOG.md](../CHANGELOG.md) -- version history

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,184 @@
+# Setup Guide -- syslog-mcp
+
+Step-by-step instructions to get syslog-mcp running locally, in Docker, or as a Claude Code plugin.
+
+## Prerequisites
+
+| Dependency | Version | Purpose |
+| --- | --- | --- |
+| Rust | 1.86+ | Compiler toolchain |
+| cargo | (bundled) | Build system and package manager |
+| Docker | 24+ | Container deployment |
+| Docker Compose | v2+ | Orchestration |
+| just | latest | Task runner |
+| openssl | any | Token generation |
+| curl | any | Health checks |
+| jq | any | JSON parsing (optional, for readable output) |
+
+## 1. Clone the repository
+
+```bash
+git clone https://github.com/jmagar/syslog-mcp.git
+cd syslog-mcp
+```
+
+## 2. Install Rust toolchain
+
+If Rust is not installed:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup default stable
+```
+
+## 3. Build
+
+```bash
+just build          # Debug build
+just release        # Release build (optimized)
+```
+
+Or directly:
+
+```bash
+cargo build --release
+```
+
+## 4. Configure environment
+
+```bash
+cp .env.example .env
+chmod 600 .env
+```
+
+Edit `.env` and set values as needed:
+
+```bash
+# Syslog listener
+SYSLOG_HOST=0.0.0.0
+SYSLOG_PORT=1514
+
+# MCP server
+SYSLOG_MCP_HOST=0.0.0.0
+SYSLOG_MCP_PORT=3100
+
+# Optional: enable bearer auth on /mcp endpoint
+#   openssl rand -hex 32
+SYSLOG_MCP_API_TOKEN=
+
+# Storage
+SYSLOG_MCP_DB_PATH=/data/syslog.db
+SYSLOG_MCP_POOL_SIZE=4
+SYSLOG_MCP_RETENTION_DAYS=90
+
+# Log verbosity
+RUST_LOG=info
+```
+
+See [CONFIG](CONFIG.md) for all environment variables.
+
+## 5. Start locally
+
+```bash
+just dev
+```
+
+Or directly:
+
+```bash
+cargo run
+```
+
+The server reads `config.toml` in the working directory. Syslog listens on `0.0.0.0:1514` (UDP+TCP) and MCP on `0.0.0.0:3100` (HTTP).
+
+## 6. Start via Docker
+
+```bash
+just up
+```
+
+Or manually:
+
+```bash
+docker compose up -d
+```
+
+Docker uses defaults and env vars exclusively -- `config.toml` is not copied into the image.
+
+## 7. Verify
+
+```bash
+just health
+```
+
+Or:
+
+```bash
+curl http://localhost:3100/health
+```
+
+Expected response:
+
+```json
+{"status": "ok"}
+```
+
+Send a test syslog message and confirm it arrives:
+
+```bash
+logger -n localhost -P 1514 --tcp "test from $(hostname)"
+
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"tail_logs","arguments":{"n":5}}}' | jq .
+```
+
+## 8. Install as Claude Code plugin
+
+```bash
+/plugin marketplace add jmagar/claude-homelab
+/plugin install syslog-mcp @jmagar-claude-homelab
+```
+
+Configure the plugin with your MCP URL and optional API token when prompted.
+
+## 9. Configure syslog sources
+
+See the root [SETUP.md](../SETUP.md) for per-host configuration:
+
+- **Linux hosts**: rsyslog `/etc/rsyslog.d/99-remote.conf`
+- **WSL hosts**: rsyslog with Tailscale IP
+- **UniFi**: Settings > System > Advanced > Remote Syslog
+- **ATT BGW-320**: Diagnostics > Syslog > Remote Syslog
+
+## Troubleshooting
+
+### "Connection refused" on health check
+
+- Confirm the server is running: `docker compose ps` or `ps aux | grep syslog-mcp`
+- Verify `SYSLOG_MCP_PORT` matches the port you are curling
+- If running in Docker, ensure port 3100 is published in `docker-compose.yml`
+
+### "401 Unauthorized" on tool calls
+
+- Verify `SYSLOG_MCP_API_TOKEN` in `.env` matches the token configured in your MCP client
+- If behind a reverse proxy (SWAG), handle auth at the proxy layer and leave `SYSLOG_MCP_API_TOKEN` unset
+
+### No syslog messages arriving
+
+- Confirm the syslog port is reachable: `nc -zvu <host> 1514`
+- Check iptables rules if redirecting 514 to 1514
+- Verify rsyslog config on the sending host: `systemctl status rsyslog`
+- Check Docker port mapping: `docker port syslog-mcp`
+
+### Database errors at startup
+
+- Ensure the data directory exists and is writable by UID 1000
+- Check volume mounts: `docker inspect syslog-mcp | jq '.[0].Mounts'`
+- Verify `SYSLOG_MCP_DB_PATH` points to a writable location
+
+### Plugin not discovered by Claude Code
+
+- Run `/plugin list` and confirm syslog-mcp appears
+- Check `~/.claude/plugins/cache/` for the plugin directory
+- Re-run `/plugin marketplace add jmagar/claude-homelab` to refresh

--- a/docs/mcp/AUTH.md
+++ b/docs/mcp/AUTH.md
@@ -1,0 +1,88 @@
+# Authentication Reference -- syslog-mcp
+
+## Overview
+
+syslog-mcp has a single authentication boundary: MCP clients authenticating to the MCP HTTP server. There is no outbound authentication -- syslog-mcp is a self-contained syslog receiver with no upstream API dependency.
+
+## Bearer token
+
+When `SYSLOG_MCP_API_TOKEN` is set, all requests to `/mcp` and `/sse` require:
+
+```
+Authorization: Bearer {SYSLOG_MCP_API_TOKEN}
+```
+
+Generate a token:
+
+```bash
+openssl rand -hex 32
+```
+
+Set it in `.env`:
+
+```bash
+SYSLOG_MCP_API_TOKEN=<generated-token>
+```
+
+## Authentication middleware
+
+The `require_auth` middleware in `src/mcp.rs` validates inbound tokens:
+
+```
+Request -> require_auth middleware -> Route Handler
+               |
+               v (401)
+         Missing/invalid token
+```
+
+- Returns HTTP 401 with JSON-RPC error `{"code": -32001, "message": "unauthorized"}` if the token is missing or incorrect
+- Uses `subtle::ConstantTimeEq` for token comparison to prevent timing side-channel attacks
+- Applies to `/mcp` (POST) and `/sse` (GET) routes only
+
+## Unauthenticated endpoints
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/health` | GET | Health check -- verifies SQLite connectivity, returns `{"status": "ok"}` |
+
+The health endpoint is intentionally unauthenticated so Docker HEALTHCHECK, docker-compose probes, and SWAG liveness checks can reach it without credentials.
+
+## No-auth mode
+
+When `SYSLOG_MCP_API_TOKEN` is not set (the default), all endpoints pass through without authentication. This is acceptable for:
+- LAN-only deployments behind a firewall
+- Deployments behind a reverse proxy that handles its own auth (SWAG with Authelia, Cloudflare Access)
+
+When exposed to the internet or untrusted networks, always set `SYSLOG_MCP_API_TOKEN`.
+
+## Plugin userConfig integration
+
+When installed as a Claude Code plugin, the token is managed via `userConfig` in `.claude-plugin/plugin.json`:
+
+```json
+{
+  "userConfig": {
+    "SYSLOG_MCP_API_TOKEN": {
+      "type": "string",
+      "title": "API Token",
+      "description": "Bearer token for authenticating MCP requests (leave empty if auth is disabled)",
+      "sensitive": true
+    }
+  }
+}
+```
+
+Fields marked `"sensitive": true` are stored encrypted by Claude Code.
+
+## Security practices
+
+- Token comparison is constant-time (`subtle::ConstantTimeEq`) to prevent timing attacks
+- Auth failure logs include HTTP method and path but never the submitted token value
+- No tokens are logged at any log level, including `RUST_LOG=trace`
+- Rotate credentials by updating `.env` and running `just restart`
+
+## See also
+
+- [ENV.md](ENV.md) -- environment variable reference
+- [TRANSPORT.md](TRANSPORT.md) -- transport-specific auth behavior
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- full security guardrails

--- a/docs/mcp/CICD.md
+++ b/docs/mcp/CICD.md
@@ -1,0 +1,97 @@
+# CI/CD Workflows -- syslog-mcp
+
+GitHub Actions configuration for syslog-mcp.
+
+## Workflows
+
+### ci.yml -- Continuous Integration
+
+Runs on every push and pull request.
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - run: cargo clippy -- -D warnings
+      - run: cargo fmt -- --check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+```
+
+### docker-publish.yml -- Docker Image Publishing
+
+Triggered on version tag push (`v*`). Builds multi-arch Docker image and pushes to GHCR.
+
+```yaml
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ghcr.io/jmagar/syslog-mcp:${{ github.ref_name }}
+```
+
+### publish-crates.yml -- crates.io Publishing
+
+Triggered on version tag push. Publishes the crate to crates.io.
+
+```yaml
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+```
+
+### codex-plugin-scanner.yml -- Plugin Validation
+
+Runs on pull requests to validate the Codex plugin manifest.
+
+## Branch strategy
+
+- `main`: Production-ready code
+- Feature branches: new features, bug fixes
+- PRs required before merge to main
+- Version tags (`v0.3.1`) trigger publish workflows
+
+## Secrets
+
+| Secret | Purpose |
+| --- | --- |
+| `GITHUB_TOKEN` | GHCR Docker image push (automatic) |
+| `CARGO_REGISTRY_TOKEN` | crates.io publishing |
+
+## See also
+
+- [PUBLISH.md](PUBLISH.md) -- versioning and release workflow
+- [TESTS.md](TESTS.md) -- test configuration

--- a/docs/mcp/CLAUDE.md
+++ b/docs/mcp/CLAUDE.md
@@ -1,0 +1,27 @@
+# MCP Server Documentation -- syslog-mcp
+
+Index for the `mcp/` documentation subdirectory. These docs cover the MCP server implementation, transport, tools, testing, and deployment.
+
+## File index
+
+| File | Purpose |
+| --- | --- |
+| `AUTH.md` | Authentication: bearer token, constant-time comparison, unauthenticated endpoints |
+| `CICD.md` | CI/CD workflows: lint, test, Docker publish, crates.io publish |
+| `CONNECT.md` | Client connection methods: plugin install, Claude Code, Codex, Gemini, curl |
+| `DEPLOY.md` | Deployment: local dev, Docker, Docker Compose, port assignment |
+| `DEV.md` | Development workflow: build cycle, adding tools, debugging, code style |
+| `ELICITATION.md` | MCP elicitation: syslog-mcp does not use elicitation (read-only tools) |
+| `ENV.md` | Environment variable reference (concise cross-ref to CONFIG.md) |
+| `LOGS.md` | Logging: RUST_LOG, tracing, structured output, error handling |
+| `MCPORTER.md` | Live smoke testing with mcporter |
+| `MCPUI.md` | MCP UI patterns: schema annotations for client rendering |
+| `PATTERNS.md` | Code patterns: flat tool dispatch, run_db helper, batch writer |
+| `PRE-COMMIT.md` | Pre-commit hook configuration |
+| `PUBLISH.md` | Publishing: versioning, crates.io, GHCR, MCP registry |
+| `RESOURCES.md` | MCP resources: syslog-mcp exposes no resources |
+| `SCHEMA.md` | Tool schema documentation: JSON Schema definitions in Rust |
+| `TESTS.md` | Testing: cargo test, live smoke tests, test coverage |
+| `TOOLS.md` | MCP tools reference: all 7 tools with parameters and response shapes |
+| `TRANSPORT.md` | Transport methods: HTTP (primary), SSE (legacy), port assignment |
+| `WEBMCP.md` | Web MCP: CORS configuration, browser access restrictions |

--- a/docs/mcp/CONNECT.md
+++ b/docs/mcp/CONNECT.md
@@ -1,0 +1,127 @@
+# Connect to MCP -- syslog-mcp
+
+How to connect to the syslog-mcp server from every supported client.
+
+## Via plugin (simplest)
+
+```bash
+# Claude Code
+/plugin marketplace add jmagar/claude-homelab
+/plugin install syslog-mcp @jmagar-claude-homelab
+```
+
+The plugin manifest handles transport and tool registration. Configure the MCP URL and optional API token when prompted.
+
+## Claude Code CLI
+
+```bash
+claude mcp add --transport http syslog-mcp http://localhost:3100/mcp
+```
+
+With bearer auth:
+
+```bash
+claude mcp add --transport http \
+  --header "Authorization: Bearer $SYSLOG_MCP_API_TOKEN" \
+  syslog-mcp http://localhost:3100/mcp
+```
+
+### Scopes
+
+| Flag | Scope | Config file |
+| --- | --- | --- |
+| `--scope project` | Current project only | `.claude/settings.local.json` |
+| `--scope user` | All projects (local) | `~/.claude/settings.json` |
+| (none) | Defaults to project | `.claude/settings.local.json` |
+
+## Codex CLI
+
+`.codex/mcp.json` (project) or `~/.codex/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "syslog-mcp": {
+      "type": "http",
+      "url": "http://localhost:3100/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      }
+    }
+  }
+}
+```
+
+## Gemini CLI
+
+`gemini-extension.json` (project root) or `~/.gemini/gemini-extension.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "syslog-mcp": {
+      "type": "http",
+      "url": "http://localhost:3100/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      }
+    }
+  }
+}
+```
+
+## Manual configuration reference
+
+All clients use the same `mcpServers` JSON structure. The only difference is the file path.
+
+### Config file locations
+
+| Client | Scope | File |
+| --- | --- | --- |
+| Claude Code | Project | `.claude/settings.local.json` |
+| Claude Code | User | `~/.claude/settings.json` |
+| Codex CLI | Project | `.codex/mcp.json` |
+| Codex CLI | User | `~/.codex/mcp.json` |
+| Gemini CLI | Project | `gemini-extension.json` |
+| Gemini CLI | Global | `~/.gemini/gemini-extension.json` |
+
+## Via SWAG reverse proxy
+
+When syslog-mcp is behind SWAG, the MCP endpoint becomes:
+
+```
+https://syslog-mcp.tootie.tv/mcp
+```
+
+Configure clients to use this URL instead of `localhost:3100`.
+
+## Verifying connection
+
+```bash
+# Health check (unauthenticated)
+curl -s http://localhost:3100/health
+# Expected: {"status":"ok"}
+
+# List available tools
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+# Test a tool call
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_stats","arguments":{}}}'
+```
+
+If connection fails, check:
+
+1. Server is running (`just up` or `just dev`)
+2. Port 3100 is not blocked by firewall
+3. Bearer token matches between client config and server `.env`
+4. Docker port mapping is correct: `docker port syslog-mcp`
+
+## See also
+
+- [AUTH.md](AUTH.md) -- bearer token setup
+- [ENV.md](ENV.md) -- environment variables
+- [TRANSPORT.md](TRANSPORT.md) -- transport details

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -1,0 +1,123 @@
+# Deployment Guide -- syslog-mcp
+
+Deployment patterns for syslog-mcp. Choose the method that fits your environment.
+
+## Local development
+
+```bash
+cargo run
+```
+
+Or via Justfile:
+
+```bash
+just dev
+```
+
+The server reads `config.toml` in the working directory. Syslog listens on `0.0.0.0:1514` and MCP on `0.0.0.0:3100`.
+
+## Cargo install
+
+```bash
+cargo install syslog-mcp
+syslog-mcp
+```
+
+The binary reads `config.toml` from the current directory and accepts env var overrides.
+
+## Docker
+
+### Build
+
+Multi-stage Dockerfile: Rust 1.86 builder compiles the release binary, Debian bookworm-slim runtime copies only the binary.
+
+```bash
+just docker-build
+# or: docker build -t syslog-mcp .
+```
+
+### Compose
+
+```yaml
+services:
+  syslog-mcp:
+    build: .
+    container_name: syslog-mcp
+    restart: unless-stopped
+    user: "${SYSLOG_UID:-1000}:${SYSLOG_GID:-1000}"
+    env_file:
+      - path: ~/.claude-homelab/.env
+        required: false
+    ports:
+      - "${SYSLOG_PORT:-1514}:1514/udp"
+      - "${SYSLOG_PORT:-1514}:1514/tcp"
+      - "${SYSLOG_MCP_PORT:-3100}:3100/tcp"
+    volumes:
+      - ${SYSLOG_MCP_DATA_VOLUME:-syslog-mcp-data}:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3100/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '1.0'
+```
+
+```bash
+just up         # docker compose up -d
+just down       # docker compose down
+just restart    # docker compose restart
+just logs       # docker compose logs -f
+```
+
+### Container conventions
+
+| Concern | Pattern |
+| --- | --- |
+| Base image | `rust:1.86-slim-bookworm` (builder) + `debian:bookworm-slim` (runtime) |
+| User | Non-root, UID 1000 (`syslog`) |
+| Health check | `curl -sf http://localhost:3100/health` every 30s |
+| Data | Named volume mounted at `/data` |
+| Network | External Docker network (`jakenet`) |
+| Signals | Graceful shutdown on SIGTERM/SIGINT (tokio signal handler) |
+| Config | No `config.toml` in image -- defaults + env vars only |
+
+### Entrypoint
+
+The entrypoint is minimal -- it delegates directly to the binary:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+exec "$@"
+```
+
+All configuration is handled by the Rust binary's config loading (defaults + env vars).
+
+## Port assignment
+
+| Service | Default Port | Env Var | Protocol |
+| --- | --- | --- | --- |
+| Syslog receiver | 1514 | `SYSLOG_PORT` | UDP + TCP |
+| MCP HTTP server | 3100 | `SYSLOG_MCP_PORT` | TCP |
+
+Port 1514 is used instead of the standard syslog port 514 to avoid needing root or `CAP_NET_BIND_SERVICE`. Use iptables PREROUTING to redirect 514 to 1514 for devices that cannot be reconfigured.
+
+## SWAG reverse proxy
+
+See `docs/syslog.subdomain.conf` for a working nginx config that exposes MCP over HTTPS at `https://syslog-mcp.tootie.tv/mcp`.
+
+Key requirements for SSE support:
+- `proxy_buffering off`
+- `chunked_transfer_encoding off`
+- `proxy_http_version 1.1`
+
+## See also
+
+- [ENV.md](ENV.md) -- environment variables
+- [LOGS.md](LOGS.md) -- logging configuration
+- [CONNECT.md](CONNECT.md) -- client connection methods

--- a/docs/mcp/DEV.md
+++ b/docs/mcp/DEV.md
@@ -1,0 +1,147 @@
+# Development Workflow -- syslog-mcp
+
+Day-to-day development guide for the syslog-mcp server.
+
+## Quick start
+
+```bash
+git clone https://github.com/jmagar/syslog-mcp.git
+cd syslog-mcp
+cp .env.example .env
+chmod 600 .env
+
+just dev          # Start dev server (cargo run)
+```
+
+## Project structure
+
+```
+syslog-mcp/
+  src/
+    main.rs              # Entry point, task wiring, graceful shutdown
+    config.rs            # Config: config.toml + env var overlay
+    db.rs                # SQLite pool, FTS5, schema, retention, storage budget
+    syslog.rs            # UDP/TCP listeners, RFC 3164/5424 parsing, batch writer
+    mcp.rs               # Axum HTTP, JSON-RPC dispatch, all 7 tool handlers
+  tests/                 # Live integration tests
+  scripts/               # Smoke tests, backups, plugin checks
+  hooks/                 # Claude Code hooks (pre-commit, sync-env)
+  skills/syslog/         # Skill definition (SKILL.md)
+  .claude-plugin/        # Claude Code plugin manifest
+  .codex-plugin/         # Codex CLI plugin manifest
+  gemini-extension.json  # Gemini CLI manifest
+  docker-compose.yml     # Container deployment
+  Dockerfile             # Container build
+  config.toml            # Local dev config (not in Docker image)
+  .env.example           # Environment variable template
+  Justfile               # Task runner recipes
+```
+
+## Development cycle
+
+1. **Edit source code** -- modify tool handlers in `src/mcp.rs`, database queries in `src/db.rs`, syslog parsing in `src/syslog.rs`.
+2. **Run dev server** -- `just dev` compiles and runs the binary.
+3. **Test interactively** -- call tools via curl:
+   ```bash
+   # Health (unauthenticated)
+   curl http://localhost:3100/health
+
+   # Tool call
+   curl -s -X POST http://localhost:3100/mcp \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"tail_logs","arguments":{"n":10}}}'
+   ```
+4. **Run checks**:
+   ```bash
+   just lint && just test
+   ```
+5. **Commit** with conventional prefix:
+   ```bash
+   git commit -m "feat(tools): add search filter by facility"
+   ```
+
+## Adding a new MCP tool
+
+1. **Define the tool schema** -- add a JSON object to the `tool_definitions()` vec in `src/mcp.rs`.
+2. **Add dispatch entry** -- add a match arm in `execute_tool()`.
+3. **Implement handler** -- write an async function `tool_<name>()` that calls `run_db()` for database access.
+4. **Add database query** -- implement the query function in `src/db.rs` with parameterized SQL.
+5. **Add unit test** -- write `#[test]` or `#[tokio::test]` in the relevant module.
+6. **Update syslog_help** -- add the tool to the help text in `tool_syslog_help()`.
+7. **Update SKILL.md** -- add the tool to the skill documentation.
+8. **Update plugin manifests** -- add the tool name to `.claude-plugin/plugin.json` tools array.
+
+## Debugging
+
+### Log levels
+
+Set `RUST_LOG` in `.env` or environment:
+
+| Level | Use case |
+| --- | --- |
+| `trace` | Full syslog parse output, SQL queries, batch details |
+| `debug` | Request/response details, batch flush, queue depth |
+| `info` | Startup, tool calls, retention purge, storage enforcement (default) |
+| `warn` | Backpressure, oversized messages, connection limits |
+| `error` | Failures, DB errors, channel closed |
+
+Targeted filtering:
+
+```bash
+RUST_LOG=syslog_mcp=debug,tower_http=info cargo run
+```
+
+### mcporter testing
+
+```bash
+mcporter list syslog-mcp --config config/mcporter.json
+mcporter call --config config/mcporter.json syslog-mcp.get_stats
+mcporter call --config config/mcporter.json syslog-mcp.tail_logs n=10
+```
+
+### MCP Inspector
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Connect to `http://localhost:3100/mcp` with your bearer token.
+
+## Code style
+
+| Tool | Command | Purpose |
+| --- | --- | --- |
+| clippy | `just lint` | Lint with `-D warnings` |
+| rustfmt | `just fmt` | Auto-format |
+| cargo check | `just check` | Type check without building |
+| cargo test | `just test` | Run test suite |
+
+## Justfile recipes
+
+| Recipe | Description |
+| --- | --- |
+| `just dev` | Start dev server (`cargo run`) |
+| `just build` | Debug build |
+| `just release` | Release build |
+| `just check` | `cargo check` |
+| `just lint` | `cargo clippy -- -D warnings` |
+| `just fmt` | `cargo fmt` |
+| `just test` | `cargo test` |
+| `just up` | `docker compose up -d` |
+| `just down` | `docker compose down` |
+| `just restart` | `docker compose restart` |
+| `just logs` | `docker compose logs -f` |
+| `just health` | curl health endpoint |
+| `just test-live` | Run live smoke tests |
+| `just docker-build` | Build Docker image |
+| `just setup` | Copy .env.example to .env |
+| `just gen-token` | Generate bearer token |
+| `just check-contract` | Validate plugin manifests |
+| `just clean` | `cargo clean` |
+| `just publish` | Bump version, tag, push |
+
+## See also
+
+- [CONNECT.md](CONNECT.md) -- client connection methods
+- [PATTERNS.md](PATTERNS.md) -- code patterns
+- [TESTS.md](TESTS.md) -- testing guide

--- a/docs/mcp/ELICITATION.md
+++ b/docs/mcp/ELICITATION.md
@@ -1,0 +1,26 @@
+# MCP Elicitation -- syslog-mcp
+
+## Overview
+
+Elicitation is an MCP protocol capability that allows servers to request information from users interactively. syslog-mcp does not use elicitation.
+
+## Why no elicitation
+
+syslog-mcp is a self-contained syslog receiver with no external API dependencies. There are no upstream credentials to collect at first-run. All configuration is handled via environment variables and `config.toml`.
+
+Additionally, all 7 MCP tools are read-only. There are no destructive operations that would benefit from confirmation gates via elicitation.
+
+## Configuration entry points
+
+Instead of elicitation, syslog-mcp uses:
+
+| Method | Purpose |
+| --- | --- |
+| Environment variables | All runtime configuration |
+| `config.toml` | Local development overrides |
+| Plugin `userConfig` | MCP URL and API token when installed via Claude Code plugin |
+
+## See also
+
+- [ENV.md](ENV.md) -- environment variable reference
+- [AUTH.md](AUTH.md) -- bearer token configuration

--- a/docs/mcp/ENV.md
+++ b/docs/mcp/ENV.md
@@ -1,0 +1,68 @@
+# Environment Variable Reference -- syslog-mcp
+
+Concise reference. See [CONFIG.md](../CONFIG.md) for full documentation including config.toml overlay and validation rules.
+
+## Syslog listener
+
+| Variable | Required | Default | Description | Sensitive |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_HOST` | no | `0.0.0.0` | Listen host for UDP+TCP syslog | no |
+| `SYSLOG_PORT` | no | `1514` | Listen port (shared UDP and TCP) | no |
+| `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | Max message size in bytes | no |
+| `SYSLOG_BATCH_SIZE` | no | `100` | Entries per batch flush | no |
+| `SYSLOG_FLUSH_INTERVAL` | no | `500` | Batch flush interval in ms | no |
+
+## MCP server
+
+| Variable | Required | Default | Description | Sensitive |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_MCP_HOST` | no | `0.0.0.0` | HTTP bind address | no |
+| `SYSLOG_MCP_PORT` | no | `3100` | HTTP listen port | no |
+| `SYSLOG_MCP_API_TOKEN` | no | (none) | Bearer token for `/mcp` and `/sse`. Generate: `openssl rand -hex 32` | **yes** |
+
+## Storage
+
+| Variable | Required | Default | Description | Sensitive |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_MCP_DB_PATH` | no | `/data/syslog.db` | SQLite database file path | no |
+| `SYSLOG_MCP_POOL_SIZE` | no | `4` | Connection pool size | no |
+| `SYSLOG_MCP_RETENTION_DAYS` | no | `90` | Days before automatic purge (0 = forever) | no |
+
+## Storage budget
+
+| Variable | Required | Default | Description | Sensitive |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_MCP_MAX_DB_SIZE_MB` | no | `1024` | Soft DB size limit in MB (0 = disable) | no |
+| `SYSLOG_MCP_RECOVERY_DB_SIZE_MB` | no | `900` | Cleanup target after DB-size breach | no |
+| `SYSLOG_MCP_MIN_FREE_DISK_MB` | no | `512` | Min free disk in MB (0 = disable) | no |
+| `SYSLOG_MCP_RECOVERY_FREE_DISK_MB` | no | `768` | Cleanup target after free-disk breach | no |
+| `SYSLOG_MCP_CLEANUP_INTERVAL_SECS` | no | `60` | Enforcement check interval in seconds | no |
+| `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` | no | `2000` | Rows deleted per chunk (1 to 1,000,000) | no |
+
+## Logging
+
+| Variable | Required | Default | Description | Sensitive |
+| --- | --- | --- | --- | --- |
+| `RUST_LOG` | no | `info` | Tracing filter directive (e.g. `debug`, `syslog_mcp=trace`) | no |
+
+## Docker / container
+
+| Variable | Required | Default | Description | Sensitive |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_UID` | no | `1000` | Container user ID | no |
+| `SYSLOG_GID` | no | `1000` | Container group ID | no |
+| `DOCKER_NETWORK` | no | `syslog-mcp` | External Docker network name | no |
+
+## Token generation
+
+```bash
+openssl rand -hex 32
+```
+
+Store the result in `SYSLOG_MCP_API_TOKEN` in your `.env` file.
+
+## See also
+
+- [AUTH.md](AUTH.md) -- how tokens are used for authentication
+- [TRANSPORT.md](TRANSPORT.md) -- transport-specific variable usage
+- [../CONFIG.md](../CONFIG.md) -- full configuration reference with validation rules

--- a/docs/mcp/LOGS.md
+++ b/docs/mcp/LOGS.md
@@ -1,0 +1,107 @@
+# Logging and Error Handling -- syslog-mcp
+
+## Log configuration
+
+syslog-mcp uses the `tracing` crate with `tracing-subscriber` for structured logging.
+
+| Env Var | Values | Default |
+| --- | --- | --- |
+| `RUST_LOG` | Tracing filter directives | `info` |
+
+### Filter directive examples
+
+```bash
+RUST_LOG=info                           # Default: info level for all modules
+RUST_LOG=debug                          # All modules at debug
+RUST_LOG=syslog_mcp=debug              # Only syslog-mcp at debug
+RUST_LOG=syslog_mcp=trace,tower_http=info  # Trace syslog-mcp, info for HTTP layer
+RUST_LOG=warn                           # Quiet mode: warnings and errors only
+```
+
+## Log output
+
+All log output goes to stdout in human-readable format with timestamps, levels, and target modules:
+
+```
+2025-01-15T14:30:00.123Z  INFO syslog_mcp::main: syslog-mcp v0.3.1
+2025-01-15T14:30:00.125Z  INFO syslog_mcp::main: Configuration loaded syslog_bind=0.0.0.0:1514 mcp_bind=0.0.0.0:3100
+2025-01-15T14:30:00.130Z  INFO syslog_mcp::db: Database initialized path=/data/syslog.db
+2025-01-15T14:30:00.132Z  INFO syslog_mcp::syslog: Syslog listeners started bind=0.0.0.0:1514
+2025-01-15T14:30:00.133Z  INFO syslog_mcp::mcp: MCP server listening bind=0.0.0.0:3100
+```
+
+### Key log events
+
+| Event | Level | Module | Meaning |
+| --- | --- | --- | --- |
+| Configuration loaded | INFO | main | Startup config summary |
+| Database initialized | INFO | db | Schema created/migrated |
+| Syslog listeners started | INFO | syslog | UDP+TCP bound |
+| MCP server listening | INFO | mcp | HTTP server ready |
+| MCP tool execution started | INFO | mcp | Tool call received |
+| MCP tool execution completed | INFO | mcp | Tool call finished with timing |
+| Retention purge tick completed | INFO | main | Hourly log cleanup count |
+| Storage budget enforcement | INFO/WARN | main | Storage threshold check |
+| Backpressure applied | WARN | syslog | Write channel full |
+| Backpressure lifted | INFO | syslog | Write channel cleared |
+| Write channel closed | ERROR | syslog | Batch writer shutting down |
+| Unauthorized MCP request rejected | WARN | mcp | Invalid or missing bearer token |
+
+## Log location
+
+| Context | Path |
+| --- | --- |
+| Local dev | stdout |
+| Docker | stdout (access via `just logs` or `docker compose logs -f`) |
+
+There is no file-based logging. Container orchestrators (Docker, Kubernetes) capture stdout logs natively.
+
+## Error handling patterns
+
+### MCP tool errors
+
+Tool execution errors return MCP-formatted responses with `isError: true`:
+
+```json
+{
+  "content": [{"type": "text", "text": "Tool execution failed"}],
+  "isError": true
+}
+```
+
+The server logs the full error with timing, then returns a sanitized message to the client.
+
+### Database errors
+
+SQLite errors (busy, locked, corrupt) are caught and logged:
+- Transient lock errors trigger retry with exponential backoff (25ms, 100ms, 250ms)
+- `busy_timeout=5000` pragma prevents most lock contention
+- Persistent failures after all retries log the error and return batch to the write channel
+
+### Syslog ingestion errors
+
+- Oversized messages (> `max_message_size`) are dropped with a WARN log
+- Invalid syslog frames are parsed best-effort (facility defaults to empty, severity to "info")
+- Write channel backpressure is logged on state transitions only (not per-message) to prevent log storms
+- TCP idle timeout (300s default) drops zombie connections with a WARN log
+
+### Graceful shutdown
+
+SIGTERM and SIGINT are handled by tokio signal handlers:
+1. Log "Shutdown signal received"
+2. Stop accepting new HTTP connections
+3. Abort retention purge and storage enforcement tasks
+4. Flush remaining batch writer entries
+5. Exit cleanly
+
+### Credential safety
+
+- Bearer tokens are never logged at any level
+- Auth failure logs include method and path but not the submitted token
+- `SYSLOG_MCP_API_TOKEN` value is never printed in startup config summary (only `auth_enabled = true/false`)
+
+## See also
+
+- [DEPLOY.md](DEPLOY.md) -- Docker volume mounts
+- [ENV.md](ENV.md) -- `RUST_LOG` and other env vars
+- [TESTS.md](TESTS.md) -- testing error conditions

--- a/docs/mcp/MCPORTER.md
+++ b/docs/mcp/MCPORTER.md
@@ -1,0 +1,86 @@
+# Live Smoke Testing (mcporter) -- syslog-mcp
+
+End-to-end verification against a running syslog-mcp server. Complements unit tests in [TESTS.md](TESTS.md).
+
+## Purpose
+
+`scripts/smoke-test.sh` exercises the full MCP server stack: auth, tool dispatch, and response validation against a live syslog-mcp instance with 25 assertions.
+
+## Location
+
+```
+scripts/smoke-test.sh       # Full smoke test (25 assertions)
+tests/test_live.sh          # Extended live integration tests
+tests/mcporter/test-tools.sh  # mcporter-based tool tests
+```
+
+## Running
+
+```bash
+# Ensure server is running
+just up
+
+# Run smoke tests
+just test-live
+# or: bash scripts/smoke-test.sh
+```
+
+## mcporter configuration
+
+mcporter config is at `config/mcporter.json`:
+
+```json
+{
+  "servers": {
+    "syslog-mcp": {
+      "transport": "http",
+      "url": "http://localhost:3100/mcp"
+    }
+  }
+}
+```
+
+## Manual mcporter commands
+
+```bash
+# List available tools
+mcporter list syslog-mcp --config config/mcporter.json
+
+# Call tools
+mcporter call --config config/mcporter.json syslog-mcp.get_stats
+mcporter call --config config/mcporter.json syslog-mcp.tail_logs n=10
+mcporter call --config config/mcporter.json syslog-mcp.search_logs query=error limit=5
+mcporter call --config config/mcporter.json syslog-mcp.list_hosts
+mcporter call --config config/mcporter.json syslog-mcp.get_errors
+mcporter call --config config/mcporter.json syslog-mcp.syslog_help
+```
+
+## Test assertions
+
+The smoke test validates:
+- Health endpoint returns `{"status": "ok"}`
+- All 7 tools return valid JSON responses
+- `search_logs` returns expected `count` and `logs` fields
+- `tail_logs` respects the `n` parameter
+- `get_errors` returns `summary` array
+- `list_hosts` returns `hosts` array
+- `correlate_events` returns `hosts` grouped by hostname
+- `get_stats` returns numeric fields (total_logs, total_hosts, etc.)
+- `syslog_help` returns non-empty markdown text
+
+## Failure output
+
+```
+  PASS: health endpoint returns ok
+  PASS: search_logs returns count field
+  FAIL: tail_logs count should be <= 10, got 50
+  ---
+  25 assertions: 24 PASS, 1 FAIL
+```
+
+Exit code is non-zero if any assertion fails.
+
+## See also
+
+- [TESTS.md](TESTS.md) -- unit and integration tests
+- [CICD.md](CICD.md) -- CI workflow configuration

--- a/docs/mcp/MCPUI.md
+++ b/docs/mcp/MCPUI.md
@@ -1,0 +1,61 @@
+# MCP UI Patterns -- syslog-mcp
+
+Protocol-level UI hints for MCP servers to improve client-side rendering of tools and results.
+
+## Current state
+
+syslog-mcp does not currently include MCP UI annotations in its tool schemas. Tool inputs use standard JSON Schema properties without `x-ui-*` extensions.
+
+## Schema annotations available
+
+Tool schemas support optional UI hints that clients can interpret:
+
+### Parameter widgets
+
+```json
+{
+  "severity": {
+    "type": "string",
+    "enum": ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug"],
+    "description": "Filter by syslog severity level"
+  }
+}
+```
+
+The `enum` constraint already enables clients to render a dropdown/select widget without explicit UI annotations.
+
+### Time range inputs
+
+```json
+{
+  "from": {
+    "type": "string",
+    "description": "Start of time range (ISO 8601, e.g., '2025-01-15T00:00:00Z')"
+  }
+}
+```
+
+Clients that support datetime widgets can detect ISO 8601 format from the description.
+
+## Response formatting
+
+Tool responses return JSON as text content. Clients render this according to their capabilities:
+- CLI clients: raw JSON or formatted with jq
+- Web clients: parsed and rendered as tables
+- LLM clients: interpreted directly
+
+## Future enhancements
+
+If MCP UI annotations are adopted:
+
+| Tool | Possible UI hint |
+| --- | --- |
+| `search_logs` | Multi-line text input for query, datetime pickers for from/to |
+| `tail_logs` | Slider for n parameter |
+| `correlate_events` | Datetime picker for reference_time, slider for window_minutes |
+| `get_errors` | Datetime range picker |
+
+## See also
+
+- [TOOLS.md](TOOLS.md) -- tool reference with current schemas
+- [SCHEMA.md](SCHEMA.md) -- schema documentation

--- a/docs/mcp/PATTERNS.md
+++ b/docs/mcp/PATTERNS.md
@@ -1,0 +1,128 @@
+# Common MCP Code Patterns -- syslog-mcp
+
+Reusable patterns in the syslog-mcp implementation.
+
+## Flat tool dispatch
+
+syslog-mcp uses a flat match on tool name rather than an action/subaction router:
+
+```rust
+async fn execute_tool(state: &AppState, name: &str, args: Value) -> anyhow::Result<Value> {
+    match name {
+        "search_logs" => tool_search_logs(&state.pool, args).await,
+        "tail_logs" => tool_tail_logs(&state.pool, args).await,
+        "get_errors" => tool_get_errors(&state.pool, args).await,
+        "list_hosts" => tool_list_hosts(&state.pool, args).await,
+        "correlate_events" => tool_correlate_events(&state.pool, args).await,
+        "get_stats" => tool_get_stats(state, args).await,
+        "syslog_help" => tool_syslog_help().await,
+        _ => Err(anyhow::anyhow!("Unknown tool: {name}")),
+    }
+}
+```
+
+This pattern is appropriate when each tool has distinct parameters and behavior. The action/subaction router is better when tools share CRUD patterns on multiple resource types.
+
+## run_db helper
+
+All database operations run on tokio's blocking threadpool via a shared helper:
+
+```rust
+async fn run_db<F, T>(pool: &Arc<DbPool>, f: F) -> anyhow::Result<T>
+where
+    F: FnOnce(&DbPool) -> anyhow::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    let pool = Arc::clone(pool);
+    tokio::task::spawn_blocking(move || f(&pool))
+        .await
+        .map_err(|e| anyhow::anyhow!("Task join error: {e}"))?
+}
+```
+
+This prevents blocking the tokio runtime with synchronous rusqlite calls.
+
+## Batch writer
+
+Syslog messages flow through an mpsc channel to a batched writer:
+
+```
+UDP/TCP listener -> parse_syslog() -> mpsc::channel -> batch_writer() -> insert_logs_batch()
+```
+
+The batch writer collects entries and flushes when either:
+- The batch reaches `batch_size` entries (default 100)
+- The `flush_interval` timer fires (default 500ms)
+
+This amortizes SQLite transaction overhead across many inserts.
+
+## Storage budget with hysteresis
+
+The storage enforcement uses a two-threshold system:
+
+1. **Trigger**: DB size > `max_db_size_mb` or free disk < `min_free_disk_mb`
+2. **Recovery**: Delete oldest logs until DB size < `recovery_db_size_mb` and free disk > `recovery_free_disk_mb`
+3. **Write block**: If cleanup cannot recover, block the batch writer
+
+The gap between trigger and recovery thresholds prevents oscillation (delete-write-delete cycles).
+
+## Constant-time auth
+
+Bearer token comparison uses the `subtle` crate:
+
+```rust
+let authorized = match provided {
+    Some(token) => token.as_bytes().ct_eq(expected.as_bytes()).unwrap_u8() == 1,
+    None => false,
+};
+```
+
+This prevents timing side-channel attacks against the bearer token.
+
+## Backpressure logging
+
+State-transition logging prevents log storms under load:
+
+```rust
+let at_capacity = tx.capacity() == 0;
+if at_capacity && !backpressure {
+    warn!("syslog write channel full - backpressure applied");
+    backpressure = true;
+} else if !at_capacity && backpressure {
+    info!("syslog write channel cleared - backpressure lifted");
+    backpressure = false;
+}
+```
+
+Only the transitions are logged, not every message during backpressure.
+
+## TCP connection limiting
+
+A semaphore caps concurrent TCP connections:
+
+```rust
+let sem = Arc::new(Semaphore::new(max_connections));
+// ...
+match Arc::clone(&sem).try_acquire_owned() {
+    Ok(permit) => { /* handle connection, permit drops on close */ }
+    Err(_) => { /* reject connection */ }
+}
+```
+
+Rejection logging is rate-limited to once per 10 seconds.
+
+## SQLite retry with backoff
+
+Transient SQLite lock errors trigger retry:
+
+```rust
+const RETRY_DELAYS_MS: &[u64] = &[25, 100, 250];
+```
+
+Three attempts with increasing delay before surfacing the error.
+
+## See also
+
+- [TOOLS.md](TOOLS.md) -- tool definitions
+- [SCHEMA.md](SCHEMA.md) -- schema patterns
+- [../stack/ARCH.md](../stack/ARCH.md) -- architecture overview

--- a/docs/mcp/PRE-COMMIT.md
+++ b/docs/mcp/PRE-COMMIT.md
@@ -1,0 +1,51 @@
+# Pre-commit Hook Configuration -- syslog-mcp
+
+Hooks run as Claude Code lifecycle hooks via `hooks/hooks.json`.
+
+## Hook configuration
+
+Hooks are defined in `hooks/hooks.json` and enforced by Claude Code during sessions:
+
+| Hook | Script | Purpose |
+| --- | --- | --- |
+| `sync-env` | `hooks/scripts/sync-env.sh` | Ensures `.env.example` documents all variables read by the server |
+| `fix-env-perms` | `hooks/scripts/fix-env-perms.sh` | Sets `.env` to `chmod 600` if present |
+| `ensure-ignore-files` | `hooks/scripts/ensure-ignore-files.sh` | Verifies `.gitignore` and `.dockerignore` contain required patterns |
+
+## Manual checks
+
+Run checks manually outside of Claude Code:
+
+```bash
+# Plugin manifest validation
+just check-contract
+
+# Docker security check
+bash scripts/check-docker-security.sh
+
+# No baked env vars in Docker image
+bash scripts/check-no-baked-env.sh
+
+# Outdated dependencies
+bash scripts/check-outdated-deps.sh
+
+# Ignore file patterns
+bash scripts/ensure-ignore-files.sh
+```
+
+## Rust-specific checks
+
+Before committing, run:
+
+```bash
+just lint        # cargo clippy -- -D warnings
+just fmt         # cargo fmt
+just test        # cargo test
+```
+
+These are not automated as git hooks but are enforced in CI.
+
+## See also
+
+- [CICD.md](CICD.md) -- CI workflow enforces lint and test
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- security patterns enforced by hooks

--- a/docs/mcp/PUBLISH.md
+++ b/docs/mcp/PUBLISH.md
@@ -1,0 +1,92 @@
+# Publishing Strategy -- syslog-mcp
+
+Versioning and release workflow.
+
+## Versioning
+
+Semantic versioning (MAJOR.MINOR.PATCH). Bump type from commit prefix:
+
+| Prefix | Bump | Example |
+| --- | --- | --- |
+| `feat!:` / `BREAKING CHANGE` | Major | `0.3.1` -> `1.0.0` |
+| `feat:` / `feat(scope):` | Minor | `0.3.1` -> `0.4.0` |
+| `fix:`, `docs:`, `chore:`, etc. | Patch | `0.3.1` -> `0.3.2` |
+
+## Version sync
+
+All version-bearing files must match. Update together:
+
+| File | Field |
+| --- | --- |
+| `Cargo.toml` | `version = "X.Y.Z"` in `[package]` |
+| `.claude-plugin/plugin.json` | `"version": "X.Y.Z"` |
+| `.codex-plugin/plugin.json` | `"version": "X.Y.Z"` |
+| `gemini-extension.json` | `"version": "X.Y.Z"` |
+| `server.json` | `"version": "X.Y.Z"` |
+| `CHANGELOG.md` | New entry under `## X.Y.Z` |
+
+## Publish workflow
+
+```bash
+just publish [major|minor|patch]
+```
+
+Steps executed:
+
+1. Verify on `main` branch with clean working tree
+2. Pull latest from origin
+3. Read current version from `Cargo.toml`
+4. Compute new version based on bump type
+5. Update `Cargo.toml`, plugin manifests, and `gemini-extension.json`
+6. Run `cargo check` to update `Cargo.lock`
+7. Commit: `release: vX.Y.Z`
+8. Tag: `vX.Y.Z`
+9. Push to origin with tags (triggers CI/CD publish workflows)
+
+## Package registries
+
+| Registry | Method | Trigger |
+| --- | --- | --- |
+| crates.io | `cargo publish` via GitHub Actions | `v*` tag push |
+| GHCR | Docker image build and push | `v*` tag push |
+| MCP Registry | `server.json` under `tv.tootie/syslog-mcp` namespace | manual update |
+
+## server.json
+
+MCP Registry metadata at repo root:
+
+```json
+{
+  "name": "tv.tootie/syslog-mcp",
+  "title": "Syslog MCP",
+  "description": "Syslog receiver and MCP server for homelab log intelligence.",
+  "version": "0.2.6",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.2.6",
+      "transport": {"type": "stdio"}
+    }
+  ]
+}
+```
+
+## Verification
+
+After publishing, verify:
+
+```bash
+# crates.io
+cargo install syslog-mcp --version X.Y.Z
+
+# Docker
+docker pull ghcr.io/jmagar/syslog-mcp:vX.Y.Z
+
+# GitHub Release
+gh release view vX.Y.Z
+```
+
+## See also
+
+- [CICD.md](CICD.md) -- publish workflows triggered by tags
+- [DEPLOY.md](DEPLOY.md) -- installation methods

--- a/docs/mcp/RESOURCES.md
+++ b/docs/mcp/RESOURCES.md
@@ -1,0 +1,32 @@
+# MCP Resources Reference -- syslog-mcp
+
+## Overview
+
+MCP resources expose read-only data via URI-based access. Unlike tools, resources do not perform mutations -- they return the current state of a data source.
+
+## Available resources
+
+syslog-mcp does not expose any MCP resources. All data access is through the 7 MCP tools:
+
+| Tool | Equivalent resource use case |
+| --- | --- |
+| `get_stats` | Database status and health metrics |
+| `list_hosts` | Host registry |
+| `tail_logs` | Recent log stream |
+| `search_logs` | Log search and filtering |
+
+Tools are preferred over resources for syslog-mcp because all queries benefit from parameterized filtering (hostname, severity, time range, FTS5 query) that URI templating cannot express efficiently.
+
+## Future considerations
+
+If resources are added in the future, they would use the `syslog-mcp://` URI scheme:
+
+```
+syslog-mcp://stats           # Database statistics
+syslog-mcp://hosts           # Host registry
+syslog-mcp://hosts/{name}    # Logs for a specific host
+```
+
+## See also
+
+- [TOOLS.md](TOOLS.md) -- MCP tool reference

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -1,0 +1,103 @@
+# Tool Schema Documentation -- syslog-mcp
+
+## Overview
+
+Tool schemas define the input validation contract for MCP tools. In syslog-mcp, schemas are defined as `serde_json::json!()` objects in `src/mcp.rs` within the `tool_definitions()` function. These follow JSON Schema conventions.
+
+## Schema definition pattern
+
+Each tool definition is a JSON object with `name`, `description`, and `inputSchema`:
+
+```rust
+json!({
+    "name": "search_logs",
+    "description": "Full-text search across all syslog messages...",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "FTS5 search query..."
+            },
+            "hostname": {
+                "type": "string",
+                "description": "Filter by hostname..."
+            },
+            "severity": {
+                "type": "string",
+                "enum": ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug"],
+                "description": "Filter by syslog severity level"
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default 100, max 1000)"
+            }
+        }
+    }
+})
+```
+
+## Parameter types
+
+| JSON Schema type | Rust type | Extraction |
+| --- | --- | --- |
+| `"string"` | `Option<String>` | `args.get("key").and_then(\|v\| v.as_str()).map(String::from)` |
+| `"integer"` | `u32` or `u64` | `args.get("key").and_then(\|v\| v.as_u64()).unwrap_or(default)` |
+| `"string"` with `"enum"` | validated string | Checked against known values in handler |
+
+## Response format
+
+All tool responses use MCP text content blocks:
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"count\": 3, \"logs\": [...]}"
+    }
+  ]
+}
+```
+
+The `text` field contains pretty-printed JSON. Error responses add `"isError": true`.
+
+## Database types
+
+Request parameters are deserialized into `db::SearchParams`:
+
+```rust
+pub struct SearchParams {
+    pub query: Option<String>,        // FTS5 query
+    pub hostname: Option<String>,     // Exact match filter
+    pub severity: Option<String>,     // Single severity
+    pub severity_in: Option<Vec<String>>, // Multi-severity (correlate_events)
+    pub app_name: Option<String>,     // App name filter
+    pub from: Option<String>,         // ISO 8601 start
+    pub to: Option<String>,           // ISO 8601 end
+    pub limit: Option<u32>,           // Max results
+}
+```
+
+Response types are serde-serializable structs:
+
+| Struct | Used by |
+| --- | --- |
+| `LogEntry` | search_logs, tail_logs, correlate_events |
+| `ErrorSummaryEntry` | get_errors |
+| `HostEntry` | list_hosts |
+| `DbStats` | get_stats |
+
+## Validation
+
+Input validation happens in the tool handler functions, not at the schema level:
+- `limit` values are capped at their maximum (1000 for search, 500 for tail, 999 for correlate)
+- `severity` is validated against the known severity level list
+- `reference_time` is parsed as RFC 3339 and normalized to UTC
+- `from` and `to` timestamps are parsed and validated for correctness
+- Unknown parameters are silently ignored (JSON object properties are open by default)
+
+## See also
+
+- [TOOLS.md](TOOLS.md) -- tool reference with parameters and response shapes
+- [PATTERNS.md](PATTERNS.md) -- code patterns for tool dispatch

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -1,0 +1,116 @@
+# Testing Guide -- syslog-mcp
+
+## Unit tests
+
+```bash
+cargo test
+```
+
+Shortcut: `just test`
+
+Tests are colocated with source code in `#[cfg(test)]` modules:
+
+| Module | Tests cover |
+| --- | --- |
+| `src/config.rs` | Env var overrides, defaults, validation (host format, storage budget relationships, pool size) |
+| `src/db.rs` | Schema init, insert/search/tail/errors/hosts/stats, FTS5 queries, retention purge, storage budget enforcement, batch retry |
+| `src/syslog.rs` | RFC 3164/5424 parsing, UniFi CEF extraction, severity mapping, facility mapping, malformed input |
+| `src/mcp.rs` | Health endpoint, auth middleware (valid/invalid/missing token, no-auth mode), tool dispatch, timestamp validation, MCP lifecycle |
+| `src/main.rs` | Background interval timing |
+
+### Running specific tests
+
+```bash
+cargo test test_search           # Run tests matching "test_search"
+cargo test config::tests         # Run config module tests only
+cargo test -- --nocapture        # Show println/tracing output
+```
+
+### Test database handling
+
+Database tests use `tempfile::TempDir` for isolated SQLite instances. Each test gets a fresh database, preventing cross-test contamination. The `StorageConfig::for_test()` helper provides minimal config with pool_size=1 and WAL mode disabled.
+
+## Live smoke tests
+
+Live tests run against a running syslog-mcp server:
+
+```bash
+just test-live
+# or: bash tests/test_live.sh
+```
+
+The smoke test (`scripts/smoke-test.sh`) exercises all 7 MCP tools via mcporter with 25 assertions.
+
+### mcporter-based testing
+
+```bash
+# List available tools
+mcporter list syslog-mcp --config config/mcporter.json
+
+# Call individual tools
+mcporter call --config config/mcporter.json syslog-mcp.get_stats
+mcporter call --config config/mcporter.json syslog-mcp.tail_logs n=10
+mcporter call --config config/mcporter.json syslog-mcp.search_logs query=error limit=5
+mcporter call --config config/mcporter.json syslog-mcp.list_hosts
+```
+
+### curl-based testing
+
+```bash
+# Health check
+curl http://localhost:3100/health
+
+# Tail recent logs
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"tail_logs","arguments":{"n":10}}}'
+
+# Search
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_logs","arguments":{"query":"error","limit":5}}}'
+
+# Stats
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"get_stats","arguments":{}}}'
+```
+
+## Testing checklist
+
+- [ ] **All tools return expected shape** -- search_logs, tail_logs, get_errors, list_hosts, correlate_events, get_stats, syslog_help
+- [ ] **Auth: valid token** -- 200 with correct Bearer token
+- [ ] **Auth: invalid token** -- 401 Unauthorized
+- [ ] **Auth: no token when required** -- 401 Unauthorized
+- [ ] **Auth: no-auth mode** -- all endpoints accessible when SYSLOG_MCP_API_TOKEN is unset
+- [ ] **Health endpoint** -- `GET /health` returns 200 with no auth
+- [ ] **FTS5 query syntax** -- AND, OR, NOT, phrases, prefix matching
+- [ ] **Time range filtering** -- from/to parameters parse ISO 8601 correctly
+- [ ] **Severity filtering** -- all 8 levels work
+- [ ] **Retention purge** -- logs older than retention_days are deleted
+- [ ] **Storage budget** -- write blocking engages when limits are breached
+
+## CI configuration
+
+Tests run automatically in CI via GitHub Actions:
+
+```yaml
+# .github/workflows/ci.yml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+```
+
+## Test coverage
+
+See `tests/TEST_COVERAGE.md` for detailed coverage documentation.
+
+## See also
+
+- [MCPORTER.md](MCPORTER.md) -- live smoke tests with mcporter
+- [CICD.md](CICD.md) -- CI workflow configuration
+- [LOGS.md](LOGS.md) -- error handling patterns tested here

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -1,0 +1,231 @@
+# MCP Tools Reference -- syslog-mcp
+
+## Design philosophy
+
+syslog-mcp exposes 7 independent MCP tools using a flat dispatch pattern. Each tool has its own name, input schema, and handler -- there is no action/subaction router. All tools are read-only.
+
+| Tool | Purpose |
+| --- | --- |
+| `search_logs` | Full-text search with filters |
+| `tail_logs` | Recent log entries |
+| `get_errors` | Error/warning summary by host and severity |
+| `list_hosts` | Host registry with first/last seen |
+| `correlate_events` | Cross-host event correlation in a time window |
+| `get_stats` | Database statistics and storage health |
+| `syslog_help` | Markdown documentation for all tools |
+
+## search_logs
+
+Full-text search across all syslog messages. Uses SQLite FTS5 with porter stemming.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `query` | string | no | -- | FTS5 search query. Examples: `kernel panic`, `OOM AND killer`, `"connection refused"`, `error*` |
+| `hostname` | string | no | -- | Exact hostname match. Use `list_hosts` to enumerate. |
+| `severity` | enum | no | -- | One of: `emerg`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug` |
+| `app_name` | string | no | -- | Application name (e.g. `sshd`, `dockerd`, `kernel`) |
+| `from` | string | no | -- | Start of time range (ISO 8601, e.g. `2025-01-15T00:00:00Z`) |
+| `to` | string | no | -- | End of time range (ISO 8601) |
+| `limit` | integer | no | 100 | Max results (hard cap: 1000) |
+
+**Response:**
+
+```json
+{
+  "count": 3,
+  "logs": [
+    {
+      "id": 42,
+      "timestamp": "2025-01-15T14:30:00Z",
+      "hostname": "tootie",
+      "facility": "kern",
+      "severity": "err",
+      "app_name": "kernel",
+      "process_id": null,
+      "message": "Out of memory: Killed process 1234",
+      "received_at": "2025-01-15T14:30:01.123Z",
+      "source_ip": "10.0.0.5:54321"
+    }
+  ]
+}
+```
+
+**FTS5 query syntax:**
+
+| Pattern | Example | Meaning |
+| --- | --- | --- |
+| Simple words | `kernel panic` | Both terms in the message |
+| AND | `OOM AND killer` | Explicit AND |
+| OR | `kern OR syslog` | Either term |
+| NOT | `error NOT nginx` | Exclude term |
+| Phrase | `"connection refused"` | Exact phrase match |
+| Prefix | `error*` | Prefix match |
+| Hyphenated terms | `"smoke-test"` | Use phrase syntax (hyphen is FTS5 NOT operator) |
+
+## tail_logs
+
+Get the N most recent log entries. Equivalent to `tail -f` across all hosts.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `hostname` | string | no | -- | Filter to a specific host |
+| `app_name` | string | no | -- | Filter to a specific application |
+| `n` | integer | no | 50 | Number of recent entries (max 500) |
+
+**Response:**
+
+```json
+{
+  "count": 50,
+  "logs": [ /* same LogEntry shape as search_logs */ ]
+}
+```
+
+## get_errors
+
+Get a summary of errors and warnings across all hosts in a time window. Groups by hostname and severity level, showing counts.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `from` | string | no | (all time) | Start of time range (ISO 8601) |
+| `to` | string | no | (now) | End of time range (ISO 8601) |
+
+**Response:**
+
+```json
+{
+  "summary": [
+    {"hostname": "tootie", "severity": "err", "count": 42},
+    {"hostname": "dookie", "severity": "warning", "count": 17}
+  ]
+}
+```
+
+## list_hosts
+
+List all hosts that have sent syslog messages.
+
+**Parameters:** none
+
+**Response:**
+
+```json
+{
+  "hosts": [
+    {
+      "hostname": "tootie",
+      "first_seen": "2025-01-01T00:00:00Z",
+      "last_seen": "2025-01-15T14:30:00Z",
+      "log_count": 150000
+    }
+  ]
+}
+```
+
+## correlate_events
+
+Search for related events across multiple hosts within a time window. Useful for debugging cascading failures.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `reference_time` | string | **yes** | -- | Center timestamp (ISO 8601 / RFC 3339) |
+| `window_minutes` | integer | no | 5 | Minutes before and after reference_time (max 60) |
+| `severity_min` | enum | no | `warning` | Minimum severity to include. `warning` returns warning/err/crit/alert/emerg. `debug` returns everything. |
+| `hostname` | string | no | -- | Limit correlation to a specific host |
+| `query` | string | no | -- | FTS5 query to narrow results |
+| `limit` | integer | no | 500 | Max total events (cap: 999) |
+
+**Response:**
+
+```json
+{
+  "reference_time": "2025-01-15T14:30:00Z",
+  "window_minutes": 5,
+  "window_from": "2025-01-15T14:25:00Z",
+  "window_to": "2025-01-15T14:35:00Z",
+  "severity_min": "warning",
+  "total_events": 12,
+  "truncated": false,
+  "hosts_count": 3,
+  "hosts": [
+    {
+      "hostname": "tootie",
+      "event_count": 5,
+      "events": [ /* LogEntry objects */ ]
+    }
+  ]
+}
+```
+
+The limit parameter is capped at 999 (not 1000) because the implementation fetches `limit+1` rows to detect truncation, and the underlying `search_logs` hard-caps at 1000.
+
+## get_stats
+
+Get database statistics including storage health.
+
+**Parameters:** none
+
+**Response:**
+
+```json
+{
+  "total_logs": 500000,
+  "total_hosts": 6,
+  "oldest_log": "2025-01-01T00:00:00Z",
+  "newest_log": "2025-01-15T14:30:00Z",
+  "logical_db_size_mb": "245.67",
+  "physical_db_size_mb": "260.12",
+  "free_disk_mb": "15360.00",
+  "max_db_size_mb": 1024,
+  "min_free_disk_mb": 512,
+  "write_blocked": false,
+  "phantom_fts_rows": 0
+}
+```
+
+Fields:
+- `logical_db_size_mb`: Active data size (page_count - freelist) in MB
+- `physical_db_size_mb`: On-disk file size including WAL and freelist
+- `free_disk_mb`: Available disk space on the database filesystem
+- `write_blocked`: Whether the batch writer is currently blocked due to storage budget exhaustion
+- `phantom_fts_rows`: FTS5 entries for deleted logs (cleaned up by periodic merge)
+
+## syslog_help
+
+Returns markdown documentation for all tools. Call this to discover available operations and parameters.
+
+**Parameters:** none
+
+**Response:** MCP text content block containing the full tool reference as markdown.
+
+## Error responses
+
+Errors follow the MCP content format with `isError: true`:
+
+```json
+{
+  "content": [
+    {"type": "text", "text": "Tool execution failed"}
+  ],
+  "isError": true
+}
+```
+
+JSON-RPC level errors use standard codes:
+- `-32602`: Missing required parameter (e.g., `correlate_events` without `reference_time`)
+- `-32601`: Unknown method
+- `-32001`: Unauthorized (missing or invalid bearer token)
+
+## See also
+
+- [SCHEMA.md](SCHEMA.md) -- JSON Schema definitions for tool inputs
+- [AUTH.md](AUTH.md) -- authentication required before tool calls
+- [ENV.md](ENV.md) -- environment variables affecting tool behavior

--- a/docs/mcp/TRANSPORT.md
+++ b/docs/mcp/TRANSPORT.md
@@ -1,0 +1,128 @@
+# Transport Methods Reference -- syslog-mcp
+
+## Overview
+
+syslog-mcp supports HTTP transport for MCP communication. It does not support stdio transport -- the binary is a long-running syslog receiver that must bind UDP/TCP ports, which is incompatible with stdio's parent-process model.
+
+| Transport | Auth | Use Case | Default |
+| --- | --- | --- | --- |
+| HTTP (Streamable-HTTP) | Bearer token (optional) | Docker, remote servers, reverse proxy | yes |
+| SSE (legacy) | Bearer token (optional) | Older MCP clients | available |
+
+## HTTP transport
+
+The MCP server listens on port 3100 (configurable via `SYSLOG_MCP_PORT`).
+
+```bash
+SYSLOG_MCP_HOST=0.0.0.0
+SYSLOG_MCP_PORT=3100
+SYSLOG_MCP_API_TOKEN=your-token-here   # optional
+```
+
+### Endpoints
+
+| Endpoint | Method | Auth | Description |
+| --- | --- | --- | --- |
+| `/mcp` | POST | yes (when token set) | MCP JSON-RPC 2.0 endpoint |
+| `/sse` | GET | yes (when token set) | Server-Sent Events stream (returns endpoint URL) |
+| `/health` | GET | no | Health check (unauthenticated) |
+
+### Claude Code configuration
+
+`.claude/settings.local.json`:
+
+```json
+{
+  "mcpServers": {
+    "syslog-mcp": {
+      "type": "http",
+      "url": "http://localhost:3100/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      }
+    }
+  }
+}
+```
+
+### Codex CLI configuration
+
+`.codex/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "syslog-mcp": {
+      "type": "http",
+      "url": "http://localhost:3100/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      }
+    }
+  }
+}
+```
+
+### Gemini CLI configuration
+
+`gemini-extension.json`:
+
+```json
+{
+  "mcpServers": {
+    "syslog-mcp": {
+      "type": "http",
+      "url": "http://localhost:3100/mcp",
+      "headers": {
+        "Authorization": "Bearer your-token-here"
+      }
+    }
+  }
+}
+```
+
+## SSE transport (legacy)
+
+The `/sse` endpoint returns a single SSE event with the MCP endpoint URL:
+
+```
+event: endpoint
+data: /mcp
+```
+
+Older MCP clients use this to discover the JSON-RPC endpoint. Newer clients connect directly to `/mcp`.
+
+### SSE proxy requirements
+
+When running behind nginx/SWAG, configure SSE-compatible proxy settings:
+
+```nginx
+proxy_set_header Connection '';
+proxy_http_version 1.1;
+chunked_transfer_encoding off;
+proxy_buffering off;
+proxy_cache off;
+```
+
+Without these settings, nginx buffers SSE events and the connection appears to hang.
+
+## Why no stdio transport
+
+syslog-mcp is a dual-port server:
+- Port 1514: UDP + TCP syslog receiver (must bind to receive logs)
+- Port 3100: HTTP MCP server
+
+stdio transport requires the MCP server to communicate exclusively over stdin/stdout with a parent process. A syslog receiver must bind network ports independently, making stdio unsuitable. Use HTTP transport with Docker or a direct binary for all deployments.
+
+## Port assignment
+
+| Service | Default Port | Env Var |
+| --- | --- | --- |
+| Syslog receiver (UDP + TCP) | 1514 | `SYSLOG_PORT` |
+| MCP HTTP server | 3100 | `SYSLOG_MCP_PORT` |
+
+## See also
+
+- [AUTH.md](AUTH.md) -- bearer token setup for HTTP transport
+- [ENV.md](ENV.md) -- transport-related environment variables
+- [CONNECT.md](CONNECT.md) -- client connection methods

--- a/docs/mcp/WEBMCP.md
+++ b/docs/mcp/WEBMCP.md
@@ -1,0 +1,53 @@
+# Web MCP Integration -- syslog-mcp
+
+Browser-accessible MCP endpoints and CORS configuration.
+
+## CORS policy
+
+syslog-mcp restricts CORS to localhost origins only:
+
+```rust
+CorsLayer::new()
+    .allow_origin([
+        "http://localhost:3100",
+        "http://127.0.0.1:3100",
+    ])
+    .allow_methods([Method::POST, Method::GET])
+    .allow_headers(Any)
+```
+
+## Why restricted CORS
+
+MCP CLI clients (mcporter, curl, Claude Code) are not browser-based and ignore CORS entirely. The restriction only prevents malicious webpages visited by a LAN user from silently exfiltrating the log database via a cross-origin browser `fetch()`.
+
+## Browser access patterns
+
+### Allowed
+
+- Local web dashboards served from `localhost:3100` or `127.0.0.1:3100`
+- Direct navigation to `http://localhost:3100/health`
+
+### Blocked
+
+- Cross-origin requests from other origins (e.g., `http://evil.example.com`)
+- Requests from other local ports (e.g., `http://localhost:8080`)
+
+### Unaffected
+
+- All non-browser clients (curl, mcporter, Claude Code, Codex, httpie)
+- Reverse proxy requests (SWAG/nginx acts as the origin)
+
+## Customizing CORS
+
+CORS origins are currently hardcoded in `src/mcp.rs`. To allow additional origins:
+
+1. Edit the `allow_origin` list in `src/mcp.rs`
+2. Rebuild: `just build`
+
+A future enhancement could make CORS origins configurable via environment variables.
+
+## See also
+
+- [AUTH.md](AUTH.md) -- bearer token authentication (required even with CORS access)
+- [TRANSPORT.md](TRANSPORT.md) -- HTTP transport details
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- network security patterns

--- a/docs/plugin/AGENTS.md
+++ b/docs/plugin/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Definitions -- syslog-mcp
+
+syslog-mcp does not define any agents. The MCP tools are consumed directly by external agents (Claude Code, Codex, Gemini) without an intermediary agent layer.
+
+## Why no agents
+
+syslog-mcp is a data source (log receiver + query interface), not an orchestration layer. Agents that consume syslog data are defined elsewhere:
+- `claude-homelab` homelab-core agents can call syslog-mcp tools for log analysis
+- Custom agents in other repos can connect to syslog-mcp via HTTP transport
+
+## See also
+
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- tools available for agent consumption
+- [../mcp/CONNECT.md](../mcp/CONNECT.md) -- how agents connect to syslog-mcp

--- a/docs/plugin/CHANNELS.md
+++ b/docs/plugin/CHANNELS.md
@@ -1,0 +1,13 @@
+# Channel Integration -- syslog-mcp
+
+syslog-mcp does not use channels. It does not send or receive messages from external messaging platforms.
+
+## Why no channels
+
+syslog-mcp is a passive data store -- it receives syslog messages via UDP/TCP and answers MCP queries. It does not generate outbound notifications or integrate with messaging services.
+
+For alerting on syslog events, use the `gotify-mcp` plugin to send notifications based on `get_errors` or `search_logs` results.
+
+## See also
+
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- tools for querying log data

--- a/docs/plugin/CLAUDE.md
+++ b/docs/plugin/CLAUDE.md
@@ -1,0 +1,18 @@
+# Plugin Surface Documentation -- syslog-mcp
+
+Index for the `plugin/` documentation subdirectory. These docs cover every Claude Code plugin surface area available to syslog-mcp.
+
+## File index
+
+| File | Purpose |
+| --- | --- |
+| `AGENTS.md` | Agent definitions (none -- syslog-mcp has no agents) |
+| `CHANNELS.md` | Channel integration (none) |
+| `COMMANDS.md` | Slash commands (none) |
+| `CONFIG.md` | Plugin settings: userConfig, settings.json |
+| `HOOKS.md` | Lifecycle hooks: sync-env, fix-env-perms, ensure-ignore-files |
+| `MARKETPLACES.md` | Marketplace publishing: Claude, Codex, Gemini, MCP Registry |
+| `OUTPUT-STYLES.md` | Output style definitions (none) |
+| `PLUGINS.md` | Plugin manifest reference: .claude-plugin, .codex-plugin, gemini-extension |
+| `SCHEDULES.md` | Scheduled tasks (none) |
+| `SKILLS.md` | Skill definitions: skills/syslog/SKILL.md |

--- a/docs/plugin/COMMANDS.md
+++ b/docs/plugin/COMMANDS.md
@@ -1,0 +1,12 @@
+# Slash Commands -- syslog-mcp
+
+syslog-mcp does not define any slash commands. Tool access is through the MCP protocol, not slash command invocations.
+
+## Why no commands
+
+The 7 MCP tools (search_logs, tail_logs, get_errors, list_hosts, correlate_events, get_stats, syslog_help) are invoked directly by MCP clients. Slash commands would add an unnecessary abstraction layer for a service that is purely a query interface.
+
+## See also
+
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- MCP tool reference
+- [SKILLS.md](SKILLS.md) -- skill documentation that guides tool usage

--- a/docs/plugin/CONFIG.md
+++ b/docs/plugin/CONFIG.md
@@ -1,0 +1,33 @@
+# Plugin Settings -- syslog-mcp
+
+Plugin configuration, user-facing settings, and environment sync.
+
+## Configuration layers
+
+| Layer | File | Scope |
+| --- | --- | --- |
+| Plugin userConfig | `.claude-plugin/plugin.json` | Per-plugin settings prompted at install |
+| Hook-synced .env | `.env` | Runtime environment variables |
+| config.toml | `config.toml` | Local development overrides |
+| Compiled defaults | `src/config.rs` | Fallback values |
+
+## userConfig fields
+
+When installed as a Claude Code plugin, users are prompted for:
+
+| Field | Type | Sensitive | Description |
+| --- | --- | --- | --- |
+| `SYSLOG_MCP_URL` | string | no | Base URL of the syslog-mcp server |
+| `SYSLOG_MCP_API_TOKEN` | string | yes | Bearer token for MCP authentication |
+
+Sensitive fields are stored encrypted by Claude Code. The `sync-env.sh` hook writes these values to `.env` at session start.
+
+## settings.json
+
+syslog-mcp does not currently ship a `settings.json` for additional plugin settings beyond userConfig.
+
+## See also
+
+- [PLUGINS.md](PLUGINS.md) -- plugin manifest reference
+- [HOOKS.md](HOOKS.md) -- sync-env hook that bridges userConfig to .env
+- [../CONFIG.md](../CONFIG.md) -- full configuration reference

--- a/docs/plugin/HOOKS.md
+++ b/docs/plugin/HOOKS.md
@@ -1,0 +1,49 @@
+# Hook Configuration -- syslog-mcp
+
+Lifecycle hooks that run automatically during Claude Code sessions.
+
+## File location
+
+```
+hooks/
+  hooks.json                    # Hook definitions
+  scripts/
+    sync-env.sh                 # Sync .env.example with server variables
+    fix-env-perms.sh            # Fix .env file permissions
+    ensure-ignore-files.sh      # Verify .gitignore/.dockerignore patterns
+```
+
+## Hook definitions
+
+Hooks are registered in `hooks/hooks.json` and executed by Claude Code at the appropriate lifecycle point.
+
+### sync-env
+
+Ensures `.env.example` documents all environment variables that the server reads. Detects new variables added to `src/config.rs` that are missing from `.env.example`.
+
+### fix-env-perms
+
+Sets `.env` to `chmod 600` (owner read/write only) if the file exists. Prevents accidental world-readable credential files.
+
+### ensure-ignore-files
+
+Verifies that `.gitignore` and `.dockerignore` contain required patterns:
+- `.env`
+- `*.secret`
+- `credentials.*`
+- `data/` (SQLite database files)
+
+## Manual execution
+
+Run hooks outside of Claude Code:
+
+```bash
+bash hooks/scripts/sync-env.sh
+bash hooks/scripts/fix-env-perms.sh
+bash hooks/scripts/ensure-ignore-files.sh
+```
+
+## See also
+
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- security patterns enforced by hooks
+- [../mcp/PRE-COMMIT.md](../mcp/PRE-COMMIT.md) -- pre-commit checks

--- a/docs/plugin/MARKETPLACES.md
+++ b/docs/plugin/MARKETPLACES.md
@@ -1,0 +1,65 @@
+# Marketplace Publishing -- syslog-mcp
+
+Registration and publishing patterns for Claude, Codex, and Gemini marketplaces.
+
+## Marketplace locations
+
+| Marketplace | Manifest | Registry entry |
+| --- | --- | --- |
+| Claude Code | `.claude-plugin/plugin.json` | `claude-homelab` marketplace |
+| Codex | `.codex-plugin/plugin.json` | `claude-homelab` marketplace |
+| Gemini | `gemini-extension.json` | `claude-homelab` marketplace |
+| MCP Registry | `server.json` | `tv.tootie/syslog-mcp` |
+
+## Installation
+
+### Claude Code
+
+```bash
+/plugin marketplace add jmagar/claude-homelab
+/plugin install syslog-mcp @jmagar-claude-homelab
+```
+
+### Codex CLI
+
+```bash
+codex plugin add jmagar/syslog-mcp
+```
+
+### Gemini CLI
+
+Place `gemini-extension.json` in the project root or `~/.gemini/`.
+
+## MCP Registry
+
+syslog-mcp is registered under the `tv.tootie` namespace with DNS verification via the `tootie.tv` domain.
+
+Registry entry in `server.json`:
+
+```json
+{
+  "name": "tv.tootie/syslog-mcp",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.2.6"
+    }
+  ]
+}
+```
+
+## OCI publishing
+
+syslog-mcp uses OCI (Docker) images as the primary distribution package, not PyPI or npm:
+
+| Registry | Image |
+| --- | --- |
+| GHCR | `ghcr.io/jmagar/syslog-mcp:latest` |
+| GHCR (versioned) | `ghcr.io/jmagar/syslog-mcp:v0.3.1` |
+
+Additionally published to crates.io for `cargo install` usage.
+
+## See also
+
+- [PLUGINS.md](PLUGINS.md) -- manifest file details
+- [../mcp/PUBLISH.md](../mcp/PUBLISH.md) -- versioning and release workflow

--- a/docs/plugin/OUTPUT-STYLES.md
+++ b/docs/plugin/OUTPUT-STYLES.md
@@ -1,0 +1,22 @@
+# Output Style Definitions -- syslog-mcp
+
+syslog-mcp does not define custom output styles. Tool responses are returned as JSON text content blocks, which MCP clients render according to their own formatting preferences.
+
+## Response format
+
+All tools return JSON wrapped in MCP text content blocks:
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"count\": 3, \"logs\": [...]}"
+    }
+  ]
+}
+```
+
+## See also
+
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- tool response shapes

--- a/docs/plugin/PLUGINS.md
+++ b/docs/plugin/PLUGINS.md
@@ -1,0 +1,89 @@
+# Plugin Manifest Reference -- syslog-mcp
+
+Structure and conventions for plugin manifest files.
+
+## File locations
+
+| File | Platform | Key fields |
+| --- | --- | --- |
+| `.claude-plugin/plugin.json` | Claude Code | name, version, tools, userConfig |
+| `.codex-plugin/plugin.json` | Codex | name, version, description |
+| `gemini-extension.json` | Gemini | mcpServers configuration |
+| `server.json` | MCP Registry | name, packages, transport |
+
+All manifests must have the same `version` value.
+
+## .claude-plugin/plugin.json
+
+```json
+{
+  "name": "syslog-mcp",
+  "version": "0.2.6",
+  "description": "Syslog management via MCP",
+  "author": "jmagar",
+  "repository": "https://github.com/jmagar/syslog-mcp",
+  "license": "MIT",
+  "keywords": ["syslog", "mcp", "logging", "homelab"],
+  "tools": [
+    "search_logs",
+    "tail_logs",
+    "get_errors",
+    "list_hosts",
+    "correlate_events",
+    "get_stats"
+  ],
+  "transport": "http",
+  "port": 3100,
+  "userConfig": {
+    "SYSLOG_MCP_URL": {
+      "type": "string",
+      "title": "Syslog MCP URL",
+      "description": "Base URL of the syslog-mcp server",
+      "sensitive": false,
+      "default": "https://syslog.tootie.tv/mcp"
+    },
+    "SYSLOG_MCP_API_TOKEN": {
+      "type": "string",
+      "title": "API Token",
+      "description": "Bearer token for authenticating MCP requests",
+      "sensitive": true
+    }
+  }
+}
+```
+
+## .codex-plugin/plugin.json
+
+Contains name, version, description, and Codex-specific metadata.
+
+## gemini-extension.json
+
+Contains `mcpServers` configuration for Gemini CLI discovery.
+
+## server.json
+
+MCP Registry entry with OCI package reference:
+
+```json
+{
+  "name": "tv.tootie/syslog-mcp",
+  "title": "Syslog MCP",
+  "version": "0.2.6",
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.2.6"
+    }
+  ]
+}
+```
+
+## Version synchronization
+
+All manifests must be updated together when bumping versions. Use `just publish [major|minor|patch]` to automate this.
+
+## See also
+
+- [MARKETPLACES.md](MARKETPLACES.md) -- marketplace publishing
+- [CONFIG.md](CONFIG.md) -- plugin settings and userConfig
+- [../mcp/PUBLISH.md](../mcp/PUBLISH.md) -- versioning strategy

--- a/docs/plugin/SCHEDULES.md
+++ b/docs/plugin/SCHEDULES.md
@@ -1,0 +1,18 @@
+# Scheduled Tasks -- syslog-mcp
+
+syslog-mcp does not use Claude Code scheduled tasks (triggers). Internal scheduled operations are handled by the Rust binary itself.
+
+## Internal schedules
+
+The syslog-mcp binary runs two periodic background tasks:
+
+| Task | Interval | Purpose |
+| --- | --- | --- |
+| Retention purge | Hourly | Delete logs older than `retention_days` |
+| Storage budget enforcement | Every `cleanup_interval_secs` (default 60s) | Delete oldest logs when DB size or free disk thresholds are breached |
+
+These tasks run inside the tokio runtime and do not depend on external schedulers or Claude Code triggers.
+
+## See also
+
+- [../CONFIG.md](../CONFIG.md) -- retention and storage budget configuration

--- a/docs/plugin/SKILLS.md
+++ b/docs/plugin/SKILLS.md
@@ -1,0 +1,45 @@
+# Skill Definitions -- syslog-mcp
+
+Patterns for defining skills (domain knowledge modules) within the syslog-mcp plugin.
+
+## Directory structure
+
+```
+skills/
+  syslog/
+    SKILL.md           # Skill definition with tool reference and workflows
+```
+
+## Skill: syslog
+
+The `syslog` skill provides the client-facing documentation for all syslog-mcp tools. It is consumed by Claude Code, Codex, and Gemini to understand available capabilities.
+
+### Contents
+
+`skills/syslog/SKILL.md` includes:
+- Tool inventory (all 7 tools with descriptions)
+- Parameter reference for each tool
+- FTS5 query syntax guide
+- Common workflow patterns (health check, incident investigation, host onboarding)
+- Severity level reference (emerg through debug)
+
+### Validation
+
+```bash
+just validate-skills
+# Checks: skills/syslog/SKILL.md exists
+```
+
+## Adding a skill
+
+syslog-mcp ships a single skill. If additional skills are needed:
+
+1. Create `skills/<name>/SKILL.md`
+2. Add frontmatter with `name` and `description`
+3. Document tools, workflows, and examples
+4. Update `just validate-skills` to check the new path
+
+## See also
+
+- [PLUGINS.md](PLUGINS.md) -- plugin manifest references the skill
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- MCP tool definitions

--- a/docs/repo/CLAUDE.md
+++ b/docs/repo/CLAUDE.md
@@ -1,0 +1,13 @@
+# Repository Documentation -- syslog-mcp
+
+Reference documentation for the repository structure, conventions, and tooling.
+
+## File index
+
+| File | Purpose |
+| --- | --- |
+| `MEMORY.md` | Claude Code memory system for persistent knowledge across sessions |
+| `RECIPES.md` | Justfile recipes reference |
+| `REPO.md` | Repository directory structure |
+| `RULES.md` | Coding rules, git workflow, commit conventions |
+| `SCRIPTS.md` | Scripts reference: maintenance, hooks, testing |

--- a/docs/repo/MEMORY.md
+++ b/docs/repo/MEMORY.md
@@ -1,0 +1,33 @@
+# Memory Files -- syslog-mcp
+
+Claude Code memory system for persistent knowledge across sessions.
+
+## What is memory
+
+Claude Code stores session learnings in memory files under `.claude/projects/`. These persist across conversations and help maintain context about project decisions, patterns, and gotchas.
+
+## Key memory topics for syslog-mcp
+
+| Topic | Key facts |
+| --- | --- |
+| Port choice | 1514 not 514 -- avoids root/CAP_NET_BIND_SERVICE; iptables redirect for devices that cannot be reconfigured |
+| WAL mode | SQLite runs in WAL mode; safe backup requires checkpoint or `.backup` method |
+| FTS5 hyphen | Hyphen is the FTS5 NOT operator; search hyphenated terms with phrase syntax: `"smoke-test"` |
+| Storage budget | Two-threshold hysteresis system; trigger/recovery thresholds prevent oscillation |
+| source_ip trust | hostname field is spoofable via UDP; source_ip is the only network-verified identity |
+| Batch writer | In-memory mpsc channel; no durable WAL; persistent failures cause data loss after 10K buffer |
+| FTS5 phantoms | Deleted logs leave phantom FTS5 entries; cleaned by periodic incremental merge; query path unaffected |
+| CEF parsing | UniFi CEF messages extract hostname from UNIFIdeviceName extension, not syslog header |
+| correlate_events cap | limit parameter capped at 999 (not 1000) due to truncation sentinel needing limit+1 |
+| Docker config | config.toml not in image; defaults + env vars only in containers |
+| OCI publishing | Uses GHCR + crates.io (not PyPI/npm) |
+
+## Memory file location
+
+```
+~/.claude/projects/-home-jmagar-workspace-syslog-mcp/memory/
+```
+
+## See also
+
+- [../../CLAUDE.md](../../CLAUDE.md) -- project instructions (includes gotchas section)

--- a/docs/repo/RECIPES.md
+++ b/docs/repo/RECIPES.md
@@ -1,0 +1,55 @@
+# Justfile Recipes -- syslog-mcp
+
+Run `just --list` to see all available recipes.
+
+## Development
+
+| Recipe | Command | Description |
+| --- | --- | --- |
+| `just dev` | `cargo run` | Start dev server |
+| `just build` | `cargo build` | Debug build |
+| `just release` | `cargo build --release` | Release build |
+| `just check` | `cargo check` | Type check without building |
+| `just lint` | `cargo clippy -- -D warnings` | Lint with zero-warning policy |
+| `just fmt` | `cargo fmt` | Auto-format code |
+| `just test` | `cargo test` | Run test suite |
+| `just clean` | `cargo clean` | Remove build artifacts |
+
+## Docker
+
+| Recipe | Command | Description |
+| --- | --- | --- |
+| `just docker-build` | `docker build -t syslog-mcp .` | Build Docker image |
+| `just up` | `docker compose up -d` | Start containers |
+| `just down` | `docker compose down` | Stop containers |
+| `just restart` | `docker compose restart` | Restart containers |
+| `just logs` | `docker compose logs -f` | Tail container logs |
+
+## Testing
+
+| Recipe | Command | Description |
+| --- | --- | --- |
+| `just health` | `curl -sf http://localhost:3100/health \| jq .` | Health check |
+| `just test-live` | `bash tests/test_live.sh` | Run live smoke tests |
+
+## Setup and security
+
+| Recipe | Command | Description |
+| --- | --- | --- |
+| `just setup` | `cp -n .env.example .env` | Initialize .env file |
+| `just gen-token` | `openssl rand -hex 32` | Generate bearer token |
+| `just check-contract` | `bash scripts/lint-plugin.sh` | Validate plugin manifests |
+| `just validate-skills` | Check SKILL.md exists | Verify skill files |
+
+## Publishing
+
+| Recipe | Command | Description |
+| --- | --- | --- |
+| `just publish [bump]` | Bump, tag, push | Release with major/minor/patch bump |
+
+The `publish` recipe:
+1. Verifies clean `main` branch
+2. Bumps version in Cargo.toml and all plugin manifests
+3. Commits as `release: vX.Y.Z`
+4. Tags `vX.Y.Z`
+5. Pushes to origin (triggers CI/CD publish workflows)

--- a/docs/repo/REPO.md
+++ b/docs/repo/REPO.md
@@ -1,0 +1,98 @@
+# Repository Structure -- syslog-mcp
+
+## Directory tree
+
+```
+syslog-mcp/
+├── .claude-plugin/
+│   └── plugin.json              # Claude Code plugin manifest
+├── .codex-plugin/
+│   └── plugin.json              # Codex plugin manifest
+├── .github/
+│   └── workflows/
+│       ├── ci.yml               # Lint, check, test on push/PR
+│       ├── docker-publish.yml   # Build + push Docker image on tag
+│       ├── publish-crates.yml   # Publish to crates.io on tag
+│       └── codex-plugin-scanner.yml  # Validate Codex manifest on PR
+├── docs/
+│   ├── mcp/                     # MCP server documentation (20 files)
+│   ├── plugin/                  # Plugin surface documentation (11 files)
+│   ├── repo/                    # Repository documentation (6 files)
+│   ├── stack/                   # Technology stack documentation (4 files)
+│   ├── upstream/                # Upstream integration documentation (1 file)
+│   ├── plans/                   # Engineering plans
+│   ├── runbooks/                # Operational runbooks
+│   ├── sessions/                # Development session notes
+│   └── superpowers/             # Superpowers plans
+├── hooks/
+│   ├── hooks.json               # Hook definitions
+│   └── scripts/                 # Hook scripts (sync-env, fix-perms, ignore-files)
+├── scripts/
+│   ├── smoke-test.sh            # Live smoke test (25 assertions)
+│   ├── backup.sh                # WAL-safe SQLite backup
+│   ├── reset-db.sh              # Backup + destructive DB reset
+│   ├── lint-plugin.sh           # Plugin manifest validation
+│   ├── check-docker-security.sh # Docker security checks
+│   ├── check-no-baked-env.sh    # No credentials in Docker image
+│   ├── check-outdated-deps.sh   # Outdated cargo dependencies
+│   └── ensure-ignore-files.sh   # Verify ignore file patterns
+├── skills/
+│   └── syslog/
+│       └── SKILL.md             # Skill definition
+├── src/
+│   ├── main.rs                  # Entry point, task wiring, graceful shutdown
+│   ├── config.rs                # Config: config.toml + env var overlay
+│   ├── db.rs                    # SQLite pool, FTS5, schema, retention, storage budget
+│   ├── syslog.rs                # UDP/TCP listeners, parsing, batch writer
+│   └── mcp.rs                   # Axum HTTP, JSON-RPC, 7 tool handlers
+├── tests/
+│   ├── test_live.sh             # Extended live integration tests
+│   ├── mcporter/
+│   │   └── test-tools.sh        # mcporter-based tool tests
+│   └── TEST_COVERAGE.md         # Test coverage documentation
+├── config/
+│   └── mcporter.json            # mcporter client config
+├── data/                        # SQLite database (gitignored)
+│
+├── .env.example                 # Environment variable template
+├── AGENTS.md                    # Agent declarations (none)
+├── CHANGELOG.md                 # Version history
+├── CLAUDE.md                    # Claude Code project instructions
+├── Cargo.toml                   # Rust package manifest
+├── Cargo.lock                   # Dependency lock file (tracked)
+├── config.toml                  # Local dev config (not in Docker)
+├── docker-compose.yml           # Container orchestration
+├── Dockerfile                   # Multi-stage container build
+├── entrypoint.sh                # Container entrypoint
+├── gemini-extension.json        # Gemini CLI manifest
+├── Justfile                     # Task runner recipes
+├── LICENSE                      # MIT license
+├── README.md                    # User-facing documentation
+├── server.json                  # MCP Registry entry
+└── SETUP.md                     # Per-host syslog forwarding guide
+```
+
+## Source code
+
+| File | Purpose |
+| --- | --- |
+| `src/main.rs` | Entry point: wires config, DB, syslog, MCP; starts background tasks; graceful shutdown |
+| `src/config.rs` | Three-layer config: defaults + config.toml + env vars; validation |
+| `src/db.rs` | SQLite connection pool, schema init, migrations, FTS5, all query functions, storage budget enforcement |
+| `src/syslog.rs` | UDP/TCP listeners, RFC 3164/5424 parsing, UniFi CEF extraction, mpsc batch writer |
+| `src/mcp.rs` | Axum router, bearer auth middleware, JSON-RPC dispatch, 7 tool handlers, health endpoint |
+
+## Plugin surfaces
+
+| Directory | Surface |
+| --- | --- |
+| `skills/` | Skill definition (SKILL.md) |
+| `hooks/` | Lifecycle hooks (sync-env, fix-perms, ignore-files) |
+
+No agents, commands, channels, output styles, or schedules.
+
+## See also
+
+- [RULES.md](RULES.md) -- coding conventions
+- [RECIPES.md](RECIPES.md) -- Justfile recipes
+- [SCRIPTS.md](SCRIPTS.md) -- scripts reference

--- a/docs/repo/RULES.md
+++ b/docs/repo/RULES.md
@@ -1,0 +1,77 @@
+# Coding Rules -- syslog-mcp
+
+Standards and conventions enforced across the repository.
+
+## Git workflow
+
+- `main` branch: production-ready code
+- Feature branches for new features and bug fixes
+- Pull requests required before merge
+- Conventional commit prefixes required
+
+## Commit conventions
+
+```
+<type>(<scope>): <description>
+```
+
+| Type | Purpose |
+| --- | --- |
+| `feat` | New feature (minor bump) |
+| `feat!` | Breaking change (major bump) |
+| `fix` | Bug fix (patch bump) |
+| `docs` | Documentation (patch bump) |
+| `refactor` | Code refactoring (patch bump) |
+| `test` | Test changes (patch bump) |
+| `chore` | Maintenance (patch bump) |
+
+Examples:
+```
+feat(tools): add search filter by facility
+fix(db): handle WAL checkpoint timeout
+docs(readme): update tool parameter table
+refactor(syslog): extract CEF parser to function
+```
+
+## Version bumping
+
+Every feature branch push must bump the version in all version-bearing files:
+- `Cargo.toml`
+- `.claude-plugin/plugin.json`
+- `.codex-plugin/plugin.json`
+- `gemini-extension.json`
+- `server.json`
+- `CHANGELOG.md`
+
+All files must have the same version. Never bump only one file.
+
+## Rust code style
+
+- `cargo clippy -- -D warnings` must pass (zero warnings)
+- `cargo fmt` must not produce changes
+- `set -euo pipefail` in all bash scripts
+- Quote all shell variables: `"$var"`
+- Use `anyhow::Result` for error handling
+- Use `tracing` macros for logging (not `println!`)
+- Parameterize all SQL queries (no string interpolation)
+- Use `Arc<DbPool>` for shared database access
+- Run blocking database operations via `tokio::task::spawn_blocking`
+
+## Never commit
+
+- `.env` files (gitignored)
+- Credentials or API keys
+- SQLite database files (`data/`)
+- Build artifacts (`target/`)
+- Temporary/debug files
+
+## Dependency management
+
+- `Cargo.lock` is tracked (binary crate -- reproducible builds)
+- Pin major versions in `Cargo.toml` (e.g., `tokio = { version = "1", ... }`)
+- Run `scripts/check-outdated-deps.sh` periodically
+
+## See also
+
+- [../mcp/PUBLISH.md](../mcp/PUBLISH.md) -- version bumping and release workflow
+- [RECIPES.md](RECIPES.md) -- Justfile recipes for lint, fmt, test

--- a/docs/repo/SCRIPTS.md
+++ b/docs/repo/SCRIPTS.md
@@ -1,0 +1,47 @@
+# Scripts Reference -- syslog-mcp
+
+Scripts used for maintenance, hooks, and testing.
+
+## Maintenance scripts (`scripts/`)
+
+| Script | Purpose | Usage |
+| --- | --- | --- |
+| `smoke-test.sh` | Live smoke test with 25 assertions across all 7 MCP tools | `bash scripts/smoke-test.sh` |
+| `backup.sh` | WAL-safe SQLite backup using PRAGMA wal_checkpoint + .backup | `bash scripts/backup.sh` |
+| `reset-db.sh` | Backup first, then destructive DB reset (stop server first) | `bash scripts/reset-db.sh` |
+| `lint-plugin.sh` | Validate plugin manifests, tool schemas, contract compliance | `just check-contract` |
+| `check-docker-security.sh` | Verify Docker security: non-root user, no baked secrets | `bash scripts/check-docker-security.sh` |
+| `check-no-baked-env.sh` | Verify no credentials baked into Docker image | `bash scripts/check-no-baked-env.sh` |
+| `check-outdated-deps.sh` | Check for outdated cargo dependencies | `bash scripts/check-outdated-deps.sh` |
+| `ensure-ignore-files.sh` | Verify .gitignore and .dockerignore patterns | `bash scripts/ensure-ignore-files.sh` |
+
+## Hook scripts (`hooks/scripts/`)
+
+| Script | Purpose | Trigger |
+| --- | --- | --- |
+| `sync-env.sh` | Sync .env.example with server variables | Claude Code lifecycle |
+| `fix-env-perms.sh` | Set .env to chmod 600 | Claude Code lifecycle |
+| `ensure-ignore-files.sh` | Verify ignore file patterns | Claude Code lifecycle |
+
+## Test scripts (`tests/`)
+
+| Script | Purpose | Usage |
+| --- | --- | --- |
+| `test_live.sh` | Extended live integration tests | `just test-live` |
+| `mcporter/test-tools.sh` | mcporter-based tool tests | `bash tests/mcporter/test-tools.sh` |
+
+## Script conventions
+
+All bash scripts follow these patterns:
+- `#!/bin/bash` shebang
+- `set -euo pipefail` strict mode
+- Quoted variables: `"$var"`
+- Non-zero exit code on failure
+- Human-readable output with PASS/FAIL indicators
+- JSON output where appropriate (piped through `jq`)
+
+## See also
+
+- [RECIPES.md](RECIPES.md) -- Justfile recipes that invoke these scripts
+- [../mcp/TESTS.md](../mcp/TESTS.md) -- testing guide
+- [../mcp/MCPORTER.md](../mcp/MCPORTER.md) -- mcporter smoke testing

--- a/docs/stack/ARCH.md
+++ b/docs/stack/ARCH.md
@@ -1,0 +1,152 @@
+# Architecture Overview -- syslog-mcp
+
+## Dual-port design
+
+syslog-mcp is a dual-port server combining a syslog receiver and an MCP query interface:
+
+```
+                    ┌──────────────────────────────────────┐
+  rsyslog/syslog-ng ──▶  UDP :1514 ──┐                     │
+  network devices   ──▶  TCP :1514 ──┤                     │
+                    │               ▼                     │
+                    │     parse_syslog()                  │
+                    │        │                            │
+                    │        ▼                            │
+                    │     mpsc channel (10K buffer)       │
+                    │        │                            │
+                    │        ▼                            │
+                    │     batch_writer()                  │
+                    │        │                            │
+                    │        ▼                            │
+                    │     SQLite + FTS5 (WAL mode)        │
+                    │        ▲                            │
+                    │        │                            │
+  MCP clients ◀────────▶ HTTP :3100/mcp (JSON-RPC 2.0)   │
+                    │                                    │
+                    │     Background tasks:               │
+                    │       - Hourly retention purge      │
+                    │       - Storage budget enforcement   │
+                    └──────────────────────────────────────┘
+```
+
+## Request flow (MCP)
+
+```
+MCP Client (Claude Code / Codex / Gemini / curl)
+    │
+    ▼
+HTTP Transport (axum, port 3100)
+    │
+    ▼
+Auth Middleware (bearer token via subtle::ConstantTimeEq)
+    │
+    ▼
+JSON-RPC Dispatch (match on method: initialize, tools/list, tools/call)
+    │
+    ▼
+Tool Handler (validate input, build SearchParams)
+    │
+    ▼
+run_db() — spawn_blocking to avoid blocking tokio
+    │
+    ▼
+SQLite (r2d2 pool, rusqlite, FTS5 for full-text search)
+    │
+    ▼
+JSON Response (serde_json serialization)
+```
+
+## Data flow (syslog ingestion)
+
+```
+UDP/TCP packet arrives
+    │
+    ▼
+parse_syslog() — syslog_loose parser, RFC 3164/5424
+    │              extracts: timestamp, hostname, facility, severity, app_name, message
+    │              captures: source_ip from network address
+    │
+    ▼
+mpsc::channel — 10K entry buffer, applies backpressure when full
+    │
+    ▼
+batch_writer() — collects entries, flushes on batch_size or flush_interval
+    │              checks storage budget state before writing
+    │
+    ▼
+insert_logs_batch() — SQLite transaction with retry (25ms, 100ms, 250ms)
+    │                   FTS5 INSERT trigger fires per row
+    │
+    ▼
+hosts table — UPSERT updates last_seen and log_count
+```
+
+## Module structure
+
+| Module | File | Responsibility |
+| --- | --- | --- |
+| Entry point | `main.rs` | Tokio runtime, config load, DB init, task spawning, graceful shutdown |
+| Config | `config.rs` | Three-layer config (defaults + TOML + env vars), validation |
+| Database | `db.rs` | Connection pool, schema, migrations, all SQL queries, storage budget |
+| Syslog | `syslog.rs` | UDP/TCP listeners, message parsing, batch writer, backpressure |
+| MCP | `mcp.rs` | Axum router, auth middleware, JSON-RPC, tool dispatch, SSE |
+
+## SQLite schema
+
+```sql
+-- Main log table
+CREATE TABLE logs (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp   TEXT NOT NULL,
+    hostname    TEXT NOT NULL,
+    facility    TEXT,
+    severity    TEXT NOT NULL,
+    app_name    TEXT,
+    process_id  TEXT,
+    message     TEXT NOT NULL,
+    raw         TEXT NOT NULL,
+    received_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    source_ip   TEXT NOT NULL DEFAULT ''
+);
+
+-- FTS5 full-text index
+CREATE VIRTUAL TABLE logs_fts USING fts5(
+    message, content='logs', content_rowid='id', tokenize='porter unicode61'
+);
+
+-- Host registry
+CREATE TABLE hosts (
+    hostname    TEXT PRIMARY KEY,
+    first_seen  TEXT NOT NULL,
+    last_seen   TEXT NOT NULL,
+    log_count   INTEGER NOT NULL DEFAULT 0
+);
+
+-- Indexes
+CREATE INDEX idx_logs_timestamp ON logs(timestamp);
+CREATE INDEX idx_logs_hostname ON logs(hostname);
+CREATE INDEX idx_logs_severity ON logs(severity);
+CREATE INDEX idx_logs_app_name ON logs(app_name);
+CREATE INDEX idx_logs_host_time ON logs(hostname, timestamp);
+CREATE INDEX idx_logs_sev_time ON logs(severity, timestamp);
+CREATE INDEX idx_logs_received_at ON logs(received_at);
+CREATE INDEX idx_logs_hostname_received_at ON logs(hostname, received_at);
+```
+
+## Error handling
+
+| Source | Error | Response |
+| --- | --- | --- |
+| Auth middleware | Missing/invalid token | HTTP 401, JSON-RPC error -32001 |
+| Tool dispatch | Unknown tool name | JSON-RPC error -32601 |
+| Tool handler | Missing required param | JSON-RPC error -32602 |
+| Database | Query error | MCP content with `isError: true` |
+| Syslog | Oversized message | Dropped with WARN log |
+| Syslog | Write channel full | Backpressure applied |
+| Storage | Budget exceeded | Batch writer blocked until recovery |
+
+## Cross-references
+
+- [TECH.md](TECH.md) -- technology stack choices
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- MCP tool definitions
+- [../upstream/CLAUDE.md](../upstream/CLAUDE.md) -- upstream integration (self-contained)

--- a/docs/stack/CLAUDE.md
+++ b/docs/stack/CLAUDE.md
@@ -1,0 +1,11 @@
+# Technology Stack Documentation -- syslog-mcp
+
+Reference documentation for the technology choices, architecture, and prerequisites.
+
+## File index
+
+| File | Purpose |
+| --- | --- |
+| `ARCH.md` | Architecture overview: dual-port design, data flow, module structure |
+| `PRE-REQS.md` | Prerequisites: Rust toolchain, Docker, system dependencies |
+| `TECH.md` | Technology choices: crate selection rationale, SQLite vs alternatives |

--- a/docs/stack/PRE-REQS.md
+++ b/docs/stack/PRE-REQS.md
@@ -1,0 +1,53 @@
+# Prerequisites -- syslog-mcp
+
+Required tools and versions before developing or deploying.
+
+## Development
+
+| Tool | Version | Purpose | Install |
+| --- | --- | --- | --- |
+| Rust | 1.86+ | Compiler toolchain | `rustup default stable` |
+| cargo | (bundled) | Build system, package manager | (included with Rust) |
+| just | latest | Task runner | `cargo install just` |
+| Docker | 24+ | Container deployment | [docs.docker.com](https://docs.docker.com/get-docker/) |
+| Docker Compose | v2+ | Orchestration | (included with Docker Desktop) |
+| curl | any | Health checks, API testing | System package |
+| jq | any | JSON formatting (optional) | System package |
+| openssl | any | Token generation | System package |
+
+## Runtime (Docker)
+
+The Docker image includes all runtime dependencies. No additional tools needed on the host beyond Docker.
+
+## Runtime (bare metal)
+
+| Dependency | Purpose |
+| --- | --- |
+| glibc | Standard C library (Debian bookworm-slim compatible) |
+| ca-certificates | TLS certificate bundle |
+| curl | Container health check |
+
+SQLite is statically linked via `rusqlite` with the `bundled` feature -- no system SQLite required.
+
+## Optional tools
+
+| Tool | Purpose |
+| --- | --- |
+| mcporter | MCP client for smoke testing |
+| rsyslog | Syslog forwarder for sending test messages |
+| logger | CLI tool for sending test syslog messages |
+| sqlite3 | Direct database inspection |
+
+## System requirements
+
+| Resource | Minimum | Recommended |
+| --- | --- | --- |
+| RAM | 64 MB | 256 MB |
+| Disk | 100 MB + DB size | 2 GB |
+| CPU | 1 core | 2 cores |
+| Network | UDP/TCP port 1514, TCP port 3100 | Same |
+
+## See also
+
+- [../SETUP.md](../SETUP.md) -- full setup guide
+- [TECH.md](TECH.md) -- technology choices

--- a/docs/stack/TECH.md
+++ b/docs/stack/TECH.md
@@ -1,0 +1,97 @@
+# Technology Choices -- syslog-mcp
+
+Technology stack reference and rationale.
+
+## Language: Rust
+
+Rust was chosen for syslog-mcp because:
+- High-throughput syslog ingestion requires low-latency, zero-copy message handling
+- Memory safety without garbage collection prevents the pauses that would cause UDP packet loss
+- Single static binary simplifies Docker image and deployment
+- `rusqlite` with bundled SQLite avoids system library version issues
+
+## Async runtime: tokio
+
+Full-featured async runtime for concurrent UDP/TCP listeners, batch writer, and HTTP server. The `full` feature set enables:
+- `tokio::net` -- UDP/TCP socket binding
+- `tokio::sync` -- mpsc channels, semaphores
+- `tokio::signal` -- graceful shutdown
+- `tokio::time` -- batch flush intervals, idle timeouts
+- `tokio::task::spawn_blocking` -- offload synchronous SQLite calls
+
+## HTTP framework: axum
+
+Minimal, composable HTTP framework built on tokio and tower:
+- Native tower middleware support (CORS, tracing)
+- Type-safe state extraction
+- Composable router with method routing
+- SSE support via `axum::response::sse`
+
+## Database: SQLite (rusqlite + r2d2)
+
+SQLite was chosen over PostgreSQL/MySQL because:
+- Zero-dependency deployment (bundled, no external database server)
+- WAL mode enables concurrent reads during writes
+- FTS5 provides full-text search with porter stemming
+- Single-file database simplifies backup and migration
+- Sufficient throughput for homelab log volumes (thousands of messages/second)
+
+| Crate | Purpose |
+| --- | --- |
+| `rusqlite` | SQLite driver with bundled SQLite and FTS5 vtab support |
+| `r2d2` | Generic connection pooling |
+| `r2d2_sqlite` | SQLite adapter for r2d2 |
+
+## Syslog parsing: syslog_loose
+
+Lenient syslog parser that handles both RFC 3164 (BSD) and RFC 5424 (IETF) formats. The "loose" parsing is critical for homelab environments where devices send non-compliant syslog messages (UniFi CEF, ATT router logs, etc.).
+
+## Serialization: serde + serde_json + toml
+
+- `serde` -- derive macros for all data structures
+- `serde_json` -- JSON-RPC request/response, MCP protocol, tool responses
+- `toml` -- config.toml parsing
+
+## Time: chrono
+
+RFC 3339 timestamp parsing and formatting. Used for:
+- Parsing syslog timestamps
+- Time range filtering in search queries
+- Correlation window calculation
+
+## Auth: subtle
+
+Constant-time byte comparison for bearer token validation. Prevents timing side-channel attacks.
+
+## Filesystem: rustix
+
+Low-level filesystem operations for free disk space measurement (`statvfs`). Used by the storage budget enforcement system.
+
+## Logging: tracing + tracing-subscriber
+
+Structured, span-based logging with environment filter support:
+- `RUST_LOG` directive parsing
+- Target-based filtering (per-module verbosity)
+- Human-readable console output with timestamps
+
+## Error handling: anyhow
+
+Flexible error type for application code. `anyhow::Result` is used throughout for:
+- Config loading errors
+- Database errors
+- Tool execution errors
+- Propagation with `?` operator
+
+## Development dependencies
+
+| Crate | Purpose |
+| --- | --- |
+| `tempfile` | Temporary directories for isolated test databases |
+| `serial_test` | Serialize tests that mutate environment variables |
+| `tower` | HTTP testing utilities for axum handler tests |
+
+## See also
+
+- [ARCH.md](ARCH.md) -- architecture overview
+- [PRE-REQS.md](PRE-REQS.md) -- tool requirements
+- [../INVENTORY.md](../INVENTORY.md) -- complete dependency listing

--- a/docs/upstream/CLAUDE.md
+++ b/docs/upstream/CLAUDE.md
@@ -1,0 +1,56 @@
+# Upstream Service Integration -- syslog-mcp
+
+## Self-contained architecture
+
+syslog-mcp has no upstream API dependency. Unlike other MCP servers that wrap an external service (Plex, Overseerr, Gotify), syslog-mcp **is** the service. It receives syslog messages directly via UDP/TCP, stores them in SQLite, and exposes them through MCP tools.
+
+```
+                No upstream API
+                      ↓
+  Syslog sources ──▶ syslog-mcp ──▶ MCP clients
+  (rsyslog, UniFi,    (receiver +     (Claude Code,
+   ATT router, etc.)   query server)   Codex, Gemini)
+```
+
+## Inbound data sources
+
+Instead of an upstream API, syslog-mcp receives data from syslog sources:
+
+| Source | Protocol | Configuration |
+| --- | --- | --- |
+| Linux hosts (rsyslog) | TCP or UDP | `/etc/rsyslog.d/99-remote.conf` |
+| WSL hosts | TCP or UDP | rsyslog with Tailscale IP |
+| UniFi Cloud Gateway | UDP | Settings > System > Remote Syslog |
+| ATT BGW-320 Router | UDP | Diagnostics > Syslog > Remote Syslog |
+
+See [SETUP.md](../../SETUP.md) for per-host configuration.
+
+## Syslog protocol support
+
+| Standard | Support |
+| --- | --- |
+| RFC 3164 (BSD syslog) | Full -- parsed by `syslog_loose` |
+| RFC 5424 (IETF syslog) | Full -- parsed by `syslog_loose` |
+| UniFi CEF (Common Event Format) | Partial -- hostname extracted from UNIFIdeviceName extension |
+
+The `syslog_loose` crate performs lenient parsing that tolerates non-compliant messages common in homelab environments.
+
+## Trust boundary
+
+Syslog content is untrusted user-controlled data:
+- `hostname`: claimed by the sender, spoofable via UDP
+- `message`, `app_name`: arbitrary text from the sending device
+- `source_ip`: actual network sender address (the only trustworthy identity)
+
+All query parameters are SQL-parameterized. FTS5 queries use their own DSL (not SQL), preventing injection.
+
+## No outbound credentials
+
+syslog-mcp reads no `_URL`, `_API_KEY`, or similar environment variables for upstream connectivity. The only credential is the optional `SYSLOG_MCP_API_TOKEN` for inbound MCP authentication.
+
+## Cross-references
+
+- [../mcp/ENV.md](../mcp/ENV.md) -- environment variables (no upstream credentials)
+- [../stack/ARCH.md](../stack/ARCH.md) -- architecture overview
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- MCP tools that query the stored data
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- input handling and trust boundaries

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.2.6",
+  "version": "0.3.2",
   "description": "Homelab syslog receiver and MCP server for searching, tailing, and correlating logs across hosts.",
   "mcpServers": {
     "syslog-mcp": {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+const MAX_CLEANUP_CHUNK_SIZE: usize = 1_000_000;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
     pub syslog: SyslogConfig,
@@ -378,10 +380,10 @@ fn validate_storage_config(storage: &StorageConfig) -> anyhow::Result<()> {
         ));
     }
 
-    if storage.cleanup_chunk_size > i64::MAX as usize {
+    if storage.cleanup_chunk_size > MAX_CLEANUP_CHUNK_SIZE {
         return Err(anyhow::anyhow!(
-            "cleanup_chunk_size must be <= {}",
-            i64::MAX
+            "cleanup_chunk_size must be <= {} (larger values hold the write lock too long)",
+            MAX_CLEANUP_CHUNK_SIZE
         ));
     }
 
@@ -552,30 +554,26 @@ mod tests {
 
     #[test]
     #[serial]
-    fn rejects_cleanup_chunk_size_overflow() {
-        // On 64-bit: i64::MAX+1 fits in usize, so validate_storage_config fires.
-        // On 32-bit: the parse itself fails (value exceeds u32::MAX). Either way Err.
-        let overflow = (i64::MAX as u128 + 1).to_string();
-        std::env::set_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE", &overflow);
+    fn rejects_cleanup_chunk_size_over_max() {
+        std::env::set_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE", "1000001");
         let result = Config::load();
         std::env::remove_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE");
 
-        let err = result.expect_err("Config::load() should reject oversized cleanup_chunk_size");
+        let err = result.expect_err("Config::load() should reject cleanup_chunk_size > 1_000_000");
         assert!(
-            err.to_string().contains("cleanup_chunk_size")
-                || err.to_string().contains("SYSLOG_MCP_CLEANUP_CHUNK_SIZE"),
+            err.to_string().contains("cleanup_chunk_size"),
             "Expected error referencing cleanup_chunk_size, got: {err}"
         );
     }
 
     #[test]
     #[serial]
-    fn accepts_cleanup_chunk_size_at_i64_max() {
-        std::env::set_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE", &i64::MAX.to_string());
+    fn accepts_cleanup_chunk_size_at_max() {
+        std::env::set_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE", "1000000");
         let result = Config::load();
         std::env::remove_var("SYSLOG_MCP_CLEANUP_CHUNK_SIZE");
 
-        let cfg = result.expect("cleanup_chunk_size == i64::MAX should be accepted");
-        assert_eq!(cfg.storage.cleanup_chunk_size, i64::MAX as usize);
+        let cfg = result.expect("cleanup_chunk_size == 1_000_000 should be accepted");
+        assert_eq!(cfg.storage.cleanup_chunk_size, 1_000_000);
     }
 }

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -1,0 +1,631 @@
+# TEST_COVERAGE.md — `tests/test_live.sh`
+
+## 1. Overview
+
+`tests/test_live.sh` is the canonical integration test suite for the **syslog-mcp** MCP server. It exercises the server end-to-end over HTTP using real JSON-RPC requests, not unit stubs or mocks.
+
+**Service under test:** syslog-mcp — a read-only MCP server that exposes syslog data from a SQLite backing store via the Model Context Protocol (MCP) over HTTP.
+
+**MCP server exercised:** The HTTP transport endpoint at `POST /mcp`, plus the unauthenticated health check at `GET /health`. All MCP calls use JSON-RPC 2.0.
+
+**What it does NOT test:**
+- Syslog ingestion (UDP/TCP listeners)
+- Write operations of any kind (there are none in the tool surface, but the principle applies)
+- Stdio transport (see section 9)
+- Long-running streaming / SSE events beyond accept header negotiation
+
+---
+
+## 2. How to Run
+
+### Prerequisites
+
+| Tool    | Required for         |
+|---------|---------------------|
+| `curl`  | All modes            |
+| `jq`    | All modes            |
+| `docker`| `docker` / `all` mode only |
+
+The script checks all prerequisites before running and exits with code `2` if any are missing.
+
+### Modes
+
+#### `docker` / `all` (default)
+
+Builds the Docker image from the project root, starts a container with a tmpfs-backed SQLite store, runs all four test phases, then tears down the container.
+
+```bash
+# Minimal — no auth
+bash tests/test_live.sh
+
+# With bearer token
+SYSLOG_MCP_API_TOKEN=ci-integration-token bash tests/test_live.sh
+
+# Explicit mode
+bash tests/test_live.sh --mode docker
+
+# Alias (identical to docker)
+bash tests/test_live.sh --mode all
+```
+
+Required env vars: none (token is optional).
+Optional env vars:
+- `SYSLOG_MCP_API_TOKEN` — bearer token; if set, auth tests execute and the token is passed to the container.
+- `PORT` — overrides the default port `3100` used as fallback when port mapping detection fails.
+
+#### `http`
+
+Tests against a server that is already running. Does not build or manage Docker.
+
+```bash
+# Local server on default port
+bash tests/test_live.sh --mode http
+
+# Remote server
+bash tests/test_live.sh --mode http --url http://192.168.1.10:3100
+
+# Remote server with auth
+bash tests/test_live.sh --mode http --url http://192.168.1.10:3100 \
+  --token my-secret-token
+```
+
+Required env vars: none.
+`--url` defaults to `http://localhost:${PORT}` (where `PORT` defaults to `3100`).
+
+#### `stdio` (not implemented)
+
+The script has no `stdio` mode. See section 9 for the reasoning.
+
+### Additional Flags
+
+| Flag        | Effect |
+|-------------|--------|
+| `--verbose` | Prints raw JSON responses for every tool call to stdout |
+| `--help`    | Prints the usage block from the script header and exits `0` |
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | All tests passed (SKIPs are not failures) |
+| `1`  | One or more tests failed |
+| `2`  | Prerequisite missing, Docker build/start failed, or unknown mode |
+
+---
+
+## 3. Test Phases
+
+The script always runs exactly four phases in this order:
+
+```
+Phase 1 — Health
+Phase 2 — Auth
+Phase 3 — Protocol
+Phase 4 — Tool calls
+```
+
+All four phases run regardless of earlier phase outcomes. A failure in Phase 1 does not abort Phase 2–4.
+
+---
+
+## 4. Every Test — Detailed Assertions
+
+### Phase 1 — Health (`phase_health`)
+
+**Purpose:** Verify the `/health` HTTP endpoint is reachable and reports the server as healthy. This is the baseline liveness check.
+
+**HTTP request:**
+```
+GET <BASE_URL>/health
+Headers: Accept: application/json, text/event-stream
+Timeout: 10 seconds
+```
+
+| Test label | jq expression | Expected value | PASS condition | FAIL condition |
+|---|---|---|---|---|
+| `GET /health returns 200` | n/a — uses curl exit code | n/a | curl exits 0 and response is non-empty | curl fails or returns empty body |
+| `GET /health — status is ok` | `.status` | `"ok"` | `.status` equals the string `"ok"` | `.status` is missing, null, or any other string |
+
+**Note:** If curl itself fails (non-2xx HTTP or network error), the first test records a FAIL and the function returns early without running the second assertion.
+
+---
+
+### Phase 2 — Auth (`phase_auth`)
+
+**Purpose:** Verify that when a bearer token is configured, the `/mcp` endpoint enforces authentication — rejecting requests with no token and requests with an incorrect token, both with HTTP 401.
+
+**Conditional execution:** Both auth tests are **SKIPPED** (not failed) when `SYSLOG_MCP_API_TOKEN` is not set. The skip reason is `"SYSLOG_MCP_API_TOKEN not set — auth assumed disabled"`. This reflects that the server supports running in no-auth mode.
+
+#### Test: `auth: unauthenticated /mcp returns 401`
+
+**HTTP request (no auth header):**
+```
+POST <BASE_URL>/mcp
+Content-Type: application/json
+Body: {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+Timeout: 10 seconds
+```
+
+| Outcome | Condition |
+|---------|-----------|
+| PASS | HTTP status code is exactly `401` |
+| FAIL | HTTP status code is anything other than `401` (actual code is reported) |
+
+#### Test: `auth: bad token returns 401`
+
+**HTTP request (wrong token):**
+```
+POST <BASE_URL>/mcp
+Authorization: Bearer intentionally-wrong-token-for-testing
+Content-Type: application/json
+Body: {"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
+Timeout: 10 seconds
+```
+
+| Outcome | Condition |
+|---------|-----------|
+| PASS | HTTP status code is exactly `401` |
+| FAIL | HTTP status code is anything other than `401` (actual code is reported) |
+
+**Note:** The literal string `intentionally-wrong-token-for-testing` is the hardcoded wrong token. The test does NOT verify that a valid token returns 200 — that is implicitly proved by the subsequent phases succeeding when `AUTH_ARGS` contains the correct token.
+
+---
+
+### Phase 3 — Protocol (`phase_protocol`)
+
+**Purpose:** Verify that the MCP protocol handshake works — `initialize` returns valid server metadata and `tools/list` returns the expected set of seven tools.
+
+#### 3a. `initialize`
+
+**JSON-RPC request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {},
+    "clientInfo": {"name": "test_live.sh", "version": "1.0.0"}
+  }
+}
+```
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `initialize — protocolVersion present` | `.result.protocolVersion` | Field is non-null, non-empty, non-false |
+| `initialize — serverInfo.name present` | `.result.serverInfo.name` | Field is non-null, non-empty, non-false |
+| `initialize — capabilities.tools present` | `.result.capabilities.tools` | Field is non-null, non-empty, non-false |
+
+All three use the no-expected-value form of `assert_jq` — they check presence and non-nullness only, not specific values.
+
+#### 3b. `tools/list`
+
+**JSON-RPC request:**
+```json
+{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+```
+
+| Test label | Check | PASS condition |
+|---|---|---|
+| `tools/list — returns N tools (expected 7)` | `.result.tools \| length` | Count is `>= 7` |
+
+Then for each of the 7 expected tool names, one test per tool:
+
+| Test label | jq expression | Expected value |
+|---|---|---|
+| `tools/list — tool 'search_logs' present` | `.result.tools[] \| select(.name == "search_logs") \| .name` | `"search_logs"` |
+| `tools/list — tool 'tail_logs' present` | `.result.tools[] \| select(.name == "tail_logs") \| .name` | `"tail_logs"` |
+| `tools/list — tool 'get_errors' present` | `.result.tools[] \| select(.name == "get_errors") \| .name` | `"get_errors"` |
+| `tools/list — tool 'list_hosts' present` | `.result.tools[] \| select(.name == "list_hosts") \| .name` | `"list_hosts"` |
+| `tools/list — tool 'correlate_events' present` | `.result.tools[] \| select(.name == "correlate_events") \| .name` | `"correlate_events"` |
+| `tools/list — tool 'get_stats' present` | `.result.tools[] \| select(.name == "get_stats") \| .name` | `"get_stats"` |
+| `tools/list — tool 'syslog_help' present` | `.result.tools[] \| select(.name == "syslog_help") \| .name` | `"syslog_help"` |
+
+A tool is considered present only if its `.name` field exactly matches the expected string.
+
+---
+
+### Phase 4 — Tool Calls (`phase_tools`)
+
+**Transport mechanics:** Every tool call uses `call_tool`, which:
+1. Builds a JSON-RPC `tools/call` request body using `jq -nc`.
+2. POSTs to `<BASE_URL>/mcp` with a monotonically incrementing `id`.
+3. Extracts `.result.content[0].text` from the raw JSON-RPC response.
+4. Parses that text value as JSON (the inner payload), and returns it.
+
+All subsequent assertions operate on this inner JSON payload, not the raw JSON-RPC envelope.
+
+---
+
+#### Tool: `syslog_help`
+
+**Arguments:** `{}` (no arguments)
+
+**Purpose:** Confirm the help tool returns a non-empty help string containing the word "syslog".
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `syslog_help — help field present` | `.help` | Non-null, non-empty, non-false |
+| `syslog_help — help text is non-empty` | `.help \| length > 0` | Evaluates to `true` |
+| `syslog_help — help text contains 'syslog'` | `.help \| ascii_downcase \| contains("syslog")` | Evaluates to `true` |
+
+The third assertion is case-insensitive via `ascii_downcase` — the word "syslog" or "Syslog" or "SYSLOG" all pass.
+
+---
+
+#### Tool: `get_stats`
+
+**Arguments:** `{}` (no arguments)
+
+**Purpose:** Confirm the stats tool returns a valid statistics object with all expected numeric fields.
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `get_stats — total_logs field present` | `.total_logs != null` | Evaluates to `true` |
+| `get_stats — total_hosts field present` | `.total_hosts != null` | Evaluates to `true` |
+| `get_stats — logical_db_size_mb present` | `.logical_db_size_mb` | Non-null, non-empty |
+| `get_stats — physical_db_size_mb present` | `.physical_db_size_mb` | Non-null, non-empty |
+| `get_stats — write_blocked field present` | `.write_blocked != null` | Evaluates to `true` |
+| `get_stats — total_logs is a number >= 0` | `.total_logs >= 0` | Evaluates to `true` |
+| `get_stats — total_hosts is a number >= 0` | `.total_hosts >= 0` | Evaluates to `true` |
+
+The `!= null` form is used for `total_logs`, `total_hosts`, and `write_blocked` so that a value of `0` or `false` still passes — these are valid production values. The `>= 0` checks additionally assert numeric type.
+
+---
+
+#### Tool: `list_hosts`
+
+**Arguments:** `{}` (no arguments)
+
+**Purpose:** Confirm the tool returns a hosts array. If hosts exist, validate each entry's structure.
+
+**Unconditional tests:**
+
+| Test label | jq expression | Expected value |
+|---|---|---|
+| `list_hosts — hosts field is an array` | `.hosts \| type` | `"array"` |
+
+**Conditional tests (only run when `.hosts \| length > 0`):**
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `list_hosts — entry has hostname field` | `.hosts[0].hostname` | Non-null, non-empty |
+| `list_hosts — entry has log_count field` | `.hosts[0].log_count != null` | Evaluates to `true` |
+| `list_hosts — entry has first_seen field` | `.hosts[0].first_seen` | Non-null, non-empty |
+| `list_hosts — entry has last_seen field` | `.hosts[0].last_seen` | Non-null, non-empty |
+
+**Skipped when:** `hosts` array is empty. Skip reason: `"no hosts in DB (no syslog data ingested)"`. This is expected in a fresh CI container with no ingested syslog traffic.
+
+---
+
+#### Tool: `search_logs` (with query)
+
+**Arguments:** `{"query": "error", "limit": 10}`
+
+**Purpose:** Confirm a keyword search returns a properly structured result.
+
+**Unconditional tests:**
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `search_logs — count field present` | `.count != null` | Evaluates to `true` |
+| `search_logs — logs field is array` | `.logs \| type` | `"array"` |
+| `search_logs — count is number >= 0` | `.count >= 0` | Evaluates to `true` |
+
+**Conditional tests (only run when `.logs \| length > 0`):**
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `search_logs — log entry has message field` | `.logs[0].message` | Non-null, non-empty |
+| `search_logs — log entry has hostname field` | `.logs[0].hostname` | Non-null, non-empty |
+| `search_logs — log entry has severity field` | `.logs[0].severity` | Non-null, non-empty |
+| `search_logs — log entry has timestamp field` | `.logs[0].timestamp` | Non-null, non-empty |
+
+**Skipped when:** No logs match the query `"error"`. Skip reason: `"no matching logs (empty DB)"`.
+
+#### Tool: `search_logs` (no query — list recent)
+
+A second invocation with different arguments, run immediately after the first:
+
+**Arguments:** `{"limit": 5}`
+
+**Purpose:** Confirm the tool works without a query (browsing mode — returns most recent logs).
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `search_logs (no query) — count field present` | `.count != null` | Evaluates to `true` |
+| `search_logs (no query) — logs field is array` | `.logs \| type` | `"array"` |
+
+No per-entry field validation on this second call — it only checks the envelope shape.
+
+---
+
+#### Tool: `get_errors`
+
+**Arguments:** `{"limit": 10}`
+
+**Purpose:** Confirm the error-summary tool returns a valid summary array for error-level logs.
+
+**Unconditional tests:**
+
+| Test label | jq expression | Expected value |
+|---|---|---|
+| `get_errors — summary field is array` | `.summary \| type` | `"array"` |
+
+**Conditional tests (only run when `.summary \| length > 0`):**
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `get_errors — entry has hostname field` | `.summary[0].hostname` | Non-null, non-empty |
+| `get_errors — entry has severity field` | `.summary[0].severity` | Non-null, non-empty |
+| `get_errors — entry has count field` | `.summary[0].count != null` | Evaluates to `true` |
+
+**Skipped when:** No error-level logs in the database. Skip reason: `"no error-level logs in DB"`.
+
+---
+
+#### Tool: `tail_logs`
+
+**Arguments:** `{"n": 10}`
+
+**Purpose:** Confirm the tail tool returns the N most recent log entries with the correct structure.
+
+**Unconditional tests:**
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `tail_logs — count field present` | `.count != null` | Evaluates to `true` |
+| `tail_logs — logs field is array` | `.logs \| type` | `"array"` |
+| `tail_logs — count is number >= 0` | `.count >= 0` | Evaluates to `true` |
+
+**Conditional tests (only run when `.logs \| length > 0`):**
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `tail_logs — entry has message field` | `.logs[0].message` | Non-null, non-empty |
+| `tail_logs — entry has hostname field` | `.logs[0].hostname` | Non-null, non-empty |
+| `tail_logs — entry has severity field` | `.logs[0].severity` | Non-null, non-empty |
+| `tail_logs — entry has timestamp field` | `.logs[0].timestamp` | Non-null, non-empty |
+
+**Skipped when:** No logs in database. Skip reason: `"no logs in DB"`.
+
+---
+
+#### Tool: `correlate_events`
+
+**Arguments (dynamically built):**
+```json
+{
+  "reference_time": "<current UTC time in ISO 8601>",
+  "window_minutes": 5,
+  "severity_min": "debug",
+  "limit": 50
+}
+```
+
+The `reference_time` is generated at test runtime via `date -u +%Y-%m-%dT%H:%M:%SZ`. The `jq -nc` call with `--arg t` injects it safely.
+
+**Purpose:** Confirm the correlation tool returns a complete temporal window object. This is the most structurally rich response — it validates both metadata fields and the envelope of correlated data.
+
+| Test label | jq expression | PASS condition |
+|---|---|---|
+| `correlate_events — reference_time present` | `.reference_time` | Non-null, non-empty |
+| `correlate_events — window_minutes present` | `.window_minutes != null` | Evaluates to `true` |
+| `correlate_events — window_from present` | `.window_from` | Non-null, non-empty |
+| `correlate_events — window_to present` | `.window_to` | Non-null, non-empty |
+| `correlate_events — hosts field is array` | `.hosts \| type` | `"array"` |
+| `correlate_events — total_events >= 0` | `.total_events >= 0` | Evaluates to `true` |
+| `correlate_events — truncated field present` | `.truncated != null` | Evaluates to `true` |
+
+All seven assertions are unconditional — `correlate_events` is expected to always return all metadata fields even when the time window contains zero events. The `window_from` and `window_to` fields prove the server computed temporal bounds correctly. The `truncated` field (boolean) proves the pagination logic field is always present regardless of data volume.
+
+---
+
+## 5. Skipped Operations and Why
+
+### Tests that are conditionally skipped
+
+| Skip label | Condition | Reason |
+|---|---|---|
+| `auth: unauthenticated /mcp returns 401` | `SYSLOG_MCP_API_TOKEN` not set | Auth assumed disabled; enforcing 401 without a configured token is not the server's job |
+| `auth: bad token returns 401` | `SYSLOG_MCP_API_TOKEN` not set | Same as above |
+| `list_hosts — entry field validation` | `hosts` array is empty | No syslog data has been ingested; empty array is valid |
+| `search_logs — log entry field validation` | No logs matching `"error"` | Empty DB is valid; field shape only verified when data exists |
+| `get_errors — entry field validation` | `summary` array is empty | No error-level logs; empty is valid |
+| `tail_logs — entry field validation` | No logs in DB | Empty DB; field shape only verified when data exists |
+
+### Operations that are entirely absent from the script
+
+No write operations exist in the syslog-mcp tool surface (it is a read-only server), so there is nothing to exclude on data-safety grounds. The script tests every tool in the `tools/list` surface:
+
+| Tool | Tested? |
+|---|---|
+| `search_logs` | Yes — two invocations |
+| `tail_logs` | Yes |
+| `get_errors` | Yes |
+| `list_hosts` | Yes |
+| `correlate_events` | Yes |
+| `get_stats` | Yes |
+| `syslog_help` | Yes |
+
+---
+
+## 6. What "Proving Correct Operation" Means Per Tool
+
+| Tool | What correctness means beyond "responded" |
+|---|---|
+| `syslog_help` | `.help` is a non-empty string that mentions "syslog" — proves the help content is not empty or boilerplate |
+| `get_stats` | All numeric fields are present AND `>= 0` — proves the DB query ran and returned sensible (not negative) values; `write_blocked` is proven non-null (may be `false`) |
+| `list_hosts` | `.hosts` is a JSON array (not an object or string); if populated, each entry has `hostname`, `log_count`, `first_seen`, `last_seen` — proves the host aggregation query produced correctly shaped rows |
+| `search_logs` | `.count` is numeric `>= 0` and `.logs` is an array; if populated, entries have all four log fields — proves the full-text search plumbing returns correctly shaped log rows |
+| `get_errors` | `.summary` is an array; if populated, entries have `hostname`, `severity`, and `count` — proves the severity-filtered aggregation returns the correct schema |
+| `tail_logs` | `.count >= 0` and `.logs` is an array; if populated, entries have all four log fields — proves the recency ordering query returns correct log rows |
+| `correlate_events` | All seven fields (`reference_time`, `window_minutes`, `window_from`, `window_to`, `hosts`, `total_events`, `truncated`) are present — proves the temporal windowing logic computed bounds and populated all metadata even on an empty window |
+
+---
+
+## 7. Authentication Tests
+
+The auth phase covers exactly two negative scenarios. Positive auth (correct token accepted) is proven implicitly by all Phase 3 and Phase 4 tests passing when `TOKEN` is non-empty.
+
+| Scenario | Method | Token sent | Expected HTTP code |
+|---|---|---|---|
+| No auth header | POST /mcp | None | 401 |
+| Wrong token | POST /mcp | `intentionally-wrong-token-for-testing` (literal) | 401 |
+| Correct token | POST /mcp | Value of `TOKEN` | Implicit — Phase 3/4 pass |
+
+The `/health` endpoint is tested without any auth header and is expected to return 200. This verifies that health is publicly accessible regardless of auth configuration.
+
+---
+
+## 8. Docker Mode Specifics
+
+### Image Build
+
+```bash
+docker build -t syslog-mcp-test <project_root>
+```
+
+The project root is resolved by navigating one directory up from the script's location (`dirname "$BASH_SOURCE[0]"` + `/..`), then canonicalized with `pwd -P`. The image tag is the hardcoded string `syslog-mcp-test`.
+
+On build failure, the script exits with code `2`.
+
+### Container Start
+
+```bash
+docker run \
+  --name syslog-mcp-test-$$ \
+  --detach \
+  --rm \
+  -p 0:3100 \
+  --tmpfs /data:rw,noexec,nosuid,size=64m \
+  [-e SYSLOG_MCP_API_TOKEN=<token>] \
+  -e SYSLOG_MCP_MAX_DB_SIZE_MB=0 \
+  -e SYSLOG_MCP_RECOVERY_DB_SIZE_MB=0 \
+  -e SYSLOG_MCP_MIN_FREE_DISK_MB=0 \
+  -e SYSLOG_MCP_RECOVERY_FREE_DISK_MB=0 \
+  syslog-mcp-test
+```
+
+Key design decisions:
+
+| Decision | Rationale |
+|---|---|
+| `--name syslog-mcp-test-$$` | Uses the shell PID to avoid container name collisions between parallel test runs |
+| `-p 0:3100` | Docker assigns a random host port — avoids conflicts with existing processes on port 3100 |
+| `--tmpfs /data:rw,noexec,nosuid,size=64m` | SQLite database lives entirely in memory — no disk I/O, no volume cleanup, always starts clean |
+| `SYSLOG_MCP_MAX_DB_SIZE_MB=0` etc. | Zeroes out storage budget limits that would conflict with the tmpfs size cap |
+| `SYSLOG_MCP_API_TOKEN` | Conditionally passed only when `TOKEN` is non-empty |
+
+### Port Discovery
+
+After the container starts, the actual mapped host port is discovered via:
+```bash
+docker inspect <container> \
+  --format '{{(index (index .NetworkSettings.Ports "3100/tcp") 0).HostPort}}'
+```
+
+If this fails (empty result), the script falls back to `$PORT` (default `3100`) with a warning. `BASE_URL` is then set to `http://localhost:<mapped_port>`.
+
+### Health Polling
+
+The script polls `GET <BASE_URL>/health` in a loop:
+- Maximum 30 attempts, 1 second sleep between each.
+- Considers the server healthy when `jq -r '.status'` returns `"ok"`.
+- On timeout (30 attempts exhausted), dumps the last 30 lines of `docker logs <container>` to stderr and returns exit code `2`.
+
+### Teardown
+
+A `trap docker_cleanup EXIT INT TERM` is registered immediately before the build step. The cleanup function runs:
+```bash
+docker rm -f <container_name>
+```
+
+The container was started with `--rm`, so Docker also removes it on exit — the explicit `rm -f` is a belt-and-suspenders safeguard.
+
+---
+
+## 9. Stdio Mode
+
+The script has **no stdio mode**. There is no `--mode stdio` option and no stdio-related code paths.
+
+This is appropriate because:
+- The syslog-mcp server exposes the MCP HTTP transport, not the stdio transport.
+- Stdio transport would require spawning the server binary as a subprocess and piping JSON-RPC messages over stdin/stdout, which is a different integration surface.
+- All MCP tools are fully exercised via the HTTP transport in Phase 3 and Phase 4.
+
+If a future stdio transport is added to syslog-mcp, a corresponding mode would need to be added to this script.
+
+---
+
+## 10. Output Format and Interpreting Results
+
+### Per-test output
+
+Each test prints one line:
+
+```
+[PASS] <test label>
+[FAIL] <test label>
+       expected '<value>', got '<value>'
+[SKIP] <test label> — <reason>
+```
+
+Color coding is applied when stdout is a terminal and `NO_COLOR` is unset:
+- `[PASS]` — green
+- `[FAIL]` — red
+- `[SKIP]` — yellow
+
+### Section headers
+
+Each phase and sub-section is announced with:
+```
+=== Phase N — <name> ===
+```
+
+### Verbose mode
+
+When `--verbose` is passed, every tool call additionally prints:
+```
+[VERBOSE] <tool_name> response:
+<raw JSON-RPC response>
+```
+
+This shows the complete JSON-RPC envelope including `.result.content[0].text` before inner JSON parsing.
+
+### Summary block
+
+At the end, a 65-character wide summary is printed:
+
+```
+=================================================================
+PASS                  42
+FAIL                   0
+SKIP                   6
+TOTAL                 48
+=================================================================
+```
+
+If any tests failed, a bulleted list of failed test labels follows:
+```
+Failed tests:
+  • <test label>
+  • <test label>
+```
+
+### Interpreting SKIPs
+
+SKIPs are **not failures**. They indicate the test was logically valid but could not execute due to a missing precondition (typically an empty database). In a CI environment bootstrapped with no syslog traffic, several per-entry field validation tests will SKIP — this is the expected and correct behavior. To exercise those tests, pre-populate the SQLite database with syslog entries before running.
+
+### Interpreting FAILs
+
+A FAIL always includes a reason line. Common patterns:
+
+| Reason pattern | Likely cause |
+|---|---|
+| `expected 'ok', got ''` | `/health` returned non-JSON or server not started |
+| `expression '.field' returned 'null'` | Tool response missing an expected field — schema mismatch |
+| `got HTTP 000` | Server unreachable (connection refused) |
+| `got HTTP 200` on auth tests | Auth not configured on the server but `TOKEN` is set in the test runner |
+| `curl failed for tool <name>` | Network error or server crashed during test |

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -1,0 +1,780 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test-tools.sh — Integration smoke-test for syslog-mcp MCP server tools
+#
+# Exercises broad non-destructive coverage of all syslog-mcp tools via HTTP:
+#   search_logs, tail_logs, get_errors, list_hosts, correlate_events,
+#   get_stats, syslog_help
+#
+# The server runs as a Docker container over HTTP. No stdio launch needed.
+# Credentials are sourced from ~/.claude-homelab/.env:
+#   SYSLOG_MCP_HOST  (default: localhost)
+#   SYSLOG_MCP_PORT  (default: 3100)
+#   NO_AUTH          (if "true", no Authorization header sent)
+#   SYSLOG_MCP_TOKEN (optional; only used when NO_AUTH != true)
+#
+# Usage:
+#   ./tests/mcporter/test-tools.sh [--timeout-ms N] [--parallel] [--verbose]
+#
+# Options:
+#   --timeout-ms N   Per-call timeout in milliseconds (default: 25000)
+#   --parallel       Run independent test groups in parallel (default: off)
+#   --verbose        Print raw mcporter output for each call
+#
+# Exit codes:
+#   0 — all tests passed or skipped
+#   1 — one or more tests failed
+#   2 — prerequisite check failed (mcporter not found, server unreachable)
+# =============================================================================
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+readonly SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly PROJECT_DIR="$(cd -- "${SCRIPT_DIR}/../.." && pwd -P)"
+readonly SCRIPT_NAME="$(basename -- "${BASH_SOURCE[0]}")"
+readonly TS_START="$(date +%s%N)"
+readonly LOG_FILE="${TMPDIR:-/tmp}/${SCRIPT_NAME%.sh}.$(date +%Y%m%d-%H%M%S).log"
+readonly ENV_FILE="${HOME}/.claude-homelab/.env"
+
+# Colours (disabled automatically when stdout is not a terminal)
+if [[ -t 1 ]]; then
+  C_RESET='\033[0m'
+  C_BOLD='\033[1m'
+  C_GREEN='\033[0;32m'
+  C_RED='\033[0;31m'
+  C_YELLOW='\033[0;33m'
+  C_CYAN='\033[0;36m'
+  C_DIM='\033[2m'
+else
+  C_RESET='' C_BOLD='' C_GREEN='' C_RED='' C_YELLOW='' C_CYAN='' C_DIM=''
+fi
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via flags)
+# ---------------------------------------------------------------------------
+CALL_TIMEOUT_MS=25000
+USE_PARALLEL=false
+VERBOSE=false
+
+# ---------------------------------------------------------------------------
+# Counters (updated by run_test / skip_test)
+# ---------------------------------------------------------------------------
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+declare -a FAIL_NAMES=()
+
+# Runtime globals — populated after ENV load
+MCP_URL=''
+MCPORTER_HEADER_ARGS=()
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --timeout-ms)
+        CALL_TIMEOUT_MS="${2:?--timeout-ms requires a value}"
+        shift 2
+        ;;
+      --parallel)
+        USE_PARALLEL=true
+        shift
+        ;;
+      --verbose)
+        VERBOSE=true
+        shift
+        ;;
+      -h|--help)
+        printf 'Usage: %s [--timeout-ms N] [--parallel] [--verbose]\n' "${SCRIPT_NAME}"
+        exit 0
+        ;;
+      *)
+        printf '[ERROR] Unknown argument: %s\n' "$1" >&2
+        exit 2
+        ;;
+    esac
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+log_info()  { printf "${C_CYAN}[INFO]${C_RESET}  %s\n" "$*" | tee -a "${LOG_FILE}"; }
+log_warn()  { printf "${C_YELLOW}[WARN]${C_RESET}  %s\n" "$*" | tee -a "${LOG_FILE}"; }
+log_error() { printf "${C_RED}[ERROR]${C_RESET} %s\n" "$*" | tee -a "${LOG_FILE}" >&2; }
+
+elapsed_ms() {
+  local now
+  now="$(date +%s%N)"
+  printf '%d' "$(( (now - TS_START) / 1000000 ))"
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup trap
+# ---------------------------------------------------------------------------
+cleanup() {
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    log_warn "Script exited with rc=${rc}. Log: ${LOG_FILE}"
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Load environment and build MCP URL + auth headers
+# ---------------------------------------------------------------------------
+load_env() {
+  if [[ -f "${ENV_FILE}" ]]; then
+    # shellcheck disable=SC1090
+    set -a
+    source "${ENV_FILE}"
+    set +a
+    log_info "Loaded credentials from ${ENV_FILE}"
+  else
+    log_warn "${ENV_FILE} not found — using defaults / environment"
+  fi
+
+  local host="${SYSLOG_MCP_HOST:-localhost}"
+  # SYSLOG_MCP_HOST in .env is set to "0.0.0.0" (bind address), not the access address.
+  # Remap 0.0.0.0 → localhost for outbound connections.
+  if [[ "${host}" == "0.0.0.0" ]]; then
+    host="localhost"
+  fi
+  local port="${SYSLOG_MCP_PORT:-3100}"
+  MCP_URL="http://${host}:${port}/mcp"
+
+  # Auth: NO_AUTH=true in .env means the server runs without token validation.
+  # Honour an explicit SYSLOG_MCP_TOKEN if set regardless.
+  local token="${SYSLOG_MCP_TOKEN:-}"
+  local no_auth="${NO_AUTH:-true}"
+
+  MCPORTER_HEADER_ARGS=()
+  if [[ -n "${token}" ]]; then
+    MCPORTER_HEADER_ARGS+=(--header "Authorization: Bearer ${token}")
+  elif [[ "${no_auth}" != "true" ]]; then
+    log_warn "NO_AUTH is not 'true' and SYSLOG_MCP_TOKEN is unset — calls may return 401"
+  fi
+
+  log_info "MCP URL: ${MCP_URL}"
+  if [[ ${#MCPORTER_HEADER_ARGS[@]} -gt 0 ]]; then
+    log_info "Auth: Bearer token configured"
+  else
+    log_info "Auth: none (NO_AUTH=true)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+check_prerequisites() {
+  local missing=false
+
+  if ! command -v mcporter &>/dev/null; then
+    log_error "mcporter not found in PATH. Install it and re-run."
+    missing=true
+  fi
+
+  if ! command -v python3 &>/dev/null; then
+    log_error "python3 not found in PATH."
+    missing=true
+  fi
+
+  if ! command -v curl &>/dev/null; then
+    log_error "curl not found in PATH."
+    missing=true
+  fi
+
+  if [[ "${missing}" == true ]]; then
+    return 2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Server connectivity smoke-test
+#   Hits /health (unauthenticated) then verifies MCP tools/list responds.
+# ---------------------------------------------------------------------------
+smoke_test_server() {
+  log_info "Smoke-testing server connectivity..."
+
+  local base_url="${MCP_URL%/mcp}"
+
+  # 1. Health endpoint (no auth required)
+  local health_status
+  health_status="$(
+    curl -sf --max-time 10 "${base_url}/health" 2>/dev/null | \
+    python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null
+  )" || health_status=''
+
+  if [[ "${health_status}" != "ok" ]]; then
+    log_error "Health endpoint at ${base_url}/health did not return status=ok (got: '${health_status}')"
+    log_error "Is the syslog-mcp container running?  docker ps | grep syslog-mcp"
+    return 2
+  fi
+  log_info "Health endpoint OK"
+
+  # 2. tools/list to confirm MCP layer responds
+  local tool_count
+  tool_count="$(
+    curl -sf --max-time 10 \
+      -X POST "${MCP_URL}" \
+      -H "Content-Type: application/json" \
+      ${MCPORTER_HEADER_ARGS[@]+"${MCPORTER_HEADER_ARGS[@]}"} \
+      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' 2>/dev/null | \
+    python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+tools = d.get('result', {}).get('tools', [])
+print(len(tools))
+" 2>/dev/null
+  )" || tool_count=0
+
+  if [[ "${tool_count}" -lt 1 ]] 2>/dev/null; then
+    log_error "tools/list returned ${tool_count} tools — expected at least 7"
+    return 2
+  fi
+
+  log_info "Server OK — ${tool_count} tools available"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# mcporter call wrapper
+#   Usage: mcporter_call <tool_name> <args_json>
+# ---------------------------------------------------------------------------
+mcporter_call() {
+  local tool="${1:?tool required}"
+  local args_json="${2:?args_json required}"
+
+  mcporter call \
+    --http-url "${MCP_URL}" \
+    --allow-http \
+    ${MCPORTER_HEADER_ARGS[@]+"${MCPORTER_HEADER_ARGS[@]}"} \
+    --tool "${tool}" \
+    --args "${args_json}" \
+    --timeout "${CALL_TIMEOUT_MS}" \
+    --output json \
+    2>>"${LOG_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Test runner
+#   Usage: run_test <label> <tool_name> <args_json> [expected_key]
+# ---------------------------------------------------------------------------
+run_test() {
+  local label="${1:?label required}"
+  local tool="${2:?tool required}"
+  local args="${3:?args required}"
+  local expected_key="${4:-}"
+
+  local t0
+  t0="$(date +%s%N)"
+
+  local output
+  output="$(mcporter_call "${tool}" "${args}")" || true
+
+  local elapsed_ms
+  elapsed_ms="$(( ( $(date +%s%N) - t0 ) / 1000000 ))"
+
+  if [[ "${VERBOSE}" == true ]]; then
+    printf '%s\n' "${output}" | tee -a "${LOG_FILE}"
+  else
+    printf '%s\n' "${output}" >> "${LOG_FILE}"
+  fi
+
+  # Validate JSON is parseable and not an error payload
+  local json_check
+  json_check="$(
+    printf '%s' "${output}" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if isinstance(d, dict) and ('error' in d or d.get('kind') == 'error'):
+        print('error: ' + str(d.get('error', d.get('message', 'unknown error'))))
+    else:
+        print('ok')
+except Exception as e:
+    print('invalid_json: ' + str(e))
+" 2>/dev/null
+  )" || json_check="parse_error"
+
+  if [[ "${json_check}" != "ok" ]]; then
+    printf "${C_RED}[FAIL]${C_RESET} %-60s ${C_DIM}%dms${C_RESET}\n" \
+      "${label}" "${elapsed_ms}" | tee -a "${LOG_FILE}"
+    printf '       response validation failed: %s\n' "${json_check}" | tee -a "${LOG_FILE}"
+    FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+    FAIL_NAMES+=("${label}")
+    return 1
+  fi
+
+  # Validate optional key presence (dot-notation e.g. "hosts" or "logs.0")
+  if [[ -n "${expected_key}" ]]; then
+    local key_check
+    key_check="$(
+      printf '%s' "${output}" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    keys = '${expected_key}'.split('.')
+    node = d
+    for k in keys:
+        if k:
+            node = node[int(k)] if (isinstance(node, list) and k.isdigit()) else node[k]
+    print('ok')
+except Exception as e:
+    print('missing: ' + str(e))
+" 2>/dev/null
+    )" || key_check="parse_error"
+
+    if [[ "${key_check}" != "ok" ]]; then
+      printf "${C_RED}[FAIL]${C_RESET} %-60s ${C_DIM}%dms${C_RESET}\n" \
+        "${label}" "${elapsed_ms}" | tee -a "${LOG_FILE}"
+      printf '       expected key .%s not found: %s\n' "${expected_key}" "${key_check}" | tee -a "${LOG_FILE}"
+      FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+      FAIL_NAMES+=("${label}")
+      return 1
+    fi
+  fi
+
+  printf "${C_GREEN}[PASS]${C_RESET} %-60s ${C_DIM}%dms${C_RESET}\n" \
+    "${label}" "${elapsed_ms}" | tee -a "${LOG_FILE}"
+  PASS_COUNT=$(( PASS_COUNT + 1 ))
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Skip helper
+# ---------------------------------------------------------------------------
+skip_test() {
+  local label="${1:?label required}"
+  local reason="${2:-prerequisite returned empty}"
+  printf "${C_YELLOW}[SKIP]${C_RESET} %-60s %s\n" "${label}" "${reason}" | tee -a "${LOG_FILE}"
+  SKIP_COUNT=$(( SKIP_COUNT + 1 ))
+}
+
+# ---------------------------------------------------------------------------
+# Safe JSON payload builder
+#   Usage: _json_payload '<jq-template>' key1=value1 key2=value2 ...
+# ---------------------------------------------------------------------------
+_json_payload() {
+  local template="${1:?template required}"; shift
+  local jq_args=()
+  local pair k v
+  for pair in "$@"; do
+    k="${pair%%=*}"
+    v="${pair#*=}"
+    jq_args+=(--arg "$k" "$v")
+  done
+  jq -n "${jq_args[@]}" "$template"
+}
+
+# ---------------------------------------------------------------------------
+# ID / value extractors  (used for parameterised tests)
+# ---------------------------------------------------------------------------
+
+# Returns the hostname with the highest log_count (most data = best for testing)
+get_primary_host() {
+  local raw
+  raw="$(mcporter_call list_hosts '{}'  2>/dev/null)" || return 0
+  printf '%s' "${raw}" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    hosts = sorted(d.get('hosts', []), key=lambda h: h.get('log_count', 0), reverse=True)
+    # Filter out malformed hostnames (timestamp-like strings)
+    for h in hosts:
+        name = h.get('hostname','')
+        if name and 'T' not in name and ':' not in name:
+            print(name)
+            break
+except Exception:
+    pass
+" 2>/dev/null || true
+}
+
+# Returns a recent error timestamp from get_errors, used for correlate_events
+get_recent_error_time() {
+  local raw
+  raw="$(mcporter_call get_errors '{}'  2>/dev/null)" || return 0
+  # get_stats has newest_log which is more reliable
+  local stats
+  stats="$(mcporter_call get_stats '{}' 2>/dev/null)" || return 0
+  printf '%s' "${stats}" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    ts = d.get('newest_log', '')
+    if ts:
+        print(ts)
+except Exception:
+    pass
+" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Test suites
+# ---------------------------------------------------------------------------
+
+suite_meta() {
+  printf '\n%b== meta (help + health) ==%b\n' "${C_BOLD}" "${C_RESET}" | tee -a "${LOG_FILE}"
+  run_test "syslog_help: returns documentation"    syslog_help '{}'
+  run_test "get_stats: returns database statistics" get_stats   '{}' "total_logs"
+  run_test "get_stats: write_blocked field present" get_stats   '{}' "write_blocked"
+  run_test "get_stats: free_disk_mb field present"  get_stats   '{}' "free_disk_mb"
+}
+
+suite_hosts() {
+  printf '\n%b== list_hosts ==%b\n' "${C_BOLD}" "${C_RESET}" | tee -a "${LOG_FILE}"
+  run_test "list_hosts: returns hosts array"     list_hosts '{}' "hosts"
+  run_test "list_hosts: hosts have hostname key" list_hosts '{}' "hosts.0.hostname"
+  run_test "list_hosts: hosts have log_count"    list_hosts '{}' "hosts.0.log_count"
+  run_test "list_hosts: hosts have first_seen"   list_hosts '{}' "hosts.0.first_seen"
+  run_test "list_hosts: hosts have last_seen"    list_hosts '{}' "hosts.0.last_seen"
+}
+
+suite_tail() {
+  printf '\n%b== tail_logs ==%b\n' "${C_BOLD}" "${C_RESET}" | tee -a "${LOG_FILE}"
+  run_test "tail_logs: default (50 entries)"  tail_logs '{}' "logs"
+  run_test "tail_logs: count field present"   tail_logs '{}' "count"
+  run_test "tail_logs: n=10 returns entries"  tail_logs '{"n":10}' "logs"
+  run_test "tail_logs: log entry has message" tail_logs '{"n":5}' "logs.0.message"
+  run_test "tail_logs: log entry has hostname" tail_logs '{"n":5}' "logs.0.hostname"
+  run_test "tail_logs: log entry has severity" tail_logs '{"n":5}' "logs.0.severity"
+  run_test "tail_logs: log entry has timestamp" tail_logs '{"n":5}' "logs.0.timestamp"
+
+  # Host-scoped tail
+  local primary_host
+  primary_host="$(get_primary_host)" || primary_host=''
+  if [[ -n "${primary_host}" ]]; then
+    run_test "tail_logs: host=${primary_host} filter" \
+      tail_logs \
+      "$(_json_payload '{"hostname":$h,"n":10}' h="${primary_host}")" \
+      "logs"
+  else
+    skip_test "tail_logs: host-scoped" "no usable hostname found"
+  fi
+}
+
+suite_search() {
+  printf '\n%b== search_logs ==%b\n' "${C_BOLD}" "${C_RESET}" | tee -a "${LOG_FILE}"
+
+  run_test "search_logs: basic query (error)"         search_logs '{"query":"error","limit":10}' "logs"
+  run_test "search_logs: count field present"         search_logs '{"query":"error","limit":5}' "count"
+  run_test "search_logs: severity filter (err)"       search_logs '{"severity":"err","limit":10}' "logs"
+  run_test "search_logs: severity filter (warning)"   search_logs '{"severity":"warning","limit":10}' "logs"
+  run_test "search_logs: limit respected"             search_logs '{"query":"info","limit":3}' "logs"
+  run_test "search_logs: no query (list recent)"      search_logs '{"limit":20}' "logs"
+
+  # App-name filter — discover real app name from tail first
+  local app_name
+  app_name="$(
+    mcporter_call tail_logs '{"n":20}' 2>/dev/null | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    apps = [l.get('app_name','') for l in d.get('logs',[]) if l.get('app_name','')]
+    # Pick first non-empty, reasonably short app name
+    for a in apps:
+        if a and len(a) < 30 and ' ' not in a:
+            print(a)
+            break
+except Exception:
+    pass
+" 2>/dev/null
+  )" || app_name=''
+
+  if [[ -n "${app_name}" ]]; then
+    run_test "search_logs: app_name=${app_name} filter" \
+      search_logs \
+      "$(_json_payload '{"app_name":$a,"limit":10}' a="${app_name}")" \
+      "logs"
+  else
+    skip_test "search_logs: app_name filter" "no usable app_name found in recent logs"
+  fi
+
+  # Host-scoped search
+  local primary_host
+  primary_host="$(get_primary_host)" || primary_host=''
+  if [[ -n "${primary_host}" ]]; then
+    run_test "search_logs: hostname=${primary_host} filter" \
+      search_logs \
+      "$(_json_payload '{"hostname":$h,"limit":10}' h="${primary_host}")" \
+      "logs"
+  else
+    skip_test "search_logs: hostname filter" "no usable hostname found"
+  fi
+
+  # FTS5 phrase matching
+  run_test "search_logs: FTS5 phrase query"    search_logs '{"query":"\"connection refused\"","limit":10}' "logs"
+  # Prefix matching
+  run_test "search_logs: FTS5 prefix query"    search_logs '{"query":"kernel*","limit":10}' "logs"
+  # Time-bounded search — last 24 hours
+  local since
+  since="$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+  if [[ -n "${since}" ]]; then
+    run_test "search_logs: time range (last 24h)" \
+      search_logs \
+      "$(_json_payload '{"from":$f,"limit":20}' f="${since}")" \
+      "logs"
+  else
+    skip_test "search_logs: time range filter" "could not compute timestamp"
+  fi
+}
+
+suite_errors() {
+  printf '\n%b== get_errors ==%b\n' "${C_BOLD}" "${C_RESET}" | tee -a "${LOG_FILE}"
+
+  run_test "get_errors: all time"       get_errors '{}' "summary"
+  run_test "get_errors: summary has hostname" get_errors '{}' "summary.0.hostname"
+  run_test "get_errors: summary has severity" get_errors '{}' "summary.0.severity"
+  run_test "get_errors: summary has count"    get_errors '{}' "summary.0.count"
+
+  # Time-bounded get_errors (last 1 hour)
+  local since
+  since="$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+  local until_now
+  until_now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if [[ -n "${since}" ]]; then
+    run_test "get_errors: time range (last 1h)" \
+      get_errors \
+      "$(_json_payload '{"from":$f,"to":$t}' f="${since}" t="${until_now}")" \
+      "summary"
+  else
+    skip_test "get_errors: time range filter" "could not compute timestamp"
+  fi
+}
+
+suite_correlate() {
+  printf '\n%b== correlate_events ==%b\n' "${C_BOLD}" "${C_RESET}" | tee -a "${LOG_FILE}"
+
+  # correlate_events requires reference_time (the only required field)
+  local ref_time
+  ref_time="$(get_recent_error_time)" || ref_time=''
+
+  if [[ -z "${ref_time}" ]]; then
+    # Fallback: use current time
+    ref_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  fi
+
+  run_test "correlate_events: default window (5m)" \
+    correlate_events \
+    "$(_json_payload '{"reference_time":$t}' t="${ref_time}")"
+
+  run_test "correlate_events: wider window (15m)" \
+    correlate_events \
+    "$(_json_payload '{"reference_time":$t,"window_minutes":15}' t="${ref_time}")"
+
+  run_test "correlate_events: severity_min=err" \
+    correlate_events \
+    "$(_json_payload '{"reference_time":$t,"severity_min":"err"}' t="${ref_time}")"
+
+  run_test "correlate_events: severity_min=debug (all)" \
+    correlate_events \
+    "$(_json_payload '{"reference_time":$t,"window_minutes":2,"severity_min":"debug","limit":50}' t="${ref_time}")"
+
+  run_test "correlate_events: with FTS query" \
+    correlate_events \
+    "$(_json_payload '{"reference_time":$t,"query":"error*","window_minutes":10}' t="${ref_time}")"
+
+  # Host-scoped correlation
+  local primary_host
+  primary_host="$(get_primary_host)" || primary_host=''
+  if [[ -n "${primary_host}" ]]; then
+    run_test "correlate_events: host=${primary_host} scoped" \
+      correlate_events \
+      "$(_json_payload '{"reference_time":$t,"hostname":$h,"window_minutes":5}' t="${ref_time}" h="${primary_host}")"
+  else
+    skip_test "correlate_events: host-scoped" "no usable hostname found"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Auth enforcement tests (only run when NO_AUTH != "true")
+# ---------------------------------------------------------------------------
+suite_auth() {
+  local no_auth="${NO_AUTH:-true}"
+  if [[ "${no_auth}" == "true" ]]; then
+    printf '\n%b== auth (skipped — NO_AUTH=true) ==%b\n' "${C_BOLD}" "${C_RESET}" | tee -a "${LOG_FILE}"
+    skip_test "auth: unauthenticated request returns 401" "NO_AUTH=true"
+    skip_test "auth: bad token returns 401"                "NO_AUTH=true"
+    return
+  fi
+
+  printf '\n%b== auth enforcement ==%b\n' "${C_BOLD}" "${C_RESET}" | tee -a "${LOG_FILE}"
+
+  local base_url="${MCP_URL%/mcp}"
+  local label status
+
+  label="auth: unauthenticated /mcp returns 401"
+  status="$(curl -s --max-time 10 -o /dev/null -w "%{http_code}" \
+    "${MCP_URL}" -X POST -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' 2>/dev/null)" || status=0
+  if [[ "${status}" == "401" ]]; then
+    printf "${C_GREEN}[PASS]${C_RESET} %-60s\n" "${label}" | tee -a "${LOG_FILE}"
+    PASS_COUNT=$(( PASS_COUNT + 1 ))
+  else
+    printf "${C_RED}[FAIL]${C_RESET} %-60s (got HTTP %s)\n" "${label}" "${status}" | tee -a "${LOG_FILE}"
+    FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+    FAIL_NAMES+=("${label}")
+  fi
+
+  label="auth: bad token returns 401"
+  status="$(curl -s --max-time 10 -o /dev/null -w "%{http_code}" \
+    "${MCP_URL}" -X POST \
+    -H "Authorization: Bearer bad-token-intentionally-invalid" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' 2>/dev/null)" || status=0
+  if [[ "${status}" == "401" ]]; then
+    printf "${C_GREEN}[PASS]${C_RESET} %-60s\n" "${label}" | tee -a "${LOG_FILE}"
+    PASS_COUNT=$(( PASS_COUNT + 1 ))
+  else
+    printf "${C_RED}[FAIL]${C_RESET} %-60s (got HTTP %s)\n" "${label}" "${status}" | tee -a "${LOG_FILE}"
+    FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+    FAIL_NAMES+=("${label}")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Print final summary
+# ---------------------------------------------------------------------------
+print_summary() {
+  local total_ms="$(( ( $(date +%s%N) - TS_START ) / 1000000 ))"
+  local total=$(( PASS_COUNT + FAIL_COUNT + SKIP_COUNT ))
+
+  printf '\n%b%s%b\n' "${C_BOLD}" "$(printf '=%.0s' {1..65})" "${C_RESET}"
+  printf '%b%-20s%b  %b%d%b\n' "${C_BOLD}" "PASS" "${C_RESET}" "${C_GREEN}" "${PASS_COUNT}" "${C_RESET}"
+  printf '%b%-20s%b  %b%d%b\n' "${C_BOLD}" "FAIL" "${C_RESET}" "${C_RED}"   "${FAIL_COUNT}" "${C_RESET}"
+  printf '%b%-20s%b  %b%d%b\n' "${C_BOLD}" "SKIP" "${C_RESET}" "${C_YELLOW}" "${SKIP_COUNT}" "${C_RESET}"
+  printf '%b%-20s%b  %d\n' "${C_BOLD}" "TOTAL" "${C_RESET}" "${total}"
+  printf '%b%-20s%b  %ds (%dms)\n' "${C_BOLD}" "ELAPSED" "${C_RESET}" \
+    "$(( total_ms / 1000 ))" "${total_ms}"
+  printf '%b%s%b\n' "${C_BOLD}" "$(printf '=%.0s' {1..65})" "${C_RESET}"
+
+  if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+    printf '\n%bFailed tests:%b\n' "${C_RED}" "${C_RESET}"
+    local name
+    for name in "${FAIL_NAMES[@]}"; do
+      printf '  • %s\n' "${name}"
+    done
+    printf '\nFull log: %s\n' "${LOG_FILE}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Parallel runner
+# ---------------------------------------------------------------------------
+run_parallel() {
+  log_warn "--parallel mode: per-suite counters aggregated via temp files."
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf -- "${tmp_dir}"' RETURN
+
+  local suites=(
+    suite_meta
+    suite_hosts
+    suite_tail
+    suite_search
+    suite_errors
+    suite_correlate
+    suite_auth
+  )
+
+  local pids=()
+  local suite
+  for suite in "${suites[@]}"; do
+    (
+      PASS_COUNT=0; FAIL_COUNT=0; SKIP_COUNT=0; FAIL_NAMES=()
+      "${suite}"
+      printf '%d %d %d\n' "${PASS_COUNT}" "${FAIL_COUNT}" "${SKIP_COUNT}" \
+        > "${tmp_dir}/${suite}.counts"
+      printf '%s\n' "${FAIL_NAMES[@]:-}" > "${tmp_dir}/${suite}.fails"
+    ) &
+    pids+=($!)
+  done
+
+  local pid
+  for pid in "${pids[@]}"; do
+    wait "${pid}" || true
+  done
+
+  local f
+  for f in "${tmp_dir}"/*.counts; do
+    [[ -f "${f}" ]] || continue
+    local p fl s
+    read -r p fl s < "${f}"
+    PASS_COUNT=$(( PASS_COUNT + p ))
+    FAIL_COUNT=$(( FAIL_COUNT + fl ))
+    SKIP_COUNT=$(( SKIP_COUNT + s ))
+  done
+
+  for f in "${tmp_dir}"/*.fails; do
+    [[ -f "${f}" ]] || continue
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && FAIL_NAMES+=("${line}")
+    done < "${f}"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Sequential runner
+# ---------------------------------------------------------------------------
+run_sequential() {
+  suite_auth
+  suite_meta
+  suite_hosts
+  suite_tail
+  suite_search
+  suite_errors
+  suite_correlate
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  parse_args "$@"
+  load_env
+
+  printf '%b%s%b\n' "${C_BOLD}" "$(printf '=%.0s' {1..65})" "${C_RESET}"
+  printf '%b  syslog-mcp integration smoke-test%b\n' "${C_BOLD}" "${C_RESET}"
+  printf '%b  Project:  %s%b\n' "${C_BOLD}" "${PROJECT_DIR}" "${C_RESET}"
+  printf '%b  MCP URL:  %s%b\n' "${C_BOLD}" "${MCP_URL}" "${C_RESET}"
+  printf '%b  Timeout:  %dms/call | Parallel: %s%b\n' \
+    "${C_BOLD}" "${CALL_TIMEOUT_MS}" "${USE_PARALLEL}" "${C_RESET}"
+  printf '%b  Log:      %s%b\n' "${C_BOLD}" "${LOG_FILE}" "${C_RESET}"
+  printf '%b%s%b\n\n' "${C_BOLD}" "$(printf '=%.0s' {1..65})" "${C_RESET}"
+
+  check_prerequisites || exit 2
+
+  smoke_test_server || {
+    log_error ""
+    log_error "Server connectivity check failed. Aborting — no tests will run."
+    log_error ""
+    log_error "To diagnose:"
+    log_error "  docker ps | grep syslog-mcp"
+    log_error "  curl http://localhost:3100/health"
+    log_error "  curl -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \\"
+    log_error "    -d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}'"
+    exit 2
+  }
+
+  if [[ "${USE_PARALLEL}" == true ]]; then
+    run_parallel
+  else
+    run_sequential
+  fi
+
+  print_summary
+
+  if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+    exit 1
+  fi
+  exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Create 42 documentation files following the plugin-lab template structure
- Cover all 5 subdirectories: mcp/ (19 files), plugin/ (11 files), repo/ (6 files), stack/ (4 files), upstream/ (1 file) plus 6 root-level docs
- All content is real, derived from reading the Rust codebase -- zero template placeholders
- Tailored for the Rust/axum/tokio/SQLite stack (not Python/TS boilerplate)
- Documents dual-port architecture (1514 syslog + 3100 MCP), all 7 tools, storage budget system, FTS5 search, auth, deployment, and security guardrails
- Preserves existing docs/ content (plans/, runbooks/, sessions/, superpowers/)

## Test plan

- [ ] Verify no template placeholders: `grep -r "my-plugin\|scaffold:specialize" docs/`
- [ ] Spot-check cross-references between docs
- [ ] Confirm existing docs (plans/, sessions/, runbooks/) are untouched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a complete documentation set for `syslog-mcp`, introduces live test docs and `mcporter` tool tests, and synchronizes all manifests to version 0.3.2. Also caps the cleanup chunk size to prevent long SQLite write locks.

- **New Features**
  - Full docs structure (root + `mcp/`, `plugin/`, `repo/`, `stack/`, `upstream/`) tailored to Rust/`axum`/`tokio`/SQLite.
  - Added `tests/TEST_COVERAGE.md` and `tests/mcporter/test-tools.sh` for live tool coverage.

- **Bug Fixes**
  - Capped `cleanup_chunk_size` at 1_000_000 with a clearer validation error.
  - Synced versions to `0.3.2` in `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `gemini-extension.json`, and `Cargo.toml`; updated `CHANGELOG.md`.

<sup>Written for commit d3752b3f06e81913a10f45611e6302b346f8fe94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

