### PR TITLE
feat: ingest docker socket proxy logs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Syslog management via MCP",
   "author": "jmagar",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Syslog management via MCP.",
   "homepage": "https://github.com/jmagar/syslog-mcp",
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,15 @@ SYSLOG_MCP_POOL_SIZE=4
 # Log retention in days (0 = keep forever)
 SYSLOG_MCP_RETENTION_DAYS=90
 
+# --- Docker socket-proxy ingest ---
+
+# Keep Docker's normal local/json-file/journald logging driver and have
+# syslog-mcp pull container logs through read-only docker-socket-proxy endpoints.
+SYSLOG_DOCKER_INGEST_ENABLED=false
+# SYSLOG_DOCKER_HOSTS_FILE=/config/docker-hosts.toml
+# SYSLOG_DOCKER_RECONNECT_INITIAL_MS=1000
+# SYSLOG_DOCKER_RECONNECT_MAX_MS=30000
+
 # --- Container ---
 
 # Container runtime user/group for bind-mounted data directories.
@@ -79,3 +88,6 @@ DOCKER_NETWORK=syslog_mcp
 
 # Data volume: named volume (default) or bind mount path (e.g. ./data)
 # SYSLOG_MCP_DATA_VOLUME=syslog-mcp-data
+
+# Read-only config mount used for optional files such as docker-hosts.toml.
+# SYSLOG_MCP_CONFIG_VOLUME=./config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-05
+
+### Added
+
+- **Docker socket-proxy ingest**: Added optional pull-based Docker container log ingestion through read-only docker-socket-proxy endpoints, including host reconnect loops, container start event handling, stdout/stderr parsing, and per-container checkpoints in SQLite.
+- **Shared ingest writer**: Routed syslog listener input and Docker log input through one bounded batch writer so retention, storage guardrails, and write blocking remain centralized.
+- **Configuration/docs**: Added Docker ingest config, env vars, setup guidance, Compose `/config` mount, and `.env.example` entries for remote Docker hosts.
+
 ## [0.6.0] - 2026-05-05
 
 ### Added
@@ -362,7 +370,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/jmagar/syslog-mcp/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/jmagar/syslog-mcp/compare/v0.5.0...v0.6.0
 [0.1.7]: https://github.com/jmagar/syslog-mcp/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/jmagar/syslog-mcp/compare/v0.1.5...v0.1.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,10 +114,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bollard"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.49.1-rc.28.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+]
 
 [[package]]
 name = "bumpalo"
@@ -217,6 +268,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -386,6 +458,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -422,6 +500,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -487,6 +571,7 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -496,12 +581,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -529,6 +619,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +711,38 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -608,6 +812,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -688,6 +898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +970,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -891,7 +1122,7 @@ dependencies = [
  "pin-project-lite",
  "rand",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -985,6 +1216,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1097,6 +1340,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1369,24 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -1204,6 +1476,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,17 +1511,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syslog-mcp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
+ "bollard",
+ "bytes",
  "chrono",
+ "futures-util",
  "r2d2",
  "r2d2_sqlite",
  "rmcp",
  "rusqlite",
  "rustix 0.38.44",
+ "scheduled-thread-pool",
  "serde",
  "serde_json",
  "serial_test",
@@ -1308,6 +1601,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1389,7 +1723,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1511,6 +1845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,6 +1861,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -1551,6 +1909,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1638,7 +2005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1651,9 +2018,31 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1833,7 +2222,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -1864,7 +2253,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -1883,7 +2272,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -1891,6 +2280,35 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1907,6 +2325,60 @@ name = "zerocopy-derive"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"
@@ -18,9 +18,14 @@ tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
 rusqlite = { version = "0.32", features = ["bundled", "vtab"] }
 r2d2 = "0.8"
 r2d2_sqlite = "0.25"
+scheduled-thread-pool = "0.2"
 
 # Syslog parsing
 syslog_loose = "0.21"
+
+# Docker Engine API client for optional docker-socket-proxy ingestion
+bollard = { version = "0.19", default-features = false, features = ["http", "chrono"] }
+bytes = "1"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -41,6 +46,7 @@ anyhow = "1"
 subtle = "2"
 rustix = { version = "0.38", features = ["fs"] }
 
+futures-util = "0.3"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Full-text search across all syslog messages with optional filters. Uses SQLite F
 |-----------|------|----------|---------|-------------|
 | `query` | string | no | — | FTS5 search query (see [FTS5 query syntax](#fts5-query-syntax)) |
 | `hostname` | string | no | — | Exact hostname match. Use `list_hosts` to enumerate. |
-| `source_ip` | string | no | — | Exact verified sender address (`IP:port`) captured from the network connection |
+| `source_ip` | string | no | — | Exact source identifier. Syslog entries use the verified network sender address (`IP:port`); Docker ingest entries use `docker://host/container/stream` from configured ingest metadata. |
 | `severity` | string | no | — | One of: `emerg alert crit err warning notice info debug` |
 | `app_name` | string | no | — | Application name, e.g. `sshd`, `dockerd`, `kernel` |
 | `from` | string | no | — | Start of time range (ISO 8601 / RFC 3339, e.g. `2025-01-15T00:00:00Z`) |
@@ -87,7 +87,7 @@ Return the N most recent log entries. Equivalent to `tail -f` across all hosts.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `hostname` | string | no | — | Filter to a specific host |
-| `source_ip` | string | no | — | Filter to an exact verified sender address (`IP:port`) captured from the network connection |
+| `source_ip` | string | no | — | Filter to an exact source identifier. Syslog entries use the verified network sender address (`IP:port`); Docker ingest entries use `docker://host/container/stream` from configured ingest metadata. |
 | `app_name` | string | no | — | Filter to a specific application |
 | `n` | integer | no | 50 | Number of recent entries (hard cap: 500) |
 
@@ -159,7 +159,7 @@ Search for related events across multiple hosts within a ±N minute window aroun
 | `window_minutes` | integer | no | 5 | Minutes before and after `reference_time` (max 60) |
 | `severity_min` | string | no | `warning` | Minimum severity to include. `warning` returns `warning/err/crit/alert/emerg`. `debug` returns everything. |
 | `hostname` | string | no | — | Limit correlation to one host |
-| `source_ip` | string | no | — | Limit correlation to an exact verified sender address (`IP:port`) captured from the network connection |
+| `source_ip` | string | no | — | Limit correlation to an exact source identifier. Syslog entries use the verified network sender address (`IP:port`); Docker ingest entries use `docker://host/container/stream`. |
 | `query` | string | no | — | FTS5 query to narrow results |
 | `limit` | integer | no | 500 | Max total events (hard cap: 999) |
 
@@ -260,9 +260,9 @@ Each stored log entry has these fields:
 | `process_id` | text\|null | PID from the syslog message |
 | `message` | text | Log message body (FTS5-indexed) |
 | `received_at` | text | Server-side receipt timestamp (RFC 3339, UTC). Used for retention. |
-| `source_ip` | text | Exact network sender address (`IP:port`) captured from the packet/connection peer. Trustworthy network identity, including the sender port. |
+| `source_ip` | text | Source identifier. Syslog entries use the exact network sender address (`IP:port`) captured from the packet/connection peer. Docker ingest entries use `docker://host/container/stream` from configured Docker ingest metadata. |
 
-**Important:** `hostname` is taken from the syslog message body, which any LAN device can set to an arbitrary value over UDP. `source_ip` is the only trustworthy network identifier. Retention cutoffs use `received_at` (server clock) so that devices with misconfigured clocks cannot cause premature or indefinite log retention.
+**Important:** `hostname` is taken from the syslog message body, which any LAN device can set to an arbitrary value over UDP. For syslog entries, `source_ip` is the only trustworthy network identifier. For Docker ingest entries, `source_ip` identifies the configured Docker ingest host/container/stream and should be trusted only as far as the configured docker-socket-proxy endpoint and network path are trusted. Retention cutoffs use `received_at` (server clock) so that devices with misconfigured clocks cannot cause premature or indefinite log retention.
 
 ### Severity levels
 
@@ -359,6 +359,33 @@ The plain JSON API is disabled by default. When enabled, it is mounted under `/a
 | `SYSLOG_BATCH_SIZE` | no | `100` | Number of messages per batch write |
 | `SYSLOG_FLUSH_INTERVAL` | no | `500` | Batch flush interval in milliseconds |
 
+#### Docker socket-proxy ingest
+
+Optional pull-based Docker log ingestion keeps each remote host on its normal Docker logging driver and has syslog-mcp read container stdout/stderr through read-only `docker-socket-proxy` endpoints. This avoids configuring Docker's daemon-level syslog driver and does not block container startup when syslog-mcp is down.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SYSLOG_DOCKER_INGEST_ENABLED` | no | `false` | Enable remote Docker log ingestion |
+| `SYSLOG_DOCKER_HOSTS_FILE` | yes, if hosts are not configured elsewhere | — | TOML file containing remote Docker socket-proxy hosts |
+| `SYSLOG_DOCKER_RECONNECT_INITIAL_MS` | no | `1000` | Initial reconnect delay after host stream failure |
+| `SYSLOG_DOCKER_RECONNECT_MAX_MS` | no | `30000` | Maximum reconnect delay after repeated failures |
+
+The hosts file uses this shape:
+
+```toml
+[[hosts]]
+name = "edge-host-a"
+base_url = "http://edge-host-a:2375"
+allow_insecure_http = true
+
+[[hosts]]
+name = "app-host-b"
+base_url = "http://app-host-b:2375"
+allow_insecure_http = true
+```
+
+The docker-socket-proxy side only needs read access to containers, events, ping, and version endpoints: `CONTAINERS=1`, `EVENTS=1`, `PING=1`, `VERSION=1`, `POST=0`. `CONTAINERS=1` exposes the broader read-only Docker container API to anything that can reach the proxy, so bind it only on a trusted private network, firewall it to syslog-mcp, or put it behind authenticated TLS. Plain `http://` endpoints require `allow_insecure_http = true` in the hosts file so that this trust decision is explicit.
+
 #### Storage
 
 | Variable | Required | Default | Description |
@@ -380,6 +407,7 @@ The plain JSON API is disabled by default. When enabled, it is mounted under `/a
 | `SYSLOG_UID` | no | `1000` | Container user ID for data volume ownership |
 | `SYSLOG_GID` | no | `1000` | Container group ID for data volume ownership |
 | `SYSLOG_MCP_DATA_VOLUME` | no | `syslog-mcp-data` | Docker volume name or bind-mount path |
+| `SYSLOG_MCP_CONFIG_VOLUME` | no | `./config` | Read-only config mount for optional files such as `docker-hosts.toml` |
 | `DOCKER_NETWORK` | no | `syslog-mcp` | Docker network name (must exist) |
 | `RUST_LOG` | no | `info` | Log level (`trace`, `debug`, `info`, `warn`, `error`) |
 | `TZ` | no | `UTC` | Container timezone |
@@ -410,6 +438,16 @@ host = "0.0.0.0"
 port = 3100
 server_name = "syslog-mcp"
 # api_token = "your-secret-token"
+
+[docker_ingest]
+enabled = false
+reconnect_initial_ms = 1000
+reconnect_max_ms = 30000
+
+[[docker_ingest.hosts]]
+name = "edge-host-a"
+base_url = "http://edge-host-a:2375"
+allow_insecure_http = true
 ```
 
 ---

--- a/config.toml
+++ b/config.toml
@@ -26,3 +26,8 @@ server_name = "syslog-mcp"
 # Optional extra RMCP Host/Origin allow-lists for reverse proxies.
 # allowed_hosts = ["syslog.example.com", "syslog.example.com:443"]
 # allowed_origins = ["https://syslog.example.com"]
+
+[docker_ingest]
+enabled = false
+reconnect_initial_ms = 1000
+reconnect_max_ms = 30000

--- a/config/docker-hosts.example.toml
+++ b/config/docker-hosts.example.toml
@@ -1,0 +1,9 @@
+[[hosts]]
+name = "edge-host-a"
+base_url = "http://edge-host-a:2375"
+allow_insecure_http = true
+
+[[hosts]]
+name = "app-host-b"
+base_url = "http://app-host-b:2375"
+allow_insecure_http = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,15 @@ services:
     env_file:
       - path: ~/.claude-homelab/.env
         required: false
+      - path: .env
+        required: false
     ports:
       - "${SYSLOG_PORT:-1514}:1514/udp"
       - "${SYSLOG_PORT:-1514}:1514/tcp"
       - "${SYSLOG_MCP_PORT:-3100}:3100/tcp"
     volumes:
       - ${SYSLOG_MCP_DATA_VOLUME:-syslog-mcp-data}:/data
+      - ${SYSLOG_MCP_CONFIG_VOLUME:-./config}:/config:ro
     # Needed if redirecting privileged port 514 -> 1514 inside container
     # cap_add:
     #   - NET_BIND_SERVICE

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -39,6 +39,16 @@ allowed_origins = ["https://syslog.example.com"]
 
 [api]
 enabled = false
+
+[docker_ingest]
+enabled = false
+reconnect_initial_ms = 1000
+reconnect_max_ms = 30000
+
+[[docker_ingest.hosts]]
+name = "edge-host-a"
+base_url = "http://edge-host-a:2375"
+allow_insecure_http = true
 ```
 
 Bind host fields (`SYSLOG_HOST` and `SYSLOG_MCP_HOST`) must be hostnames or IP
@@ -59,6 +69,43 @@ such as `https://syslog.example.com`.
 | `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | no | Max message size in bytes per syslog frame |
 | `SYSLOG_BATCH_SIZE` | no | `100` | no | Entries per batch flush to SQLite |
 | `SYSLOG_FLUSH_INTERVAL` | no | `500` | no | Batch flush interval in milliseconds |
+
+### Docker socket-proxy ingest (`SYSLOG_DOCKER_*`)
+
+This optional mode pulls stdout/stderr logs from remote Docker hosts through `docker-socket-proxy` instead of changing Docker's daemon-level logging driver. Containers keep their existing local logging behavior, and remote host/container startup does not depend on syslog-mcp being online.
+
+The hosts file is a TOML file with `[[hosts]]` entries:
+
+```toml
+[[hosts]]
+name = "edge-host-a"
+base_url = "http://edge-host-a:2375"
+allow_insecure_http = true
+
+[[hosts]]
+name = "app-host-b"
+base_url = "http://app-host-b:2375"
+allow_insecure_http = true
+```
+
+| Variable | Required | Default | Sensitive | Description |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_DOCKER_INGEST_ENABLED` | no | `false` | no | Enable pull-based Docker log ingestion |
+| `SYSLOG_DOCKER_HOSTS_FILE` | yes, if hosts are not configured elsewhere | (none) | no | Path to TOML hosts file |
+| `SYSLOG_DOCKER_RECONNECT_INITIAL_MS` | no | `1000` | no | Initial reconnect delay after host stream failure |
+| `SYSLOG_DOCKER_RECONNECT_MAX_MS` | no | `30000` | no | Maximum reconnect delay after repeated failures |
+
+Minimum recommended docker-socket-proxy permissions on each remote host:
+
+```env
+CONTAINERS=1
+EVENTS=1
+PING=1
+VERSION=1
+POST=0
+```
+
+`CONTAINERS=1` exposes the broader read-only Docker container API to every client that can reach docker-socket-proxy. Bind the proxy on a trusted private network, firewall it so only syslog-mcp can connect, or put it behind authenticated TLS. Hosts using plain `http://` must set `allow_insecure_http = true` in the hosts file; otherwise config validation rejects them.
 
 ### MCP server (`SYSLOG_MCP_*`)
 
@@ -113,6 +160,7 @@ The plain JSON API is disabled by default. When enabled, it is mounted under `/a
 | `SYSLOG_PORT` | no | `1514` | no | Host-side syslog port mapping |
 | `SYSLOG_MCP_PORT` | no | `3100` | no | Host-side MCP port mapping |
 | `SYSLOG_MCP_DATA_VOLUME` | no | `syslog-mcp-data` | no | Named Docker volume for `/data` |
+| `SYSLOG_MCP_CONFIG_VOLUME` | no | `./config` | no | Read-only config mount for optional files such as `docker-hosts.toml` |
 | `DOCKER_NETWORK` | no | `syslog-mcp` | no | External Docker network name |
 
 ## Storage budget behavior
@@ -136,6 +184,10 @@ Set both `max_db_size_mb` and `min_free_disk_mb` to 0 to disable all storage enf
 - `SYSLOG_API_TOKEN` is required when `SYSLOG_API_ENABLED=true`
 - Bind host fields (`SYSLOG_HOST`, `SYSLOG_MCP_HOST`) must not contain a colon (port is a separate setting)
 - `SYSLOG_MCP_ALLOWED_HOSTS` values may include `host:port` to match reverse-proxy Host headers
+- `docker_ingest.hosts` or `SYSLOG_DOCKER_HOSTS_FILE` must contain at least one host when Docker ingest is enabled
+- Docker ingest host names must be unique
+- Docker ingest host `base_url` values must start with `http://` or `https://`
+- Docker ingest `http://` hosts must set `allow_insecure_http = true`
 
 ## Plugin deployment
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -151,6 +151,46 @@ See [docs/](.) for per-host configuration:
 - **WSL hosts**: rsyslog with Tailscale IP
 - **UniFi**: Settings > System > Advanced > Remote Syslog
 - **ATT BGW-320**: Diagnostics > Syslog > Remote Syslog
+- **Docker hosts**: optional docker-socket-proxy pull mode for container stdout/stderr logs
+
+### Optional Docker host log ingest
+
+If your hosts already run `docker-socket-proxy`, syslog-mcp can pull Docker container logs from those hosts without switching the Docker daemon to the syslog logging driver.
+
+On each remote Docker host, expose only the read endpoints syslog-mcp needs:
+
+```env
+CONTAINERS=1
+EVENTS=1
+PING=1
+VERSION=1
+POST=0
+```
+
+Create a hosts file mounted into the syslog-mcp container, for example `/config/docker-hosts.toml`. You can start from `config/docker-hosts.example.toml`:
+
+```toml
+[[hosts]]
+name = "edge-host-a"
+base_url = "http://edge-host-a:2375"
+allow_insecure_http = true
+
+[[hosts]]
+name = "app-host-b"
+base_url = "http://app-host-b:2375"
+allow_insecure_http = true
+```
+
+Enable it in `.env`:
+
+```env
+SYSLOG_DOCKER_INGEST_ENABLED=true
+SYSLOG_DOCKER_HOSTS_FILE=/config/docker-hosts.toml
+```
+
+The ingest loop follows existing containers, listens for container start events, records checkpoints in SQLite, and reconnects with backoff if a host is unavailable. Remote containers still start normally if syslog-mcp is down because this path does not use Docker's daemon-level syslog logging driver.
+
+Plain `http://` docker-socket-proxy URLs require `allow_insecure_http = true`. Use that only on trusted private networks, firewall the proxy so only syslog-mcp can connect, or put the proxy behind authenticated TLS. `CONTAINERS=1` exposes Docker's broader read-only container API to anything that can reach the proxy, not just the log endpoints syslog-mcp calls.
 
 ## Troubleshooting
 

--- a/docs/mcp/ENV.md
+++ b/docs/mcp/ENV.md
@@ -51,6 +51,17 @@ syslog-mcp always runs as an HTTP daemon (it needs persistent syslog UDP/TCP lis
 | `SYSLOG_MCP_CLEANUP_INTERVAL_SECS` | no | `60` | Enforcement check interval in seconds | no |
 | `SYSLOG_MCP_CLEANUP_CHUNK_SIZE` | no | `2000` | Rows deleted per chunk (1 to 1,000,000) | no |
 
+## Docker socket-proxy ingest
+
+| Variable | Required | Default | Description | Sensitive |
+| --- | --- | --- | --- | --- |
+| `SYSLOG_DOCKER_INGEST_ENABLED` | no | `false` | Enable pull-based Docker log ingestion from remote docker-socket-proxy hosts | no |
+| `SYSLOG_DOCKER_HOSTS_FILE` | yes, if hosts are not configured elsewhere | (none) | TOML file with `[[hosts]]` entries containing `name` and `base_url` | no |
+| `SYSLOG_DOCKER_RECONNECT_INITIAL_MS` | no | `1000` | Initial reconnect delay after host stream failure | no |
+| `SYSLOG_DOCKER_RECONNECT_MAX_MS` | no | `30000` | Maximum reconnect delay after repeated failures | no |
+
+Plain `http://` hosts in the hosts file must set `allow_insecure_http = true`; use that only on trusted private networks or behind firewall/TLS controls.
+
 ## Logging
 
 | Variable | Required | Default | Description | Sensitive |
@@ -63,6 +74,7 @@ syslog-mcp always runs as an HTTP daemon (it needs persistent syslog UDP/TCP lis
 | --- | --- | --- | --- | --- |
 | `SYSLOG_UID` | no | `1000` | Container user ID | no |
 | `SYSLOG_GID` | no | `1000` | Container group ID | no |
+| `SYSLOG_MCP_CONFIG_VOLUME` | no | `./config` | Read-only config mount for optional files such as `docker-hosts.toml` | no |
 | `DOCKER_NETWORK` | no | `syslog-mcp` | External Docker network name | no |
 
 ## Token generation

--- a/docs/mcp/PUBLISH.md
+++ b/docs/mcp/PUBLISH.md
@@ -60,12 +60,12 @@ MCP Registry metadata at repo root:
   "name": "tv.tootie/syslog-mcp",
   "title": "Syslog MCP",
   "description": "Syslog receiver and MCP server for homelab log intelligence.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:0.6.0",
-      "version": "0.6.0"
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.7.0",
+      "version": "0.7.0"
     }
   ]
 }

--- a/docs/plugin/MARKETPLACES.md
+++ b/docs/plugin/MARKETPLACES.md
@@ -42,7 +42,7 @@ Registry entry in `server.json`:
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:0.6.0"
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.7.0"
     }
   ]
 }
@@ -55,7 +55,7 @@ syslog-mcp uses OCI (Docker) images as the primary distribution package, not PyP
 | Registry | Image |
 | --- | --- |
 | GHCR | `ghcr.io/jmagar/syslog-mcp:latest` |
-| GHCR (versioned) | `ghcr.io/jmagar/syslog-mcp:v0.6.0` |
+| GHCR (versioned) | `ghcr.io/jmagar/syslog-mcp:v0.7.0` |
 
 Additionally published to crates.io for `cargo install` usage.
 

--- a/docs/plugin/PLUGINS.md
+++ b/docs/plugin/PLUGINS.md
@@ -1,7 +1,7 @@
 <!--
 plugin: syslog-mcp
 surface: plugin-manifests
-version: 0.6.0
+version: 0.7.0
 author: Jacob Magar
 license: MIT
 description: Reference for syslog-mcp plugin manifests and version metadata.
@@ -27,7 +27,7 @@ All manifests must have the same `version` value.
 ```json
 {
   "name": "syslog-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Syslog management via MCP",
   "author": "jmagar",
   "repository": "https://github.com/jmagar/syslog-mcp",
@@ -78,11 +78,11 @@ MCP Registry entry with OCI package reference:
 {
   "name": "tv.tootie/syslog-mcp",
   "title": "Syslog MCP",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:0.6.0"
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.7.0"
     }
   ]
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Homelab syslog receiver and MCP server for searching, tailing, and correlating logs across hosts.",
   "mcpServers": {
     "syslog-mcp": {

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/jmagar/syslog-mcp",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.7.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:0.6.0",
-      "version": "0.6.0",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.7.0",
+      "version": "0.7.0",
       "environmentVariables": [
         {
           "name": "SYSLOG_HOST",

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -38,6 +38,7 @@ fn entry(ts: &str, host: &str, severity: &str, msg: &str, source_ip: &str) -> Lo
         message: msg.to_string(),
         raw: msg.to_string(),
         source_ip: source_ip.to_string(),
+        docker_checkpoint: None,
     }
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -23,6 +23,7 @@ fn entry(ts: &str, host: &str, severity: &str, msg: &str, source_ip: &str) -> Lo
         message: msg.to_string(),
         raw: msg.to_string(),
         source_ip: source_ip.to_string(),
+        docker_checkpoint: None,
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 const MAX_CLEANUP_CHUNK_SIZE: usize = 1_000_000;
@@ -10,6 +11,7 @@ pub struct Config {
     pub storage: StorageConfig,
     pub mcp: McpConfig,
     pub api: ApiConfig,
+    pub docker_ingest: DockerIngestConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -121,6 +123,36 @@ pub struct ApiConfig {
     pub api_token: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DockerIngestConfig {
+    /// Enable remote Docker log ingestion through docker-socket-proxy endpoints.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Remote Docker hosts to ingest from.
+    #[serde(default)]
+    pub hosts: Vec<DockerHostConfig>,
+    /// Initial reconnect backoff in milliseconds per Docker host.
+    #[serde(default = "default_docker_reconnect_initial_ms")]
+    pub reconnect_initial_ms: u64,
+    /// Maximum reconnect backoff in milliseconds per Docker host.
+    #[serde(default = "default_docker_reconnect_max_ms")]
+    pub reconnect_max_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DockerHostConfig {
+    pub name: String,
+    pub base_url: String,
+    #[serde(default)]
+    pub allow_insecure_http: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerHostsFile {
+    hosts: Vec<DockerHostConfig>,
+}
+
 // --- Defaults ---
 
 fn default_syslog_host() -> String {
@@ -183,6 +215,12 @@ fn default_true() -> bool {
 fn default_server_name() -> String {
     "syslog-mcp".into()
 }
+fn default_docker_reconnect_initial_ms() -> u64 {
+    1_000
+}
+fn default_docker_reconnect_max_ms() -> u64 {
+    30_000
+}
 
 impl Default for SyslogConfig {
     fn default() -> Self {
@@ -224,6 +262,17 @@ impl Default for McpConfig {
             api_token: None,
             allowed_hosts: Vec::new(),
             allowed_origins: Vec::new(),
+        }
+    }
+}
+
+impl Default for DockerIngestConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            hosts: Vec::new(),
+            reconnect_initial_ms: default_docker_reconnect_initial_ms(),
+            reconnect_max_ms: default_docker_reconnect_max_ms(),
         }
     }
 }
@@ -310,6 +359,32 @@ impl Config {
         env_override_bool("SYSLOG_API_ENABLED", &mut config.api.enabled)?;
         env_override_opt_str("SYSLOG_API_TOKEN", &mut config.api.api_token);
 
+        env_override_bool(
+            "SYSLOG_DOCKER_INGEST_ENABLED",
+            &mut config.docker_ingest.enabled,
+        )?;
+        env_override_parse(
+            "SYSLOG_DOCKER_RECONNECT_INITIAL_MS",
+            &mut config.docker_ingest.reconnect_initial_ms,
+        )?;
+        env_override_parse(
+            "SYSLOG_DOCKER_RECONNECT_MAX_MS",
+            &mut config.docker_ingest.reconnect_max_ms,
+        )?;
+        if config.docker_ingest.enabled {
+            if let Ok(path) = std::env::var("SYSLOG_DOCKER_HOSTS_FILE") {
+                if !path.is_empty() {
+                    let contents = std::fs::read_to_string(&path).map_err(|e| {
+                        anyhow::anyhow!("Failed to read SYSLOG_DOCKER_HOSTS_FILE={path}: {e}")
+                    })?;
+                    let parsed: DockerHostsFile = toml::from_str(&contents).map_err(|e| {
+                        anyhow::anyhow!("Failed to parse SYSLOG_DOCKER_HOSTS_FILE={path}: {e}")
+                    })?;
+                    config.docker_ingest.hosts = parsed.hosts;
+                }
+            }
+        }
+
         // Validation
         if config.storage.pool_size == 0 {
             return Err(anyhow::anyhow!("SYSLOG_MCP_POOL_SIZE must be > 0"));
@@ -318,6 +393,7 @@ impl Config {
         validate_host(&config.syslog.host)?;
         validate_host(&config.mcp.host)?;
         validate_auth_config(&config)?;
+        validate_docker_ingest_config(&config.docker_ingest)?;
 
         Ok(config)
     }
@@ -398,6 +474,52 @@ fn validate_auth_config(config: &Config) -> anyhow::Result<()> {
         }
     } else if token_is_blank(&config.api.api_token) {
         return Err(anyhow::anyhow!("api.api_token must not be empty"));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_docker_ingest_config(config: &DockerIngestConfig) -> anyhow::Result<()> {
+    if !config.enabled {
+        return Ok(());
+    }
+    if config.hosts.is_empty() {
+        return Err(anyhow::anyhow!(
+            "docker_ingest.hosts must not be empty when docker ingest is enabled"
+        ));
+    }
+    if config.reconnect_initial_ms == 0 {
+        return Err(anyhow::anyhow!(
+            "docker_ingest.reconnect_initial_ms must be > 0"
+        ));
+    }
+    if config.reconnect_max_ms < config.reconnect_initial_ms {
+        return Err(anyhow::anyhow!(
+            "docker_ingest.reconnect_max_ms must be >= reconnect_initial_ms"
+        ));
+    }
+    let mut names = HashSet::new();
+    for host in &config.hosts {
+        if host.name.trim().is_empty() {
+            return Err(anyhow::anyhow!("docker_ingest host name must not be empty"));
+        }
+        if !names.insert(host.name.as_str()) {
+            return Err(anyhow::anyhow!(
+                "duplicate docker_ingest host name: {}",
+                host.name
+            ));
+        }
+        if !(host.base_url.starts_with("http://") || host.base_url.starts_with("https://")) {
+            return Err(anyhow::anyhow!(
+                "docker_ingest host {} base_url must start with http:// or https://",
+                host.name
+            ));
+        }
+        if host.base_url.starts_with("http://") && !host.allow_insecure_http {
+            return Err(anyhow::anyhow!(
+                "docker_ingest host {} uses insecure http://; set allow_insecure_http = true only for trusted private networks",
+                host.name
+            ));
+        }
     }
     Ok(())
 }

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -85,6 +85,10 @@ fn defaults_are_applied_without_env_vars() {
         "SYSLOG_MCP_CLEANUP_CHUNK_SIZE",
         "SYSLOG_API_ENABLED",
         "SYSLOG_API_TOKEN",
+        "SYSLOG_DOCKER_INGEST_ENABLED",
+        "SYSLOG_DOCKER_HOSTS_FILE",
+        "SYSLOG_DOCKER_RECONNECT_INITIAL_MS",
+        "SYSLOG_DOCKER_RECONNECT_MAX_MS",
     ] {
         std::env::remove_var(key);
     }
@@ -110,6 +114,10 @@ fn defaults_are_applied_without_env_vars() {
     assert!(cfg.mcp.api_token.is_none());
     assert!(!cfg.api.enabled);
     assert!(cfg.api.api_token.is_none());
+    assert!(!cfg.docker_ingest.enabled);
+    assert!(cfg.docker_ingest.hosts.is_empty());
+    assert_eq!(cfg.docker_ingest.reconnect_initial_ms, 1_000);
+    assert_eq!(cfg.docker_ingest.reconnect_max_ms, 30_000);
 }
 
 #[test]
@@ -343,4 +351,136 @@ fn accepts_cleanup_chunk_size_at_max() {
 
     let cfg = result.expect("cleanup_chunk_size == 1_000_000 should be accepted");
     assert_eq!(cfg.storage.cleanup_chunk_size, 1_000_000);
+}
+
+#[test]
+fn docker_ingest_toml_hosts_parse() {
+    let raw = r#"
+        [docker_ingest]
+        enabled = true
+        reconnect_initial_ms = 250
+        reconnect_max_ms = 10000
+        [[docker_ingest.hosts]]
+        name = "edge-host-a"
+        base_url = "http://edge-host-a:2375"
+        allow_insecure_http = true
+
+        [[docker_ingest.hosts]]
+        name = "app-host-b"
+        base_url = "http://app-host-b:2375"
+        allow_insecure_http = true
+    "#;
+
+    let config: Config = toml::from_str(raw).unwrap();
+    assert!(config.docker_ingest.enabled);
+    assert_eq!(config.docker_ingest.hosts.len(), 2);
+    assert_eq!(config.docker_ingest.hosts[0].name, "edge-host-a");
+    assert_eq!(
+        config.docker_ingest.hosts[0].base_url,
+        "http://edge-host-a:2375"
+    );
+    assert_eq!(config.docker_ingest.hosts[1].name, "app-host-b");
+    assert_eq!(
+        config.docker_ingest.hosts[1].base_url,
+        "http://app-host-b:2375"
+    );
+}
+
+#[test]
+fn docker_ingest_requires_hosts_when_enabled() {
+    let mut config = DockerIngestConfig {
+        enabled: true,
+        ..Default::default()
+    };
+    config.hosts.clear();
+
+    let err = validate_docker_ingest_config(&config).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("docker_ingest.hosts must not be empty"));
+}
+
+#[test]
+fn docker_ingest_rejects_duplicate_host_names() {
+    let config = DockerIngestConfig {
+        enabled: true,
+        hosts: vec![
+            DockerHostConfig {
+                name: "edge-host-a".into(),
+                base_url: "http://edge-host-a:2375".into(),
+                allow_insecure_http: true,
+            },
+            DockerHostConfig {
+                name: "edge-host-a".into(),
+                base_url: "http://10.0.0.10:2375".into(),
+                allow_insecure_http: true,
+            },
+        ],
+        ..Default::default()
+    };
+
+    let err = validate_docker_ingest_config(&config).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("duplicate docker_ingest host name"));
+}
+
+#[test]
+#[serial]
+fn docker_ingest_loads_hosts_file_from_env() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("docker-hosts.toml");
+    std::fs::write(
+        &path,
+        r#"
+            [[hosts]]
+            name = "edge-host-a"
+            base_url = "http://edge-host-a:2375"
+            allow_insecure_http = true
+        "#,
+    )
+    .unwrap();
+
+    std::env::set_var("SYSLOG_DOCKER_INGEST_ENABLED", "true");
+    std::env::set_var("SYSLOG_DOCKER_HOSTS_FILE", &path);
+    let result = Config::load();
+    std::env::remove_var("SYSLOG_DOCKER_INGEST_ENABLED");
+    std::env::remove_var("SYSLOG_DOCKER_HOSTS_FILE");
+
+    let config = result.expect("Config::load should parse docker host file");
+    assert!(config.docker_ingest.enabled);
+    assert_eq!(config.docker_ingest.hosts.len(), 1);
+    assert_eq!(config.docker_ingest.hosts[0].name, "edge-host-a");
+}
+
+#[test]
+#[serial]
+fn docker_ingest_ignores_hosts_file_when_disabled() {
+    std::env::set_var("SYSLOG_DOCKER_INGEST_ENABLED", "false");
+    std::env::set_var(
+        "SYSLOG_DOCKER_HOSTS_FILE",
+        "/tmp/syslog-mcp-missing-docker-hosts.toml",
+    );
+    let result = Config::load();
+    std::env::remove_var("SYSLOG_DOCKER_INGEST_ENABLED");
+    std::env::remove_var("SYSLOG_DOCKER_HOSTS_FILE");
+
+    let config = result.expect("disabled Docker ingest should ignore stale hosts file env");
+    assert!(!config.docker_ingest.enabled);
+}
+
+#[test]
+fn docker_ingest_rejects_insecure_http_without_explicit_opt_in() {
+    let config = DockerIngestConfig {
+        enabled: true,
+        hosts: vec![DockerHostConfig {
+            name: "edge-host-a".into(),
+            base_url: "http://edge-host-a:2375".into(),
+            allow_insecure_http: false,
+        }],
+        ..Default::default()
+    };
+
+    let err = validate_docker_ingest_config(&config).unwrap_err();
+    assert!(err.to_string().contains("allow_insecure_http"));
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -10,7 +10,9 @@ pub use ingest::insert_logs_batch;
 pub use maintenance::{
     enforce_storage_budget, get_storage_metrics, purge_old_logs, DiskSpaceProbe,
 };
-pub use models::{DbStats, ErrorSummaryEntry, HostEntry, LogBatchEntry, LogEntry, SearchParams};
+pub use models::{
+    DbStats, DockerCheckpoint, ErrorSummaryEntry, HostEntry, LogBatchEntry, LogEntry, SearchParams,
+};
 pub use models::{StorageBudgetState, StorageEnforcementOutcome, StorageMetrics, StorageRecovery};
 pub use pool::{init_pool, DbPool};
 pub use queries::{

--- a/src/db/ingest.rs
+++ b/src/db/ingest.rs
@@ -70,9 +70,29 @@ fn insert_logs_batch_once(pool: &DbPool, entries: &[LogBatchEntry]) -> Result<us
         for (hostname, count) in &host_counts {
             host_stmt.execute(params![hostname, count])?;
         }
+        let mut checkpoint_stmt = tx.prepare_cached(
+            "INSERT INTO docker_ingest_checkpoints (host_name, container_id, last_timestamp)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(host_name, container_id) DO UPDATE SET
+                 last_timestamp = excluded.last_timestamp,
+                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+        )?;
+        let mut checkpoint_count = 0usize;
+        for entry in entries {
+            if let Some(checkpoint) = &entry.docker_checkpoint {
+                checkpoint_stmt.execute(params![
+                    checkpoint.host_name,
+                    checkpoint.container_id,
+                    checkpoint.timestamp
+                ])?;
+                checkpoint_count += 1;
+            }
+        }
+
         tracing::debug!(
             entry_count = entries.len(),
             unique_hosts = host_counts.len(),
+            checkpoint_count,
             "Prepared batch insert transaction"
         );
     }

--- a/src/db/ingest_tests.rs
+++ b/src/db/ingest_tests.rs
@@ -26,6 +26,7 @@ fn make_entry(ts: &str, host: &str, severity: &str, msg: &str) -> LogBatchEntry 
         message: msg.to_string(),
         raw: msg.to_string(),
         source_ip: "127.0.0.1:514".to_string(),
+        docker_checkpoint: None,
     }
 }
 

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -29,6 +29,7 @@ fn make_entry(ts: &str, host: &str, severity: &str, msg: &str) -> LogBatchEntry 
         message: msg.to_string(),
         raw: msg.to_string(),
         source_ip: "127.0.0.1:514".to_string(),
+        docker_checkpoint: None,
     }
 }
 

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -5,10 +5,9 @@ use serde::{Deserialize, Serialize};
 /// Replaces the former 8-tuple type alias; named fields prevent silent data corruption
 /// from positional swaps between structurally identical `String`/`Option<String>` fields.
 ///
-/// `source_ip` records the actual network sender address (IP:port) independent of the
-/// hostname claimed in the syslog message body. Any LAN host can UDP-spoof an arbitrary
-/// hostname, so `source_ip` is the only trustworthy network identity for a log entry.
-/// Log content (hostname, message, app_name) is untrusted user-controlled data.
+/// For syslog input, `source_ip` records the actual network sender address (IP:port)
+/// independent of the hostname claimed in the syslog message body. Docker ingest uses
+/// a configured `docker://host/container/stream` source identifier instead.
 #[derive(Debug, Clone)]
 pub struct LogBatchEntry {
     pub timestamp: String,
@@ -19,9 +18,17 @@ pub struct LogBatchEntry {
     pub process_id: Option<String>,
     pub message: String,
     pub raw: String,
-    /// Actual network sender address (IP:port). Separate from the claimed hostname
-    /// in the syslog message, which can be spoofed by any LAN device.
+    /// Source identifier. Syslog input uses the actual network sender address
+    /// (IP:port); Docker ingest uses docker://host/container/stream.
     pub source_ip: String,
+    pub docker_checkpoint: Option<DockerCheckpoint>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DockerCheckpoint {
+    pub host_name: String,
+    pub container_id: String,
+    pub timestamp: String,
 }
 
 /// Error/warning summary entry (one row per hostname+severity)
@@ -102,9 +109,9 @@ pub struct LogEntry {
     pub process_id: Option<String>,
     pub message: String,
     pub received_at: String,
-    /// Actual network sender address (IP:port). Separate from the claimed hostname,
-    /// which can be spoofed by any LAN device via UDP. Empty string for legacy rows
-    /// inserted before this column was added.
+    /// Source identifier. Syslog entries use verified network sender address
+    /// (IP:port); Docker ingest entries use docker://host/container/stream.
+    /// Empty string for legacy rows inserted before this column was added.
     pub source_ip: String,
 }
 
@@ -115,7 +122,8 @@ pub struct SearchParams {
     pub query: Option<String>,
     /// Filter by hostname
     pub hostname: Option<String>,
-    /// Filter by verified network sender address (IP:port)
+    /// Filter by source identifier. Syslog uses verified network sender address
+    /// (IP:port); Docker ingest uses docker://host/container/stream.
     pub source_ip: Option<String>,
     /// Filter by severity (exact match: emerg, alert, crit, err, warning, notice, info, debug)
     pub severity: Option<String>,

--- a/src/db/models_tests.rs
+++ b/src/db/models_tests.rs
@@ -12,6 +12,7 @@ fn log_batch_entry_keeps_claimed_hostname_separate_from_source_ip() {
         message: "message".to_string(),
         raw: "raw".to_string(),
         source_ip: "192.0.2.10:514".to_string(),
+        docker_checkpoint: None,
     };
 
     assert_eq!(entry.hostname, "claimed-host");

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -2,10 +2,17 @@ use anyhow::Result;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::Connection;
+use scheduled_thread_pool::ScheduledThreadPool;
+use std::sync::{Arc, OnceLock};
 
 use crate::config::StorageConfig;
 
 pub type DbPool = Pool<SqliteConnectionManager>;
+
+fn shared_scheduled_thread_pool() -> Arc<ScheduledThreadPool> {
+    static POOL: OnceLock<Arc<ScheduledThreadPool>> = OnceLock::new();
+    Arc::clone(POOL.get_or_init(|| Arc::new(ScheduledThreadPool::new(1))))
+}
 
 /// Initialize the database pool and schema
 pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
@@ -17,7 +24,10 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
     let wal_mode = config.wal_mode;
     let manager = SqliteConnectionManager::file(&config.db_path)
         .with_init(move |conn| configure_connection_pragmas(conn, wal_mode));
-    let pool = Pool::builder().max_size(config.pool_size).build(manager)?;
+    let pool = Pool::builder()
+        .max_size(config.pool_size)
+        .thread_pool(shared_scheduled_thread_pool())
+        .build(manager)?;
 
     // Initialize schema
     let conn = pool.get()?;
@@ -129,6 +139,31 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
              INSERT INTO schema_migrations (version) VALUES (1);",
         )?;
         tracing::info!("Migration 1: dropped FTS5 DELETE/UPDATE triggers");
+    }
+
+    // Migration 2: store per Docker host/container checkpoints for optional
+    // docker-socket-proxy log ingestion. This lets short syslog-mcp outages
+    // replay from Docker's local log store with /containers/{id}/logs?since=.
+    let migration_2_applied: bool = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_migrations WHERE version = 2",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+        > 0;
+    if !migration_2_applied {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS docker_ingest_checkpoints (
+                 host_name      TEXT NOT NULL,
+                 container_id   TEXT NOT NULL,
+                 last_timestamp TEXT NOT NULL,
+                 updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 PRIMARY KEY (host_name, container_id)
+             );
+             INSERT INTO schema_migrations (version) VALUES (2);",
+        )?;
+        tracing::info!("Migration 2: created docker_ingest_checkpoints table");
     }
 
     tracing::info!(path = %config.db_path.display(), "Database initialized");

--- a/src/db/queries_tests.rs
+++ b/src/db/queries_tests.rs
@@ -26,6 +26,7 @@ fn make_entry(ts: &str, host: &str, severity: &str, msg: &str) -> LogBatchEntry 
         message: msg.to_string(),
         raw: msg.to_string(),
         source_ip: "127.0.0.1:514".to_string(),
+        docker_checkpoint: None,
     }
 }
 

--- a/src/docker_ingest.rs
+++ b/src/docker_ingest.rs
@@ -1,0 +1,7 @@
+mod checkpoint;
+mod client;
+mod models;
+mod parser;
+mod supervisor;
+
+pub(crate) use supervisor::spawn_all;

--- a/src/docker_ingest/checkpoint.rs
+++ b/src/docker_ingest/checkpoint.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use rusqlite::{params, OptionalExtension};
+
+use crate::db::DbPool;
+
+pub(super) fn load_checkpoint(
+    pool: &Arc<DbPool>,
+    host_name: &str,
+    container_id: &str,
+) -> Result<Option<String>> {
+    let conn = pool.get()?;
+    let value = conn
+        .query_row(
+            "SELECT last_timestamp
+             FROM docker_ingest_checkpoints
+             WHERE host_name = ?1 AND container_id = ?2",
+            params![host_name, container_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(value)
+}
+
+#[cfg(test)]
+#[path = "checkpoint_tests.rs"]
+mod tests;

--- a/src/docker_ingest/checkpoint_tests.rs
+++ b/src/docker_ingest/checkpoint_tests.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use crate::config::StorageConfig;
+use crate::db::{self, LogBatchEntry};
+
+use super::*;
+
+fn test_pool() -> (Arc<db::DbPool>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = StorageConfig::for_test(dir.path().join("docker-checkpoint.db"));
+    (Arc::new(db::init_pool(&storage).unwrap()), dir)
+}
+
+#[test]
+fn checkpoint_round_trip() {
+    let (pool, _dir) = test_pool();
+    db::insert_logs_batch(
+        &pool,
+        &[entry_with_checkpoint(
+            "edge-host-a",
+            "abc123",
+            "2026-05-05T01:02:03.456789Z",
+        )],
+    )
+    .unwrap();
+    let loaded = load_checkpoint(&pool, "edge-host-a", "abc123").unwrap();
+    assert_eq!(loaded.as_deref(), Some("2026-05-05T01:02:03.456789Z"));
+}
+
+#[test]
+fn checkpoint_is_scoped_by_host_and_container() {
+    let (pool, _dir) = test_pool();
+    db::insert_logs_batch(
+        &pool,
+        &[entry_with_checkpoint(
+            "edge-host-a",
+            "abc123",
+            "2026-05-05T01:02:03Z",
+        )],
+    )
+    .unwrap();
+    assert_eq!(
+        load_checkpoint(&pool, "app-host-b", "abc123").unwrap(),
+        None
+    );
+    assert_eq!(
+        load_checkpoint(&pool, "edge-host-a", "def456").unwrap(),
+        None
+    );
+}
+
+fn entry_with_checkpoint(host_name: &str, container_id: &str, timestamp: &str) -> LogBatchEntry {
+    LogBatchEntry {
+        timestamp: timestamp.into(),
+        hostname: host_name.into(),
+        facility: Some("local0".into()),
+        severity: "info".into(),
+        app_name: Some("docker-test".into()),
+        process_id: Some(container_id.chars().take(12).collect()),
+        message: "checkpointed".into(),
+        raw: format!("{timestamp} checkpointed"),
+        source_ip: format!("docker://{host_name}/{container_id}/stdout"),
+        docker_checkpoint: Some(db::DockerCheckpoint {
+            host_name: host_name.into(),
+            container_id: container_id.into(),
+            timestamp: timestamp.into(),
+        }),
+    }
+}

--- a/src/docker_ingest/client.rs
+++ b/src/docker_ingest/client.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use bollard::query_parameters::{
+    EventsOptions, EventsOptionsBuilder, ListContainersOptionsBuilder, LogsOptions,
+    LogsOptionsBuilder,
+};
+use bollard::Docker;
+
+use super::models::ContainerMeta;
+
+#[derive(Clone)]
+pub(super) struct DockerHostClient {
+    docker: Docker,
+}
+
+impl DockerHostClient {
+    pub(super) fn connect(base_url: &str) -> Result<Self> {
+        let docker = Docker::connect_with_http(base_url, 120, bollard::API_DEFAULT_VERSION)?;
+        Ok(Self { docker })
+    }
+
+    pub(super) async fn list_containers(&self) -> Result<Vec<ContainerMeta>> {
+        let options = ListContainersOptionsBuilder::default().all(true).build();
+        let containers = self.docker.list_containers(Some(options)).await?;
+        Ok(containers
+            .into_iter()
+            .filter_map(ContainerMeta::from_summary)
+            .collect())
+    }
+
+    pub(super) fn logs_options(since_unix: i64) -> LogsOptions {
+        LogsOptionsBuilder::default()
+            .stdout(true)
+            .stderr(true)
+            .timestamps(true)
+            .follow(true)
+            .since(since_unix.clamp(0, i32::MAX as i64) as i32)
+            .tail("all")
+            .build()
+    }
+
+    pub(super) fn container_events_options(since_unix: i64) -> EventsOptions {
+        let mut filters: HashMap<String, Vec<String>> = HashMap::new();
+        filters.insert("type".to_string(), vec!["container".to_string()]);
+        EventsOptionsBuilder::default()
+            .filters(&filters)
+            .since(&since_unix.max(0).to_string())
+            .build()
+    }
+
+    pub(super) fn docker(&self) -> Docker {
+        self.docker.clone()
+    }
+}

--- a/src/docker_ingest/models.rs
+++ b/src/docker_ingest/models.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ContainerMeta {
+    pub id: String,
+    pub name: String,
+    pub image: String,
+    pub compose_project: Option<String>,
+    pub compose_service: Option<String>,
+}
+
+impl ContainerMeta {
+    pub(super) fn from_summary(summary: bollard::models::ContainerSummary) -> Option<Self> {
+        let id = summary.id?;
+        let name = summary
+            .names
+            .and_then(|names| names.into_iter().next())
+            .map(|name| name.trim_start_matches('/').to_string())
+            .unwrap_or_else(|| id.chars().take(12).collect());
+        let labels: HashMap<String, String> = summary.labels.unwrap_or_default();
+        Some(Self {
+            id,
+            name,
+            image: summary.image.unwrap_or_default(),
+            compose_project: labels.get("com.docker.compose.project").cloned(),
+            compose_service: labels.get("com.docker.compose.service").cloned(),
+        })
+    }
+
+    pub(super) fn app_name(&self) -> String {
+        match (&self.compose_project, &self.compose_service) {
+            (Some(project), Some(service)) => format!("{project}/{service}/{}", self.name),
+            (_, Some(service)) => format!("{service}/{}", self.name),
+            _ => self.name.clone(),
+        }
+    }
+
+    pub(super) fn short_id(&self) -> String {
+        self.id.chars().take(12).collect()
+    }
+}

--- a/src/docker_ingest/parser.rs
+++ b/src/docker_ingest/parser.rs
@@ -1,0 +1,57 @@
+use anyhow::Result;
+use bollard::container::LogOutput;
+
+use crate::db;
+
+use super::models::ContainerMeta;
+
+pub(super) fn log_output_to_entry(
+    host_name: &str,
+    container: &ContainerMeta,
+    output: LogOutput,
+) -> Result<Option<db::LogBatchEntry>> {
+    let (stream, severity, bytes) = match output {
+        LogOutput::StdOut { message } => ("stdout", "info", message),
+        LogOutput::StdErr { message } => ("stderr", "warning", message),
+        _ => return Ok(None),
+    };
+
+    let raw_line = String::from_utf8_lossy(&bytes)
+        .trim_end_matches(['\r', '\n'])
+        .to_string();
+    if raw_line.is_empty() {
+        return Ok(None);
+    }
+
+    let (timestamp, message) = split_docker_timestamp(&raw_line);
+    let checkpoint_timestamp = timestamp.clone();
+    Ok(Some(db::LogBatchEntry {
+        timestamp,
+        hostname: host_name.to_string(),
+        facility: Some("local0".to_string()),
+        severity: severity.to_string(),
+        app_name: Some(container.app_name()),
+        process_id: Some(container.short_id()),
+        message,
+        raw: raw_line,
+        source_ip: format!("docker://{}/{}/{}", host_name, container.id, stream),
+        docker_checkpoint: Some(db::DockerCheckpoint {
+            host_name: host_name.to_string(),
+            container_id: container.id.clone(),
+            timestamp: checkpoint_timestamp,
+        }),
+    }))
+}
+
+fn split_docker_timestamp(raw: &str) -> (String, String) {
+    match raw.split_once(' ') {
+        Some((ts, rest)) if chrono::DateTime::parse_from_rfc3339(ts).is_ok() => {
+            (ts.to_string(), rest.to_string())
+        }
+        _ => (chrono::Utc::now().to_rfc3339(), raw.to_string()),
+    }
+}
+
+#[cfg(test)]
+#[path = "parser_tests.rs"]
+mod tests;

--- a/src/docker_ingest/parser_tests.rs
+++ b/src/docker_ingest/parser_tests.rs
@@ -1,0 +1,73 @@
+use bollard::container::LogOutput;
+use bytes::Bytes;
+
+use super::*;
+use crate::docker_ingest::models::ContainerMeta;
+
+fn meta() -> ContainerMeta {
+    ContainerMeta {
+        id: "abcdef1234567890".into(),
+        name: "nginx-1".into(),
+        image: "nginx:latest".into(),
+        compose_project: Some("edge".into()),
+        compose_service: Some("nginx".into()),
+    }
+}
+
+#[test]
+fn stdout_frame_maps_to_info_log_entry() {
+    let entry = log_output_to_entry(
+        "edge-host-a",
+        &meta(),
+        LogOutput::StdOut {
+            message: Bytes::from_static(b"2026-05-05T01:02:03.123456789Z started nginx\n"),
+        },
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(entry.timestamp, "2026-05-05T01:02:03.123456789Z");
+    assert_eq!(entry.hostname, "edge-host-a");
+    assert_eq!(entry.facility.as_deref(), Some("local0"));
+    assert_eq!(entry.severity, "info");
+    assert_eq!(entry.app_name.as_deref(), Some("edge/nginx/nginx-1"));
+    assert_eq!(entry.process_id.as_deref(), Some("abcdef123456"));
+    assert_eq!(entry.message, "started nginx");
+    assert_eq!(
+        entry.source_ip,
+        "docker://edge-host-a/abcdef1234567890/stdout"
+    );
+}
+
+#[test]
+fn stderr_frame_maps_to_warning_log_entry() {
+    let entry = log_output_to_entry(
+        "app-host-b",
+        &meta(),
+        LogOutput::StdErr {
+            message: Bytes::from_static(b"2026-05-05T01:02:04Z failed health check\n"),
+        },
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(entry.severity, "warning");
+    assert_eq!(entry.message, "failed health check");
+    assert_eq!(
+        entry.source_ip,
+        "docker://app-host-b/abcdef1234567890/stderr"
+    );
+}
+
+#[test]
+fn non_output_frames_are_ignored() {
+    let entry = log_output_to_entry(
+        "edge-host-a",
+        &meta(),
+        LogOutput::Console {
+            message: Bytes::from_static(b"ignored\n"),
+        },
+    )
+    .unwrap();
+    assert!(entry.is_none());
+}

--- a/src/docker_ingest/supervisor.rs
+++ b/src/docker_ingest/supervisor.rs
@@ -1,0 +1,327 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use futures_util::StreamExt;
+use tokio::task::JoinHandle;
+
+use crate::config::{DockerHostConfig, DockerIngestConfig};
+use crate::db::DbPool;
+use crate::ingest::IngestTx;
+
+use super::checkpoint::load_checkpoint;
+use super::client::DockerHostClient;
+use super::models::ContainerMeta;
+use super::parser::log_output_to_entry;
+
+pub(crate) fn spawn_all(
+    config: DockerIngestConfig,
+    pool: Arc<DbPool>,
+    ingest: IngestTx,
+) -> Vec<JoinHandle<()>> {
+    if !config.enabled {
+        return Vec::new();
+    }
+
+    config
+        .hosts
+        .clone()
+        .into_iter()
+        .map(|host| {
+            let config = config.clone();
+            let pool = Arc::clone(&pool);
+            let ingest = ingest.clone();
+            tokio::spawn(async move {
+                run_host_forever(config, host, pool, ingest).await;
+            })
+        })
+        .collect()
+}
+
+async fn run_host_forever(
+    config: DockerIngestConfig,
+    host: DockerHostConfig,
+    pool: Arc<DbPool>,
+    ingest: IngestTx,
+) {
+    let mut delay_ms = config.reconnect_initial_ms;
+    loop {
+        let reset_backoff = match run_host_once(&config, &host, Arc::clone(&pool), ingest.clone())
+            .await
+        {
+            Ok(()) => {
+                tracing::warn!(host = %host.name, "Docker ingest host stream ended; reconnecting");
+                true
+            }
+            Err(e) => {
+                tracing::warn!(
+                    host = %host.name,
+                    error = %e,
+                    delay_ms,
+                    "Docker ingest host failed; retrying"
+                );
+                false
+            }
+        };
+        tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+        delay_ms = if reset_backoff {
+            config.reconnect_initial_ms
+        } else {
+            (delay_ms * 2).min(config.reconnect_max_ms)
+        };
+    }
+}
+
+async fn run_host_once(
+    config: &DockerIngestConfig,
+    host: &DockerHostConfig,
+    pool: Arc<DbPool>,
+    ingest: IngestTx,
+) -> Result<()> {
+    let event_since_unix = chrono::Utc::now().timestamp().saturating_sub(60);
+    let client = DockerHostClient::connect(&host.base_url)?;
+    let containers = client.list_containers().await?;
+    tracing::info!(
+        host = %host.name,
+        container_count = containers.len(),
+        "Docker ingest discovered containers"
+    );
+
+    let mut log_tasks: HashMap<String, JoinHandle<()>> = HashMap::new();
+    for container in containers {
+        spawn_log_task_if_absent(
+            config,
+            host,
+            &client,
+            Arc::clone(&pool),
+            ingest.clone(),
+            &mut log_tasks,
+            container,
+        );
+    }
+
+    let result = follow_container_events(
+        config,
+        host,
+        &client,
+        pool,
+        ingest,
+        &mut log_tasks,
+        event_since_unix,
+    )
+    .await;
+    for handle in log_tasks.into_values() {
+        handle.abort();
+    }
+    result
+}
+
+async fn follow_container_events(
+    config: &DockerIngestConfig,
+    host: &DockerHostConfig,
+    client: &DockerHostClient,
+    pool: Arc<DbPool>,
+    ingest: IngestTx,
+    log_tasks: &mut HashMap<String, JoinHandle<()>>,
+    event_since_unix: i64,
+) -> Result<()> {
+    let docker = client.docker();
+    let mut events = docker.events(Some(DockerHostClient::container_events_options(
+        event_since_unix,
+    )));
+    while let Some(event) = events.next().await {
+        let event = event?;
+        let action = event.action.unwrap_or_default();
+        let Some(actor) = event.actor else {
+            continue;
+        };
+        let Some(id) = actor.id else {
+            continue;
+        };
+
+        match action.as_str() {
+            "start" | "restart" | "rename" => {
+                prune_finished_tasks(log_tasks);
+                if action == "rename" {
+                    if let Some(handle) = log_tasks.remove(&id) {
+                        handle.abort();
+                    }
+                }
+                let containers = client.list_containers().await?;
+                for container in containers.into_iter().filter(|c| c.id == id) {
+                    spawn_log_task_if_absent(
+                        config,
+                        host,
+                        client,
+                        Arc::clone(&pool),
+                        ingest.clone(),
+                        log_tasks,
+                        container,
+                    );
+                }
+            }
+            "die" | "destroy" | "stop" => {
+                if let Some(handle) = log_tasks.remove(&id) {
+                    handle.abort();
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn prune_finished_tasks(tasks: &mut HashMap<String, JoinHandle<()>>) {
+    tasks.retain(|_, handle| !handle.is_finished());
+}
+
+fn spawn_log_task_if_absent(
+    config: &DockerIngestConfig,
+    host: &DockerHostConfig,
+    client: &DockerHostClient,
+    pool: Arc<DbPool>,
+    ingest: IngestTx,
+    tasks: &mut HashMap<String, JoinHandle<()>>,
+    container: ContainerMeta,
+) {
+    if tasks.contains_key(&container.id) {
+        return;
+    }
+    let docker = client.docker();
+    let host_name = host.name.clone();
+    let reconnect_initial_ms = config.reconnect_initial_ms;
+    let reconnect_max_ms = config.reconnect_max_ms;
+    let container_id = container.id.clone();
+    let task_container_id = container_id.clone();
+    let handle = tokio::spawn(async move {
+        let mut delay_ms = reconnect_initial_ms;
+        loop {
+            match follow_container_logs_once(
+                &docker,
+                &pool,
+                &ingest,
+                &host_name,
+                &task_container_id,
+                &container,
+            )
+            .await
+            {
+                Ok(()) => tracing::warn!(
+                    host = %host_name,
+                    container_id = %task_container_id,
+                    delay_ms,
+                    "Docker log stream ended; reconnecting"
+                ),
+                Err(e) => tracing::warn!(
+                    host = %host_name,
+                    container_id = %task_container_id,
+                    error = %e,
+                    delay_ms,
+                    "Docker log stream failed; retrying"
+                ),
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+            delay_ms = (delay_ms * 2).min(reconnect_max_ms);
+        }
+    });
+    tasks.insert(container_id, handle);
+}
+
+async fn follow_container_logs_once(
+    docker: &bollard::Docker,
+    pool: &Arc<DbPool>,
+    ingest: &IngestTx,
+    host_name: &str,
+    container_id: &str,
+    container: &ContainerMeta,
+) -> Result<()> {
+    let checkpoint = load_checkpoint(pool, host_name, container_id)?
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(&ts).ok());
+    let since_unix = checkpoint.map(|dt| dt.timestamp()).unwrap_or(0);
+    let mut logs = docker.logs(
+        container_id,
+        Some(DockerHostClient::logs_options(since_unix)),
+    );
+
+    while let Some(output) = logs.next().await {
+        match log_output_to_entry(host_name, container, output?) {
+            Ok(Some(entry)) => {
+                if checkpoint
+                    .as_ref()
+                    .is_some_and(|checkpoint| entry_is_at_or_before_checkpoint(&entry, checkpoint))
+                {
+                    continue;
+                }
+                if ingest.send(entry).await.is_err() {
+                    anyhow::bail!("Docker ingest channel closed");
+                }
+            }
+            Ok(None) => {}
+            Err(e) => tracing::warn!(
+                host = %host_name,
+                container_id = %container_id,
+                error = %e,
+                "Failed to parse Docker log frame"
+            ),
+        }
+    }
+    Ok(())
+}
+
+fn entry_is_at_or_before_checkpoint(
+    entry: &crate::db::LogBatchEntry,
+    checkpoint: &chrono::DateTime<chrono::FixedOffset>,
+) -> bool {
+    entry
+        .docker_checkpoint
+        .as_ref()
+        .and_then(|docker_checkpoint| {
+            chrono::DateTime::parse_from_rfc3339(&docker_checkpoint.timestamp).ok()
+        })
+        .is_some_and(|entry_ts| entry_ts <= *checkpoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::{DockerCheckpoint, LogBatchEntry};
+
+    use super::entry_is_at_or_before_checkpoint;
+
+    fn docker_entry(timestamp: &str) -> LogBatchEntry {
+        LogBatchEntry {
+            timestamp: timestamp.into(),
+            hostname: "edge-host-a".into(),
+            facility: Some("local0".into()),
+            severity: "info".into(),
+            app_name: Some("nginx".into()),
+            process_id: Some("abcdef123456".into()),
+            message: "line".into(),
+            raw: format!("{timestamp} line"),
+            source_ip: "docker://edge-host-a/abcdef123456/stdout".into(),
+            docker_checkpoint: Some(DockerCheckpoint {
+                host_name: "edge-host-a".into(),
+                container_id: "abcdef123456".into(),
+                timestamp: timestamp.into(),
+            }),
+        }
+    }
+
+    #[test]
+    fn checkpoint_filter_skips_only_entries_at_or_before_precise_checkpoint() {
+        let checkpoint =
+            chrono::DateTime::parse_from_rfc3339("2026-05-05T01:02:03.500000000Z").unwrap();
+
+        assert!(entry_is_at_or_before_checkpoint(
+            &docker_entry("2026-05-05T01:02:03.123456789Z"),
+            &checkpoint
+        ));
+        assert!(entry_is_at_or_before_checkpoint(
+            &docker_entry("2026-05-05T01:02:03.500000000Z"),
+            &checkpoint
+        ));
+        assert!(!entry_is_at_or_before_checkpoint(
+            &docker_entry("2026-05-05T01:02:03.500000001Z"),
+            &checkpoint
+        ));
+    }
+}

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,0 +1,64 @@
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
+
+use crate::config::{StorageConfig, SyslogConfig};
+use crate::db::{self, DbPool};
+use crate::syslog;
+
+pub const WRITE_CHANNEL_CAPACITY: usize = 10_000;
+
+#[derive(Clone)]
+pub(crate) struct IngestTx {
+    tx: mpsc::Sender<db::LogBatchEntry>,
+}
+
+impl IngestTx {
+    pub(crate) async fn send(
+        &self,
+        entry: db::LogBatchEntry,
+    ) -> Result<(), mpsc::error::SendError<db::LogBatchEntry>> {
+        self.tx.send(entry).await
+    }
+
+    pub(crate) fn sender(&self) -> mpsc::Sender<db::LogBatchEntry> {
+        self.tx.clone()
+    }
+}
+
+pub(crate) fn start_writer(
+    storage: StorageConfig,
+    pool: Arc<DbPool>,
+    storage_state: Arc<Mutex<Option<db::StorageBudgetState>>>,
+    batch_size: usize,
+    flush_interval_ms: u64,
+) -> IngestTx {
+    let (tx, rx) = mpsc::channel::<db::LogBatchEntry>(WRITE_CHANNEL_CAPACITY);
+    tokio::spawn(async move {
+        syslog::writer::batch_writer(
+            rx,
+            pool,
+            storage,
+            storage_state,
+            batch_size,
+            tokio::time::Duration::from_millis(flush_interval_ms),
+        )
+        .await;
+    });
+    IngestTx { tx }
+}
+
+pub(crate) fn start_writer_from_syslog_config(
+    syslog: &SyslogConfig,
+    storage: StorageConfig,
+    pool: Arc<DbPool>,
+    storage_state: Arc<Mutex<Option<db::StorageBudgetState>>>,
+) -> IngestTx {
+    start_writer(
+        storage,
+        pool,
+        storage_state,
+        syslog.batch_size,
+        syslog.flush_interval,
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,5 @@ pub mod runtime;
 pub mod syslog;
 
 pub(crate) mod db;
+pub(crate) mod docker_ingest;
+pub(crate) mod ingest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ async fn main() -> Result<()> {
         wal_mode = runtime.config.storage.wal_mode,
         mcp_auth_enabled = runtime.config.mcp.api_token.is_some(),
         api_enabled = runtime.config.api.enabled,
+        docker_ingest_enabled = runtime.config.docker_ingest.enabled,
+        docker_ingest_hosts = runtime.config.docker_ingest.hosts.len(),
         "Configuration loaded"
     );
 

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -46,6 +46,7 @@ fn entry(ts: &str, host: &str, severity: &str, msg: &str, source_ip: &str) -> Lo
         message: msg.to_string(),
         raw: msg.to_string(),
         source_ip: source_ip.to_string(),
+        docker_checkpoint: None,
     }
 }
 

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -19,7 +19,7 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                     },
                     "source_ip": {
                         "type": "string",
-                        "description": "Filter by exact verified network sender address (IP:port), independent of the claimed hostname."
+                        "description": "Filter by exact source identifier. Syslog uses the verified network sender address (IP:port); Docker ingest uses docker://host/container/stream from configured ingest metadata."
                     },
                     "severity": {
                         "type": "string",
@@ -57,7 +57,7 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                     },
                     "source_ip": {
                         "type": "string",
-                        "description": "Filter by exact verified network sender address (IP:port)"
+                        "description": "Filter by exact source identifier. Syslog uses IP:port; Docker ingest uses docker://host/container/stream."
                     },
                     "app_name": {
                         "type": "string",
@@ -123,7 +123,7 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                     },
                     "source_ip": {
                         "type": "string",
-                        "description": "Optional: limit correlation to an exact verified network sender address (IP:port)"
+                        "description": "Optional: limit correlation to an exact source identifier. Syslog uses IP:port; Docker ingest uses docker://host/container/stream."
                     },
                     "query": {
                         "type": "string",

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -134,7 +134,7 @@ phrase matching with quotes, prefix matching with *.
 **Parameters:**
 - `query` (string) — FTS5 search query, e.g. `'kernel panic'`, `'OOM AND killer'`, `'"connection refused"'`, `'error*'`
 - `hostname` (string, optional) — filter by hostname (exact match); use `list_hosts` to enumerate
-- `source_ip` (string, optional) — filter by exact verified network sender address (`IP:port`)
+- `source_ip` (string, optional) — filter by exact source identifier. Syslog uses verified `IP:port`; Docker ingest uses `docker://host/container/stream`.
 - `severity` (string, optional) — one of: `emerg`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug`
 - `app_name` (string, optional) — filter by application name, e.g. `sshd`, `dockerd`, `kernel`
 - `from` (string, optional) — start of time range (ISO 8601 / RFC3339, e.g. `2025-01-15T00:00:00Z`)
@@ -149,7 +149,7 @@ Equivalent to `tail -f` across all hosts.
 
 **Parameters:**
 - `hostname` (string, optional) — filter to a specific host
-- `source_ip` (string, optional) — filter by exact verified network sender address (`IP:port`)
+- `source_ip` (string, optional) — filter by exact source identifier. Syslog uses verified `IP:port`; Docker ingest uses `docker://host/container/stream`.
 - `app_name` (string, optional) — filter to a specific application
 - `n` (integer, optional) — number of recent entries (default 50, max 500)
 
@@ -182,7 +182,7 @@ of a reference timestamp. Results are grouped by host and ordered by time.
 - `window_minutes` (integer, optional) — minutes before and after reference_time to search (default 5, max 60)
 - `severity_min` (string, optional) — minimum severity to include (default `warning`); `debug` returns everything
 - `hostname` (string, optional) — limit correlation to a specific host
-- `source_ip` (string, optional) — limit correlation to an exact verified network sender address (`IP:port`)
+- `source_ip` (string, optional) — limit correlation to an exact source identifier. Syslog uses verified `IP:port`; Docker ingest uses `docker://host/container/stream`.
 - `query` (string, optional) — optional FTS query to narrow results
 - `limit` (integer, optional) — max total events to return (default 500, max 999)
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,7 +8,8 @@ use tokio::task::JoinHandle;
 use crate::app::SyslogService;
 use crate::config::Config;
 use crate::db::{self, DbPool, StorageBudgetState};
-use crate::{mcp, syslog};
+use crate::ingest::IngestTx;
+use crate::{docker_ingest, mcp, syslog};
 
 pub struct RuntimeCore {
     pub config: Config,
@@ -16,11 +17,13 @@ pub struct RuntimeCore {
     storage_state: Arc<Mutex<Option<StorageBudgetState>>>,
     service: SyslogService,
     maintenance_permit: Arc<Semaphore>,
+    ingest: IngestTx,
 }
 
 pub struct MaintenanceHandles {
     purge: Option<JoinHandle<()>>,
     storage: Option<JoinHandle<()>>,
+    docker_ingest: Vec<JoinHandle<()>>,
 }
 
 impl Drop for MaintenanceHandles {
@@ -29,6 +32,9 @@ impl Drop for MaintenanceHandles {
             handle.abort();
         }
         if let Some(handle) = &self.storage {
+            handle.abort();
+        }
+        for handle in &self.docker_ingest {
             handle.abort();
         }
     }
@@ -77,12 +83,19 @@ impl RuntimeCore {
             );
         }
         let service = SyslogService::new(Arc::clone(&pool), config.storage.clone());
+        let ingest = crate::ingest::start_writer_from_syslog_config(
+            &config.syslog,
+            config.storage.clone(),
+            Arc::clone(&pool),
+            Arc::clone(&storage_state),
+        );
         Ok(Self {
             config,
             pool,
             storage_state,
             service,
             maintenance_permit: Arc::new(Semaphore::new(1)),
+            ingest,
         })
     }
 
@@ -98,19 +111,22 @@ impl RuntimeCore {
     }
 
     pub async fn start_syslog(&self) -> Result<()> {
-        syslog::start_with_storage_state(
-            self.config.syslog.clone(),
-            self.config.storage.clone(),
-            Arc::clone(&self.pool),
-            Arc::clone(&self.storage_state),
-        )
-        .await
+        syslog::start_listeners(self.config.syslog.clone(), self.ingest.sender()).await
     }
 
     pub fn spawn_maintenance_tasks(&self) -> MaintenanceHandles {
         let purge = self.spawn_retention_task();
         let storage = self.spawn_storage_task();
-        MaintenanceHandles { purge, storage }
+        let docker_ingest = docker_ingest::spawn_all(
+            self.config.docker_ingest.clone(),
+            Arc::clone(&self.pool),
+            self.ingest.clone(),
+        );
+        MaintenanceHandles {
+            purge,
+            storage,
+            docker_ingest,
+        }
     }
 
     fn spawn_retention_task(&self) -> Option<JoinHandle<()>> {

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -5,12 +5,13 @@ use tracing::{error, info};
 
 use crate::config::{StorageConfig, SyslogConfig};
 use crate::db::{self, DbPool};
+use crate::ingest;
 
 mod listener;
 mod parser;
-mod writer;
+pub(crate) mod writer;
 
-const WRITE_CHANNEL_CAPACITY: usize = 10_000;
+pub(crate) const WRITE_CHANNEL_CAPACITY: usize = ingest::WRITE_CHANNEL_CAPACITY;
 
 pub async fn start_with_storage_state(
     config: SyslogConfig,
@@ -18,25 +19,14 @@ pub async fn start_with_storage_state(
     pool: Arc<DbPool>,
     storage_state: Arc<Mutex<Option<db::StorageBudgetState>>>,
 ) -> Result<()> {
-    let (tx, rx) = mpsc::channel::<db::LogBatchEntry>(WRITE_CHANNEL_CAPACITY);
+    let ingest_tx = ingest::start_writer_from_syslog_config(&config, storage, pool, storage_state);
+    start_listeners(config, ingest_tx.sender()).await
+}
 
-    let writer_pool = pool.clone();
-    let writer_storage = storage.clone();
-    let writer_storage_state = storage_state.clone();
-    let batch_size = config.batch_size;
-    let flush_interval = tokio::time::Duration::from_millis(config.flush_interval);
-    tokio::spawn(async move {
-        writer::batch_writer(
-            rx,
-            writer_pool,
-            writer_storage,
-            writer_storage_state,
-            batch_size,
-            flush_interval,
-        )
-        .await;
-    });
-
+pub async fn start_listeners(
+    config: SyslogConfig,
+    tx: mpsc::Sender<db::LogBatchEntry>,
+) -> Result<()> {
     let bind_addr = config.bind_addr();
 
     let udp_tx = tx.clone();
@@ -68,8 +58,6 @@ pub async fn start_with_storage_state(
 
     info!(
         bind = %bind_addr,
-        batch_size = config.batch_size,
-        flush_interval_ms = config.flush_interval,
         max_message_size = config.max_message_size,
         max_tcp_connections = config.max_tcp_connections,
         tcp_idle_timeout_secs = config.tcp_idle_timeout_secs,

--- a/src/syslog/parser.rs
+++ b/src/syslog/parser.rs
@@ -239,6 +239,7 @@ pub(super) fn parse_syslog(raw: &str, source_ip: String) -> db::LogBatchEntry {
         message,
         raw: raw.to_string(),
         source_ip,
+        docker_checkpoint: None,
     }
 }
 

--- a/src/syslog/writer.rs
+++ b/src/syslog/writer.rs
@@ -12,7 +12,7 @@ use super::WRITE_CHANNEL_CAPACITY;
 const INGEST_SUMMARY_INTERVAL_SECS: u64 = 60;
 
 /// Batch writer — collects messages and writes in batches for throughput.
-pub(super) async fn batch_writer(
+pub(crate) async fn batch_writer(
     mut rx: mpsc::Receiver<db::LogBatchEntry>,
     pool: Arc<DbPool>,
     storage: StorageConfig,

--- a/src/syslog/writer_tests.rs
+++ b/src/syslog/writer_tests.rs
@@ -26,6 +26,7 @@ fn make_entry(message: &str) -> db::LogBatchEntry {
         message: message.to_string(),
         raw: message.to_string(),
         source_ip: "127.0.0.1:514".to_string(),
+        docker_checkpoint: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- add optional Docker socket-proxy log ingestion for remote hosts without changing Docker daemon logging drivers
- route Docker and syslog inputs through the shared batch writer and add SQLite checkpoints for Docker containers
- document config/env/Compose setup, add example docker-hosts file, and bump version to 0.6.0

## Verification
- cargo fmt --check
- RUSTC_WRAPPER= cargo check
- RUSTC_WRAPPER= cargo clippy --all-targets -- -D warnings
- RUSTC_WRAPPER= cargo test -- --test-threads=1
- docker compose config >/tmp/syslog-mcp-compose-config.out
- bash bin/check-version-sync.sh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional pull-based Docker log ingestion via read-only docker-socket-proxy with per-container checkpoints and resilient auto-reconnect. Syslog and Docker now share one batch writer; `source_ip` is a generic source identifier; version bumped to 0.7.0.

- **New Features**
  - Optional Docker ingest: enable with `SYSLOG_DOCKER_INGEST_ENABLED`; follows existing containers and handles start/restart/rename/stop; maps stdout→info and stderr→warning; parses RFC3339 timestamps; replays via `/containers/{id}/logs?since=` and skips entries at-or-before the last checkpoint.
  - Checkpoints/backoff: per-container SQLite checkpoints; host and container reconnect loops with configurable backoff via `SYSLOG_DOCKER_RECONNECT_INITIAL_MS`/`SYSLOG_DOCKER_RECONNECT_MAX_MS`.
  - Config: define hosts under `[docker_ingest]` or via `SYSLOG_DOCKER_HOSTS_FILE`; `base_url` must be `http(s)://`; `http://` hosts require `allow_insecure_http = true`; validation enforces at least one host when enabled and unique host names.
  - Unified writer: syslog and Docker both use the shared bounded batch writer for consistent retention and storage limits.
  - Docs/Compose/versions: example `docker-hosts.toml`; Compose mounts read-only `/config` via `SYSLOG_MCP_CONFIG_VOLUME` and loads `.env`; API/MCP docs clarify `source_ip = docker://host/container/stream`; version `0.7.0`; adds dependencies `bollard`, `bytes`, `scheduled-thread-pool`, `futures-util`.
  - Database: automatic migration creates `docker_ingest_checkpoints` for replay.

- **Migration**
  - To adopt Docker ingest:
    - Mount a read-only config dir to `/config` and add a hosts file (e.g. `/config/docker-hosts.toml`), or set hosts under `[docker_ingest]`.
    - Set `SYSLOG_DOCKER_INGEST_ENABLED=true` and optionally `SYSLOG_DOCKER_HOSTS_FILE=/config/docker-hosts.toml`.
    - On each docker-socket-proxy, grant read-only: `CONTAINERS=1`, `EVENTS=1`, `PING=1`, `VERSION=1`, `POST=0`; for plain `http://` proxies, set `allow_insecure_http = true`. Database migration runs automatically.

<sup>Written for commit 38dec72917d2a6b1125608e54deecdefd15e924c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker container log ingestion via socket-proxy with automatic reconnection and per-container checkpointing.

* **Configuration**
  * New Docker ingest configuration with reconnect backoff timing and host discovery settings.
  * Updated `source_ip` field semantics to distinguish syslog sources (`IP:port`) from Docker ingest sources (`docker://host/container/stream`).

* **Documentation**
  * Enhanced setup and configuration guides with Docker socket-proxy ingest instructions and example configurations.

* **Chores**
  * Bumped version to 0.6.0 across all manifests and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->