### PR TITLE
Chore/mcp stdio local dev config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ dist/
 
 # ── Repo-specific ────────────────────────────────────────────────────────────
 config.local.toml
+config/docker-hosts.toml
 data/
 *.key
 *.pem

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,11 @@
 {
   "mcpServers": {
-    "syslog-mcp": {
-      "type": "http",
-      "url": "${userConfig.syslog_mcp_url}",
-      "headers": {
-        "Authorization": "Bearer ${userConfig.syslog_mcp_token}"
+    "syslog": {
+      "type": "stdio",
+      "command": "./bin/syslog",
+      "args": ["mcp"],
+      "env": {
+        "SYSLOG_MCP_DB_PATH": "/home/jmagar/workspace/syslog-mcp/data/syslog.db"
       }
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-05-06
+
+### Changed
+
+- **Local dev MCP config**: Switched `.mcp.json` from HTTP transport to stdio (`./bin/syslog mcp`) for local development, removing the need for a running HTTP server.
+- **Gitignore**: Added `config/docker-hosts.toml` to prevent committing local Docker host config.
+
 ## [0.10.0] - 2026-05-05
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,8 @@ dependencies = [
  "bytes",
  "chrono",
  "futures-util",
+ "hyper",
+ "hyper-util",
  "r2d2",
  "r2d2_sqlite",
  "rmcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,12 @@ tokio = { version = "1", features = ["full"] }
 
 # HTTP / MCP transport
 axum = "0.8"
-rmcp = { version = "1.6.0", default-features = false, features = ["server", "macros", "transport-streamable-http-server", "transport-io"] }
+rmcp = { version = "1.6.0", default-features = false, features = [
+  "server",
+  "macros",
+  "transport-streamable-http-server",
+  "transport-io",
+] }
 tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
 
 # SQLite
@@ -29,7 +34,12 @@ scheduled-thread-pool = "0.2"
 syslog_loose = "0.21"
 
 # Docker Engine API client for optional docker-socket-proxy ingestion
-bollard = { version = "0.19", default-features = false, features = ["http", "chrono"] }
+bollard = { version = "0.19", default-features = false, features = [
+  "http",
+  "chrono",
+] }
+hyper = { version = "1", features = ["client"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 bytes = "1"
 
 # Serialization
@@ -56,4 +66,7 @@ futures-util = "0.3"
 tempfile = "3"
 serial_test = "3"
 tower = { version = "0.5", features = ["util"] }
-rmcp = { version = "1.6.0", default-features = false, features = ["client", "transport-child-process"] }
+rmcp = { version = "1.6.0", default-features = false, features = [
+  "client",
+  "transport-child-process",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/docs/expansion.md
+++ b/docs/expansion.md
@@ -1,0 +1,464 @@
+# syslog-mcp expansion · session bootstrap
+
+> Briefing doc to load at session start. Captures fleet topology, current
+> log ingest paths, planned expansion, drop-in configs, and the
+> architecture decisions made en route. Implementation work is plotted at
+> the bottom.
+
+---
+
+## 0 · context
+
+- **owner**: jacob · homelab `tootie.tv` · tailscale-meshed
+- **existing**: `syslog-mcp` (Rust/Axum + SQLite FTS5, custom MCP tools) ingesting
+  - syslog/journald from limited hosts
+  - container stdout via `dockersocketproxy` (not the docker syslog log driver — chosen for container-startup resilience and to avoid per-host fluent agents)
+- **goal**: expand ingestion across the full fleet, capture missing log streams (nginx/authelia/fail2ban/adguard/zfs/smartd/ai), add OTLP HTTP receiver to absorb claude code & codex telemetry, host on `shart`
+- **adjacent**: `axon` (Rust RAG pipeline · TEI Qwen3-Embedding-0.6B · Qdrant · Postgres · Redis · spider.rs) handles documentation + transcript content. Logs and docs stay in separate corpora.
+
+---
+
+## 1 · fleet
+
+| host | os | role | hardware | storage | net |
+|---|---|---|---|---|---|
+| **tootie** | Unraid 7.x | media + VM host | — | 3×2TB raidz1 | 2.5GbE |
+| **dookie** | Ubuntu 25 (VM on tootie) | dev / AI / GPU | RTX 4070 + nvme + 60GB passthrough | ZFS (passthrough nvme) | 2.5GbE (host) |
+| **squirts** | Ubuntu 25 | mission-critical services | i3 NUC, UPS-backed | ZFS, hourly snaps | 2.5GbE |
+| **shart** | Unraid 7.x | backup sink + future syslog-mcp host | — | 2×8TB mirror (spinners) | 2.5GbE |
+| **steamy** | Win11 + WSL Ubuntu 25 | primary workstation | i5 11th, 48GB, RTX 3050, 2TB nvme | — | 2.5GbE |
+| **vivobook** | Win11 + WSL Ubuntu 25 | mobile, parsec → steamy | i3 13th, 24GB, 1TB nvme | — | wifi 7 |
+
+**Network edge:** ATT BGW-320 → UCG-Max → 2.5GbE PoE switch + U7 Pro AP. Tailscale flat mesh across all 6 nodes. SWAG terminates `*.tootie.tv` on squirts; non-public subdomains gated by Authelia + Duo 2FA.
+
+**Snapshot chain:** tootie/dookie/squirts → shart (hourly) → Google Drive (5TB offsite). Squirts' ~30GB critical set replicated to every node. dookie repos additionally to tootie.
+
+**Workflow chain:** vivobook (parsec) → steamy (zed remote) → dookie (compute).
+
+**Codename naming:** scatological theme; vivobook is the lone holdout.
+
+---
+
+## 2 · current ingest paths
+
+| source | mechanism | status |
+|---|---|---|
+| tootie syslog | Unraid Settings → Syslog Server | ✅ active |
+| shart syslog | Unraid Settings → Syslog Server | ✅ active |
+| Docker container stdout (all hosts) | dockersocketproxy → syslog-mcp | ✅ active |
+| ubuntu/WSL host syslog | rsyslog default | ⚠️ partial (no journald) |
+| nginx access/error (SWAG) | none | ❌ missing |
+| Authelia auth events | none — writing to file | ❌ missing |
+| fail2ban (in SWAG) | none | ❌ missing |
+| AdGuard query log | none | ❌ missing |
+| Vaultwarden auth | via container stdout | ⚠️ verify |
+| ZED (zfs events) | already in syslog default | ⚠️ verify by tag |
+| smartd | already in syslog default | ⚠️ verify by tag |
+| auditd | killed via `audit=0` on dookie (kernel cmdline) | ✅ noise eliminated |
+| claude code OTel | none | ❌ missing |
+| codex OTel | none | ❌ missing |
+| claude/codex `.jsonl` transcripts | none | ❌ missing |
+| libvirt (dookie) on tootie | none | ❌ TBD (Unraid API vs imfile) |
+
+**Why dockersocketproxy and not the syslog log driver:** if the syslog server is unreachable at container start, the syslog log driver will refuse to start the container. Pulling logs from the docker socket (read-only proxy) decouples container lifecycle from syslog-mcp availability. Trade-off: claude needs the proxy reachable to ingest, but containers run regardless.
+
+---
+
+## 3 · planned ingest expansion
+
+### 3.1 host roles for log work
+
+| host | drop-ins | notes |
+|---|---|---|
+| **tootie** | none (Unraid native covers it) | `imfile` for libvirt only if Unraid API insufficient — needs User Scripts plugin to persist in `/etc/rsyslog.d/` |
+| **shart** | none | future syslog-mcp host |
+| **squirts** | imjournal · swag · authelia · adguard | the special one — all SWAG/auth/dns lives here |
+| **dookie** | imjournal · ai-transcripts | + claude/codex jsonls |
+| **steamy-wsl** | imjournal · ai-transcripts | + claude/codex jsonls |
+| **vivobook-wsl** | imjournal · ai-transcripts | + claude/codex jsonls |
+
+### 3.2 modern Ubuntu / journald gap
+
+Ubuntu 22.04+ writes nearly everything to journald. Default rsyslog only sees what `imuxsock`/`imklog` catch + whatever journald forwards via `ForwardToSyslog=`. Most systemd services log to stderr → journald and never touch `/dev/log`. Without `imjournal`, the rsyslog stream from these hosts is sparse: cron, sshd, kernel, sudo. **`imjournal` is mandatory on all Ubuntu/WSL hosts.**
+
+### 3.3 ZED — already on by default
+
+OpenZFS ships `all-syslog.sh` ZEDLET enabled at install. Logs at `daemon.notice` with tag `zed`. Quick verification:
+
+```sql
+SELECT host, count(*) FROM logs WHERE tag = 'zed' GROUP BY host;
+```
+
+If empty, check `/etc/zfs/zed.d/all-syslog.sh` symlink and `systemctl status zfs-zed`. Tune in `/etc/zfs/zed.d/zed.rc`:
+
+```bash
+ZED_SYSLOG_SUBCLASS_EXCLUDE="history_event"   # drop zpool history spam
+ZED_SYSLOG_PRIORITY="daemon.notice"
+ZED_SYSLOG_TAG="zed"
+```
+
+### 3.4 smartd — already on by default
+
+Native syslog out of the box, `daemon.warning`, tag `smartd`. Just confirm `smartmontools` installed and `smartd` running on each Linux host.
+
+### 3.5 BGW-320 — skip
+
+ATT residential gateway has no useful remote syslog. UCG-Max behind it is doing the security work; ATT box is just NAT/PPPoE. Not worth the time investment.
+
+---
+
+## 4 · architecture decisions
+
+### 4.1 logs vs transcripts vs docs — three corpora, one query model
+
+| corpus | store | search | source |
+|---|---|---|---|
+| event stream | syslog-mcp (FTS5) | exact / time-window / host filter | rsyslog + dockersocketproxy + OTLP |
+| AI conversation content | axon (Qdrant + TEI) | semantic recall | claude/codex `.jsonl` |
+| reference docs | axon (Qdrant + TEI [+ FTS5 for hybrid/RRF]) | semantic + sparse hybrid | spider.rs crawler |
+
+**Don't ingest crawled documentation into syslog-mcp.** Different data model (reference vs event), different query patterns (topic vs time/host), pollutes log search with stale doc snippets.
+
+**RRF clarification:** RRF fuses ranked lists from dense + sparse indexes over the **same corpus** (same chunk IDs). For axon hybrid search, FTS5 lives next to Qdrant inside axon, keyed by chunk_id. Or use Qdrant native sparse vectors (BM42/SPLADE) and skip the parallel FTS5 index entirely.
+
+### 4.2 OTel ingestion — build into syslog-mcp, don't deploy a collector
+
+**Rationale:**
+- One less container, one less moving part (stated preference)
+- Keeps "anyone can spin this up" goal intact (no OTel collector dep)
+- OTLP/HTTP is trivial protobuf; existing axum + receiver muscle covers it
+- Single FTS5 index across syslog + container stdout + claude/codex telemetry → cross-stream correlation works
+
+**Scope:**
+- ✅ logs (`/v1/logs`) — translate `LogRecord` → existing log shape
+- ✅ traces (`/v1/traces`) — flatten spans into rows tagged with `trace_id` + `span_id`
+- ❌ metrics (`/v1/metrics`) — accept and discard with 200 OK; metrics belong in Prom/VictoriaMetrics, not FTS5
+- ❌ gRPC — HTTP only unless something specifically needs it
+
+**When to introduce a real collector:** once fanout to multiple backends (Prom + syslog-mcp + Loki) becomes necessary. YAGNI until then.
+
+### 4.3 claude/codex transcript routing
+
+```
+claude/codex JSONLs ──► axon (semantic recall via embeddings)
+                  │
+                  └──► imfile ──► syslog-mcp (filter by host/time)
+
+claude/codex OTel events ──► OTLP HTTP ──► syslog-mcp (api_request, tool_result, prompts-by-length)
+```
+
+Two destinations, two query modes:
+- **axon**: "the conversation about audit backlog" (semantic)
+- **syslog-mcp**: "every claude session on dookie last Tuesday between 2-4am" (structured filter + time)
+- **cross-corpora**: correlate claude activity with smartd warnings on the same host & time window via syslog-mcp JOIN
+
+### 4.4 Authelia decision
+
+Authelia is currently writing to a file (`log.file_path` set), not stdout — that's why container stdout ingestion misses it. Two paths:
+
+1. Remove `log.file_path` from authelia config → flows through dockersocketproxy
+2. Leave file in place, point `imfile` at it (chosen — minimizes blast radius on a working auth stack)
+
+Authelia logs are structured (`time=... level=... msg=...`). Parse `level` server-side at ingest to set proper severity rather than hardcoding `info`.
+
+### 4.5 AdGuard query volume warning
+
+Query log gets **loud** — every DNS query from every device. Tens of thousands per day. Worth it for phone-home detection but:
+- Filter at ingest (drop `allowed` queries, keep blocked + filtered)
+- Or partition into a dedicated table/index in syslog-mcp so it doesn't drown signal
+- Decide retention separately from other tags
+
+### 4.6 hosting
+
+`syslog-mcp` runs on **shart**:
+- Least loaded box in the fleet (backup-only)
+- Mirror pool has 8TB headroom
+- DB lands in the existing zfs send chain → automatic offsite via gdrive
+- Co-located with future OTel receiver work — single container, single endpoint
+
+---
+
+## 5 · syslog-mcp enhancements
+
+### 5.1 OTLP HTTP receiver
+
+**Crate additions:**
+```toml
+opentelemetry-proto = { version = "*", features = ["gen-tonic-messages", "logs", "trace"] }
+prost = "*"
+```
+
+**Routes:**
+- `POST /v1/logs` — `ExportLogsServiceRequest` → flatten → existing FTS5 ingest
+- `POST /v1/traces` — `ExportTraceServiceRequest` → flatten spans → log rows tagged with `trace_id`/`span_id`
+- `POST /v1/metrics` — accept body, return 200, discard
+
+**LogRecord field mapping:**
+| OTLP field | syslog-mcp column |
+|---|---|
+| `time_unix_nano` | timestamp |
+| `severity_number` | severity |
+| `body` (AnyValue) | message |
+| `resource.attributes["host.name"]` | host |
+| `resource.attributes["service.name"]` | program/tag |
+| `attributes` | flatten → JSON column or structured fields |
+| `resource.attributes["service.version"]` | metadata JSON |
+
+**Sketch:**
+```rust
+async fn otlp_logs_handler(
+    State(db): State<Db>,
+    body: Bytes,
+) -> Result<StatusCode, AppError> {
+    let req = ExportLogsServiceRequest::decode(body)?;
+
+    for resource_logs in req.resource_logs {
+        let resource_attrs = flatten_kv(&resource_logs.resource);
+
+        for scope_logs in resource_logs.scope_logs {
+            for log in scope_logs.log_records {
+                let row = LogRow {
+                    timestamp_ns: log.time_unix_nano as i64,
+                    host: resource_attrs.get("host.name").cloned(),
+                    program: resource_attrs.get("service.name").cloned(),
+                    severity: severity_from_number(log.severity_number),
+                    message: extract_body(&log.body),
+                    attributes: flatten_kv_to_json(&log.attributes),
+                };
+                db.insert_log(row).await?;
+            }
+        }
+    }
+    Ok(StatusCode::OK)
+}
+```
+
+### 5.2 ingest-side enrichment
+
+Most-bang-for-buck items to do at ingest, not query time:
+
+- **Authelia severity parsing** — extract `level=` from structured body, override severity column
+- **AdGuard tag classification** — parse JSON line, set `tag` to `adguard-blocked` / `adguard-allowed` / `adguard-rewrite` so retention rules can differentiate
+- **claude/codex transcript metadata** — pull `project` from `imfile` source filename (`addMetadata="on"`) into a dedicated column
+- **Multi-line glomming** — fail2ban + authelia panics need `startmsg.regex` discipline (already in drop-ins below)
+
+### 5.3 retention
+
+Don't filter at rsyslog — let it all in, retain selectively:
+
+- **30 days** default
+- **7 days** for `adguard-allowed`
+- **90 days** for `tag IN ('zed', 'smartd', 'authelia', 'fail2ban', 'kern.*')`
+- **forever (or until disk pressure)** for `severity >= err`
+
+Tag-based retention is cheap: nightly job with `DELETE FROM logs WHERE tag = ? AND timestamp < ?` per rule.
+
+### 5.4 message size
+
+Bump `$MaxMessageSize 256k` on rsyslog hosts that ingest claude/codex jsonls — tool results and large diffs blow past the 8KB default and get truncated.
+
+---
+
+## 6 · drop-ins (deploy)
+
+All drop-ins live in `/etc/rsyslog.d/`. Validate any change with `rsyslogd -N1` before reload.
+
+### 6.1 imjournal — all Ubuntu/WSL hosts (dookie, steamy-wsl, vivobook-wsl, squirts)
+
+```conf
+# /etc/rsyslog.d/10-imjournal.conf
+module(load="imjournal"
+       StateFile="/var/spool/rsyslog/imjournal.state"
+       Ratelimit.Interval="0"
+       Ratelimit.Burst="0")
+```
+
+WSL prerequisite — `/etc/wsl.conf`:
+```ini
+[boot]
+systemd=true
+```
+
+### 6.2 squirts only — SWAG (nginx + fail2ban)
+
+```conf
+# /etc/rsyslog.d/30-swag.conf
+$MaxMessageSize 64k
+module(load="imfile")
+
+input(type="imfile"
+      File="/path/to/swag/appdata/log/nginx/access.log"
+      Tag="swag-access"
+      Facility="local4"
+      Severity="info"
+      PersistStateInterval="100")
+
+input(type="imfile"
+      File="/path/to/swag/appdata/log/nginx/error.log"
+      Tag="swag-error"
+      Facility="local4"
+      Severity="warning"
+      PersistStateInterval="100")
+
+input(type="imfile"
+      File="/path/to/swag/appdata/log/fail2ban/fail2ban.log"
+      Tag="fail2ban"
+      Facility="local5"
+      Severity="info"
+      startmsg.regex="^[0-9]{4}-[0-9]{2}-[0-9]{2}"
+      PersistStateInterval="100")
+```
+
+> ⚠️ Replace `/path/to/swag/appdata` with the actual mount path on squirts.
+
+### 6.3 squirts only — Authelia
+
+```conf
+# /etc/rsyslog.d/35-authelia.conf
+module(load="imfile")
+
+input(type="imfile"
+      File="/path/to/authelia/config/authelia.log"
+      Tag="authelia"
+      Facility="local5"
+      Severity="info"
+      startmsg.regex="^time="
+      PersistStateInterval="100")
+```
+
+### 6.4 squirts only — AdGuard
+
+```conf
+# /etc/rsyslog.d/36-adguard.conf
+$MaxMessageSize 32k
+module(load="imfile")
+
+input(type="imfile"
+      File="/path/to/adguard/work/data/querylog.json"
+      Tag="adguard-query"
+      Facility="local6"
+      Severity="info"
+      PersistStateInterval="500")
+```
+
+### 6.5 dookie + steamy-wsl + vivobook-wsl — claude/codex transcripts
+
+```conf
+# /etc/rsyslog.d/40-ai-transcripts.conf
+$MaxMessageSize 256k
+module(load="imfile")
+
+input(type="imfile"
+      File="/home/jacob/.claude/projects/*/*.jsonl"
+      Tag="claude-transcript"
+      Facility="local7"
+      Severity="info"
+      addMetadata="on"
+      PersistStateInterval="50")
+
+input(type="imfile"
+      File="/home/jacob/.codex/sessions/*.jsonl"
+      Tag="codex-transcript"
+      Facility="local7"
+      Severity="info"
+      addMetadata="on"
+      PersistStateInterval="50")
+```
+
+### 6.6 unraid persistence
+
+Standard `/etc/rsyslog.d/` doesn't survive reboot on Unraid (overlay fs). For tootie if libvirt imfile is needed:
+
+- Option A — User Scripts plugin → run at array start: copy drop-in into `/etc/rsyslog.d/`, `kill -HUP $(cat /var/run/rsyslogd.pid)`
+- Option B — append same logic to `/boot/config/go`
+
+For tootie/shart base syslog: just use Settings → Syslog Server (native, persistent, no fuss).
+
+### 6.7 claude code & codex OTel config
+
+**Claude Code** (`~/.claude/settings.json` on dookie/steamy-wsl/vivobook-wsl):
+```json
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://shart.tailnet:4318",
+    "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "cumulative",
+    "OTEL_METRIC_EXPORT_INTERVAL": "10000",
+    "OTEL_LOGS_EXPORT_INTERVAL": "5000",
+    "OTEL_LOG_USER_PROMPTS": "1",
+    "OTEL_LOG_TOOL_DETAILS": "1"
+  }
+}
+```
+
+**Codex** (`~/.codex/config.toml`):
+```toml
+[otel]
+environment = "homelab"
+log_user_prompt = true
+exporter = { otlp-http = { endpoint = "http://shart.tailnet:4318/v1/logs", protocol = "binary" } }
+trace_exporter = { otlp-http = { endpoint = "http://shart.tailnet:4318/v1/traces", protocol = "binary" } }
+```
+
+> ⚠️ Codex OTel coverage is incomplete — `codex exec` emits no metrics, `codex mcp-server` emits nothing. Transcript ingestion via imfile is the safety net.
+
+---
+
+## 7 · open questions
+
+- **libvirt logs from tootie** — try Unraid API first; fall back to imfile + User Scripts plugin if API doesn't expose them cleanly
+- **`SELECT host, count(*) FROM logs WHERE tag IN ('zed','smartd','kern')` baseline** — confirm what's already arriving before adding drop-ins
+- **Authelia stdout switch** — keep file-based (current plan) or strip `log.file_path` and use container stdout? Either works; file path is lower-risk to a live auth stack
+- **Vaultwarden** — verify access events present in container stdout before deciding on imfile
+- **AdGuard query log retention** — how long do "allowed" queries stay? Default to 7d unless there's a reason to keep longer
+- **`adguard-blocked` separate tag** — split at ingest by parsing `result_reason`/`status` field?
+- **trace handling** — flatten spans into rows now, or store separately? Lean toward flatten + tag with `trace_id`
+
+---
+
+## 8 · implementation order
+
+Do **not** land this all at once. Each step should run for a day or two before adding the next, so volume/cost/value of each source is observable in isolation.
+
+1. **Stand up syslog-mcp container on shart** — bind mount on mirror pool, expose on tailscale
+2. **Point Unraid Settings → Syslog Server** on tootie + shart at the new endpoint
+3. **Deploy `10-imjournal.conf`** to dookie, squirts, steamy-wsl, vivobook-wsl. Validate volume baseline.
+4. **Verify ZED + smartd already arriving** by tag query
+5. **Build OTLP HTTP receiver** in syslog-mcp (`/v1/logs`, `/v1/traces`, discard `/v1/metrics`)
+6. **Configure claude code OTel** on dookie first, then steamy-wsl, then vivobook-wsl
+7. **Configure codex OTel** same order
+8. **Deploy `40-ai-transcripts.conf`** to capture jsonls (axon already has them; this is for cross-correlation in syslog-mcp)
+9. **Deploy `35-authelia.conf`** on squirts — first specialty source
+10. **Deploy `30-swag.conf`** on squirts
+11. **Deploy `36-adguard.conf`** on squirts last (highest volume — want everything else stable first)
+12. **Tag-based retention rules** — nightly job
+13. **Ingest-side enrichment** — authelia severity, adguard tag splitting
+
+---
+
+## 9 · references
+
+- [rsyslog imfile](https://www.rsyslog.com/doc/configuration/modules/imfile.html)
+- [rsyslog imjournal](https://www.rsyslog.com/doc/configuration/modules/imjournal.html)
+- [RFC 5424 syslog format](https://datatracker.ietf.org/doc/html/rfc5424)
+- [openzfs ZED docs](https://openzfs.github.io/openzfs-docs/man/master/8/zed.8.html) · [zed.rc reference](https://github.com/openzfs/zfs/blob/master/cmd/zed/zed.d/zed.rc)
+- [Authelia logging config](https://www.authelia.com/configuration/miscellaneous/logging/)
+- [Claude Code monitoring (OTel)](https://code.claude.com/docs/en/monitoring-usage)
+- [Codex advanced config (OTel)](https://developers.openai.com/codex/config-advanced) · [config reference](https://developers.openai.com/codex/config-reference)
+- [opentelemetry-proto crate](https://docs.rs/opentelemetry-proto)
+- [OTLP/HTTP spec](https://opentelemetry.io/docs/specs/otlp/#otlphttp)
+- [Qdrant hybrid search](https://qdrant.tech/articles/hybrid-search/) (relevant to axon, not syslog-mcp)
+
+---
+
+## 10 · ground rules for this work
+
+- Stack: Rust (axum, tokio, sqlx) for syslog-mcp · TypeScript / Python for tooling around it
+- Modular crates if syslog-mcp grows — `syslog-mcp-core`, `syslog-mcp-otlp`, `syslog-mcp-mcp` (mcp tool surface), `syslog-mcp-bin`
+- Monorepo-friendly: this likely belongs in the consolidating MCP plugin monorepo (git subtree)
+- No agent-foo: don't introduce abstractions for one consumer. OTLP receiver, FTS5 ingest, MCP tool surface — three concrete things, no plugin trait
+- Self-hosted only — no SaaS observability, no vendored exporters
+- Data is small in absolute terms; correctness > clever tiering. SQLite with FTS5 is the right call until proven otherwise

--- a/src/docker_ingest/client.rs
+++ b/src/docker_ingest/client.rs
@@ -12,12 +12,20 @@ use super::models::ContainerMeta;
 #[derive(Clone)]
 pub(super) struct DockerHostClient {
     docker: Docker,
+    // Separate client with no read timeout for follow=true log streams.
+    // The api client (120s) would time out quiet containers after 2 minutes.
+    streaming_docker: Docker,
 }
 
 impl DockerHostClient {
     pub(super) fn connect(base_url: &str) -> Result<Self> {
         let docker = Docker::connect_with_http(base_url, 120, bollard::API_DEFAULT_VERSION)?;
-        Ok(Self { docker })
+        let streaming_docker =
+            Docker::connect_with_http(base_url, 0, bollard::API_DEFAULT_VERSION)?;
+        Ok(Self {
+            docker,
+            streaming_docker,
+        })
     }
 
     pub(super) async fn list_containers(&self) -> Result<Vec<ContainerMeta>> {
@@ -51,5 +59,9 @@ impl DockerHostClient {
 
     pub(super) fn docker(&self) -> Docker {
         self.docker.clone()
+    }
+
+    pub(super) fn streaming_docker(&self) -> Docker {
+        self.streaming_docker.clone()
     }
 }

--- a/src/docker_ingest/client.rs
+++ b/src/docker_ingest/client.rs
@@ -1,11 +1,16 @@
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use bollard::query_parameters::{
     EventsOptions, EventsOptionsBuilder, ListContainersOptionsBuilder, LogsOptions,
     LogsOptionsBuilder,
 };
-use bollard::Docker;
+use bollard::{BollardRequest, Docker};
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
 
 use super::models::ContainerMeta;
 
@@ -16,7 +21,36 @@ pub(super) struct DockerHostClient {
 
 impl DockerHostClient {
     pub(super) fn connect(base_url: &str) -> Result<Self> {
-        let docker = Docker::connect_with_http(base_url, 120, bollard::API_DEFAULT_VERSION)?;
+        // Build an HttpConnector with TCP keepalive enabled. Bollard's stock
+        // `connect_with_http` uses `HttpConnector::new()` which leaves SO_KEEPALIVE
+        // off, so idle streaming connections (quiet container log streams, the
+        // events stream when no events fire) get silently dropped by NATs,
+        // conntrack, gateways, or peer-side idle timers, surfacing later as
+        // "error reading a body from connection". Matches docker/cli PR #415.
+        let mut http_connector = HttpConnector::new();
+        http_connector.set_keepalive(Some(Duration::from_secs(30)));
+        http_connector.set_keepalive_interval(Some(Duration::from_secs(30)));
+        http_connector.set_keepalive_retries(Some(3));
+
+        let mut client_builder = Client::builder(TokioExecutor::new());
+        client_builder.pool_max_idle_per_host(0);
+        let client = Arc::new(client_builder.build(http_connector));
+
+        let docker = Docker::connect_with_custom_transport(
+            move |req: BollardRequest| {
+                let client = Arc::clone(&client);
+                Box::pin(async move {
+                    client
+                        .request(req)
+                        .await
+                        .map_err(bollard::errors::Error::from)
+                })
+            },
+            Some(base_url.to_string()),
+            120,
+            bollard::API_DEFAULT_VERSION,
+        )?;
+
         Ok(Self { docker })
     }
 

--- a/src/docker_ingest/client.rs
+++ b/src/docker_ingest/client.rs
@@ -12,20 +12,12 @@ use super::models::ContainerMeta;
 #[derive(Clone)]
 pub(super) struct DockerHostClient {
     docker: Docker,
-    // Separate client with no read timeout for follow=true log streams.
-    // The api client (120s) would time out quiet containers after 2 minutes.
-    streaming_docker: Docker,
 }
 
 impl DockerHostClient {
     pub(super) fn connect(base_url: &str) -> Result<Self> {
         let docker = Docker::connect_with_http(base_url, 120, bollard::API_DEFAULT_VERSION)?;
-        let streaming_docker =
-            Docker::connect_with_http(base_url, 0, bollard::API_DEFAULT_VERSION)?;
-        Ok(Self {
-            docker,
-            streaming_docker,
-        })
+        Ok(Self { docker })
     }
 
     pub(super) async fn list_containers(&self) -> Result<Vec<ContainerMeta>> {
@@ -57,7 +49,7 @@ impl DockerHostClient {
             .build()
     }
 
-    pub(super) fn streaming_docker(&self) -> Docker {
-        self.streaming_docker.clone()
+    pub(super) fn docker(&self) -> Docker {
+        self.docker.clone()
     }
 }

--- a/src/docker_ingest/client.rs
+++ b/src/docker_ingest/client.rs
@@ -57,10 +57,6 @@ impl DockerHostClient {
             .build()
     }
 
-    pub(super) fn docker(&self) -> Docker {
-        self.docker.clone()
-    }
-
     pub(super) fn streaming_docker(&self) -> Docker {
         self.streaming_docker.clone()
     }

--- a/src/docker_ingest/supervisor.rs
+++ b/src/docker_ingest/supervisor.rs
@@ -125,7 +125,7 @@ async fn follow_container_events(
     log_tasks: &mut HashMap<String, JoinHandle<()>>,
     event_since_unix: i64,
 ) -> Result<()> {
-    let docker = client.streaming_docker();
+    let docker = client.docker();
     let mut events = docker.events(Some(DockerHostClient::container_events_options(
         event_since_unix,
     )));
@@ -194,7 +194,7 @@ fn spawn_log_task_if_absent(
     if tasks.contains_key(&container.id) {
         return;
     }
-    let docker = client.streaming_docker();
+    let docker = client.docker();
     let host_name = host.name.clone();
     let reconnect_initial_ms = config.reconnect_initial_ms;
     let reconnect_max_ms = config.reconnect_max_ms;

--- a/src/docker_ingest/supervisor.rs
+++ b/src/docker_ingest/supervisor.rs
@@ -187,7 +187,7 @@ fn spawn_log_task_if_absent(
     if tasks.contains_key(&container.id) {
         return;
     }
-    let docker = client.docker();
+    let docker = client.streaming_docker();
     let host_name = host.name.clone();
     let reconnect_initial_ms = config.reconnect_initial_ms;
     let reconnect_max_ms = config.reconnect_max_ms;
@@ -196,7 +196,7 @@ fn spawn_log_task_if_absent(
     let handle = tokio::spawn(async move {
         let mut delay_ms = reconnect_initial_ms;
         loop {
-            match follow_container_logs_once(
+            let reset_backoff = match follow_container_logs_once(
                 &docker,
                 &pool,
                 &ingest,
@@ -206,22 +206,32 @@ fn spawn_log_task_if_absent(
             )
             .await
             {
-                Ok(()) => tracing::warn!(
-                    host = %host_name,
-                    container_id = %task_container_id,
-                    delay_ms,
-                    "Docker log stream ended; reconnecting"
-                ),
-                Err(e) => tracing::warn!(
-                    host = %host_name,
-                    container_id = %task_container_id,
-                    error = %e,
-                    delay_ms,
-                    "Docker log stream failed; retrying"
-                ),
-            }
+                Ok(()) => {
+                    tracing::warn!(
+                        host = %host_name,
+                        container_id = %task_container_id,
+                        delay_ms,
+                        "Docker log stream ended; reconnecting"
+                    );
+                    true
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        host = %host_name,
+                        container_id = %task_container_id,
+                        error = %e,
+                        delay_ms,
+                        "Docker log stream failed; retrying"
+                    );
+                    false
+                }
+            };
             tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-            delay_ms = (delay_ms * 2).min(reconnect_max_ms);
+            delay_ms = if reset_backoff {
+                reconnect_initial_ms
+            } else {
+                (delay_ms * 2).min(reconnect_max_ms)
+            };
         }
     });
     tasks.insert(container_id, handle);

--- a/src/docker_ingest/supervisor.rs
+++ b/src/docker_ingest/supervisor.rs
@@ -125,7 +125,7 @@ async fn follow_container_events(
     log_tasks: &mut HashMap<String, JoinHandle<()>>,
     event_since_unix: i64,
 ) -> Result<()> {
-    let docker = client.docker();
+    let docker = client.streaming_docker();
     let mut events = docker.events(Some(DockerHostClient::container_events_options(
         event_since_unix,
     )));
@@ -175,6 +175,13 @@ fn prune_finished_tasks(tasks: &mut HashMap<String, JoinHandle<()>>) {
     tasks.retain(|_, handle| !handle.is_finished());
 }
 
+fn is_expected_disconnect(e: &anyhow::Error) -> bool {
+    let msg = e.to_string();
+    msg.contains("error reading a body from connection")
+        || msg.contains("connection reset by peer")
+        || msg.contains("broken pipe")
+}
+
 fn spawn_log_task_if_absent(
     config: &DockerIngestConfig,
     host: &DockerHostConfig,
@@ -207,11 +214,18 @@ fn spawn_log_task_if_absent(
             .await
             {
                 Ok(()) => {
-                    tracing::warn!(
+                    tracing::debug!(
                         host = %host_name,
                         container_id = %task_container_id,
-                        delay_ms,
                         "Docker log stream ended; reconnecting"
+                    );
+                    true
+                }
+                Err(ref e) if is_expected_disconnect(e) => {
+                    tracing::debug!(
+                        host = %host_name,
+                        container_id = %task_container_id,
+                        "Docker log stream closed by daemon; reconnecting"
                     );
                     true
                 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches local MCP dev to stdio (`./bin/syslog mcp`) and hardens Docker log ingestion with TCP keepalive and smarter reconnects. Also bumps to v0.10.1 and adds a fleet expansion planning doc.

- **Bug Fixes**
  - Enabled TCP keepalive on the `bollard` HTTP client via a custom `hyper`/`hyper-util` transport to prevent idle stream drops (logs/events).
  - Classified common daemon idle-closes as expected (“error reading a body from connection”, “connection reset by peer”, “broken pipe”); log at DEBUG and reset backoff.
  - Reset per-container reconnect backoff on normal stream end to avoid unnecessary exponential delays.

- **Migration**
  - Local dev MCP now uses stdio: `./bin/syslog mcp` (see `.mcp.json`). No HTTP server or token needed; set `SYSLOG_MCP_DB_PATH` as needed.

<sup>Written for commit 0481a073d8a214e0e4c487a82f5335ef790f9585. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive documentation for session bootstrap and expansion guidance.

* **Improvements**
  * Enhanced Docker connection handling with keep-alive transport for improved reliability.
  * Improved error detection and backoff logic for Docker log stream reconnections.
  * Updated MCP configuration to use stdio-based transport instead of HTTP.

* **Chores**
  * Version bumped to 0.10.1.
  * Updated dependencies and reorganized configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->