### PR TITLE
feat: OTLP HTTP receiver + enrichment + tag-based retention (0.11.0)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,6 +55,7 @@ jobs:
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
+          file: config/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-07
+
+### Added
+
+- **OTLP HTTP receiver** (`src/otlp.rs`): `POST /v1/logs` decodes
+  `ExportLogsServiceRequest` protobuf and feeds records through the existing
+  ingest pipeline. `POST /v1/metrics` returns 200 and discards. `POST /v1/traces`
+  returns 404 — span flattening was deferred (FTS5 cannot meaningfully query
+  hex trace IDs). New deps: `opentelemetry-proto = 0.31` (logs feature only,
+  no full gRPC) and `prost = 0.14`.
+- **OTLP receiver hardening**: `RequestBodyLimitLayer` of 4 MiB on `/v1/*`
+  with automatic `Retry-After: 86400` header on 413 to prevent OTel exporter
+  retry storms. Optional Bearer auth via the existing `SYSLOG_MCP_API_TOKEN`.
+  Peer IP captured via `ConnectInfo<SocketAddr>` and stored as `source_ip`
+  to mirror the syslog provenance model — OTLP `host.name` is client-asserted
+  and untrusted.
+- **`/health` enrichment**: response now includes `otlp_logs_received` and
+  `otlp_decode_errors` counters so operators can see ingest activity at a
+  glance.
+- **Pre-insert enrichment** (`src/syslog/enrichment.rs`): Authelia
+  `level=` parsing maps `info/warn/error/fatal` to syslog severities;
+  AdGuard JSON query log gets reclassified to `adguard-blocked` /
+  `adguard-allowed` / `adguard-rewrite`. Source-IP gating via
+  `SYSLOG_MCP_AUTHELIA_SOURCE_IP` and `SYSLOG_MCP_ADGUARD_SOURCE_IP`
+  prevents other tailnet hosts from spoofing the classification.
+- **Best-effort secret scrubbing** for AI-source records (Claude/Codex
+  transcripts and OTLP records carrying `service.name=claude-code|codex`).
+  Eight pattern classes plus the `SYSLOG_MCP_API_TOKEN` literal value.
+  Toggle with `SYSLOG_MCP_SCRUB_PROMPTS` (default `true`). Documented as
+  defense-in-depth, **not** a compliance control — regex has structural
+  bypass classes.
+- **Tag-based retention** (`db::purge_by_tag_window`): adguard-allowed,
+  adguard-query, and adguard-rewrite are purged at 7 days regardless of
+  the global `retention_days`. High-severity rows are exempt from time-based
+  purge in both `purge_by_tag_window` and `purge_old_logs`.
+- **Configurable FTS merge** via `SYSLOG_MCP_FTS_MERGE_PAGES` (default 0
+  = unconditional merge after every purge cycle).
+- **Deploy artifacts** (`deploy/`): rsyslog drop-ins for imjournal +
+  AI transcripts + squirts specialty sources, OTel client config examples
+  for Claude Code and Codex, and a step-by-step manual SSH deploy runbook.
+
+### Changed
+
+- **Migration v3**: composite index `idx_logs_app_name_received_at ON
+  logs(app_name, received_at)` added to make tag-based retention
+  O(rows-deleted) instead of O(rows-in-tag-partition × chunks). On a
+  multi-million-row DB the first-run `CREATE INDEX` may hold the write
+  lock for several minutes; `/health` will not respond and syslog UDP may
+  drop during that window. Plan a brief health-check gap when upgrading.
+- **`enforce_storage_budget` instrumentation**: emits `tracing::warn!`
+  when deleting rows with `severity IN ('err','crit','alert','emerg')` so
+  operators are not surprised when disk pressure overrides the time-based
+  retention exemption.
+- **Maintenance task ordering**: tag-window purges now run *before* global
+  retention purge to avoid SQLite write-lock contention from concurrent
+  chunked DELETEs.
+- **`IngestTx::try_send`**: new non-blocking send used by the OTLP handler
+  so HTTP requests return 503 on backpressure instead of awaiting and
+  holding the connection open.
+
+### Notes
+
+- **Phases 3–5 are deploy-only.** The Rust binary is complete; deploying
+  rsyslog drop-ins and OTel client configs to dookie / squirts /
+  steamy-wsl / vivobook-wsl requires manual SSH per `deploy/README.md`.
+
 ## [0.10.2] - 2026-05-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +952,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "js-sys",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "thiserror",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1020,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1035,6 +1105,29 @@ dependencies = [
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1118,6 +1211,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1556,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1566,8 +1671,11 @@ dependencies = [
  "futures-util",
  "hyper",
  "hyper-util",
+ "opentelemetry-proto",
+ "prost",
  "r2d2",
  "r2d2_sqlite",
+ "regex",
  "rmcp",
  "rusqlite",
  "rustix 0.38.44",
@@ -1771,6 +1879,38 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"
@@ -60,8 +60,17 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 subtle = "2"
 rustix = { version = "0.38", features = ["fs"] }
+regex = "1"
 
 futures-util = "0.3"
+
+# OTLP HTTP receiver — message types only, no gRPC transport
+opentelemetry-proto = { version = "0.31", default-features = false, features = [
+  "gen-tonic-messages",
+  "logs",
+] }
+prost = "0.14"
+
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,173 @@
+# Fleet Deployment — syslog-mcp expansion
+
+These artifacts deploy the operational side of epic
+[`syslog-mcp-6uoy`](#) (full-fleet log ingest + OTLP). Phase 1 (OTLP receiver)
+and Phase 2 (enrichment + retention) are pure Rust changes already in the
+syslog-mcp binary; the files in this directory are the manual deployment
+steps for Phases 3–5.
+
+**Deploy mechanism: manual SSH per host.** No Ansible, no automation — match
+the rest of the homelab's posture.
+
+---
+
+## Phase 3 — host-wide journald + AI transcripts
+
+Hosts: **dookie, squirts, steamy-wsl, vivobook-wsl**.
+
+### Prerequisites
+
+* WSL hosts (steamy-wsl, vivobook-wsl) need `[boot] systemd=true` in
+  `/etc/wsl.conf`, then `wsl --shutdown` from PowerShell to restart. Verify
+  with `systemctl status` after restart — must show "running."
+* `/var/spool/rsyslog/` must exist on every host. Create with
+  `sudo mkdir -p /var/spool/rsyslog && sudo chown syslog:syslog /var/spool/rsyslog`
+  if absent.
+
+### Deploy (per host)
+
+```bash
+# imjournal — all four hosts
+scp deploy/rsyslog/10-imjournal.conf <host>:/tmp/
+ssh <host> 'sudo mv /tmp/10-imjournal.conf /etc/rsyslog.d/ \
+  && sudo rsyslogd -N1 \
+  && sudo systemctl restart rsyslog'
+
+# AI transcripts — dookie, steamy-wsl, vivobook-wsl ONLY (skip squirts)
+scp deploy/rsyslog/40-ai-transcripts.conf <host>:/tmp/
+ssh <host> 'sudo mv /tmp/40-ai-transcripts.conf /etc/rsyslog.d/ \
+  && sudo rsyslogd -N1 \
+  && sudo systemctl restart rsyslog'
+```
+
+WSL alternative to `systemctl restart`: `sudo service rsyslog restart`.
+
+### Verify
+
+```bash
+# Generate a test journald entry, confirm it arrives
+ssh <host> 'logger -t deploy-test "hello from journald"'
+mcporter call --config config/mcporter.json syslog-mcp.search query=deploy-test limit=5
+
+# After a claude session runs, confirm transcripts arrive
+mcporter call --config config/mcporter.json syslog-mcp.search 'tag:claude-transcript' limit=5
+```
+
+---
+
+## Phase 4 — squirts specialty sources
+
+Three drop-ins, deploy in the **specified order** (authelia → swag → adguard).
+The order matters: AdGuard is the highest-volume source — deploy it last so
+the other sources are already stable.
+
+### Resolve `<PATH-TO-...>` placeholders first
+
+```bash
+ssh squirts 'find /mnt /opt /srv -name authelia.log     2>/dev/null | head -3'
+ssh squirts 'find /mnt /opt /srv -path "*/nginx/access.log" 2>/dev/null | head -3'
+ssh squirts 'find /mnt /opt /srv -path "*/nginx/error.log"  2>/dev/null | head -3'
+ssh squirts 'find /mnt /opt /srv -path "*/fail2ban/fail2ban.log" 2>/dev/null | head -3'
+ssh squirts 'find /mnt /opt /srv -name querylog.json    2>/dev/null | head -3'
+```
+
+Edit each `.conf` to substitute the real paths before scp'ing.
+
+### Deploy
+
+```bash
+# 1. authelia
+scp deploy/rsyslog/35-authelia.conf squirts:/tmp/
+ssh squirts 'sudo mv /tmp/35-authelia.conf /etc/rsyslog.d/ \
+  && sudo rsyslogd -N1 \
+  && sudo systemctl restart rsyslog'
+
+# 2. SWAG (nginx + fail2ban)
+scp deploy/rsyslog/30-swag.conf squirts:/tmp/
+ssh squirts 'sudo mv /tmp/30-swag.conf /etc/rsyslog.d/ \
+  && sudo rsyslogd -N1 \
+  && sudo systemctl restart rsyslog'
+
+# 3. AdGuard — LAST
+scp deploy/rsyslog/36-adguard.conf squirts:/tmp/
+ssh squirts 'sudo mv /tmp/36-adguard.conf /etc/rsyslog.d/ \
+  && sudo rsyslogd -N1 \
+  && sudo systemctl restart rsyslog'
+```
+
+### Vaultwarden gap check
+
+Before adding a vaultwarden imfile drop-in, check whether its events are
+already arriving via container stdout ingestion:
+
+```bash
+mcporter call --config config/mcporter.json syslog-mcp.search query=vaultwarden limit=10
+```
+
+If you see auth events, no further action. If empty, add a drop-in similar
+to `35-authelia.conf` pointed at vaultwarden's log file.
+
+### Optional source-IP gating
+
+Set these in syslog-mcp's environment (`/.env` or compose) to prevent other
+tailnet hosts from sending crafted messages with `tag=authelia` or
+`tag=adguard-query` to spoof severity/classification:
+
+```bash
+SYSLOG_MCP_AUTHELIA_SOURCE_IP=100.74.16.82   # squirts tailnet IP
+SYSLOG_MCP_ADGUARD_SOURCE_IP=100.74.16.82
+```
+
+---
+
+## Phase 5 — OTel client config (claude code + codex)
+
+Hosts: **dookie, steamy-wsl, vivobook-wsl**.
+
+### Prerequisite
+
+Phase 1 must be deployed and healthy first:
+
+```bash
+curl -s http://dookie:3100/health | jq
+# {"status":"ok","otlp_logs_received":0,"otlp_decode_errors":0}
+```
+
+### Claude Code
+
+`~/.claude/settings.json` — **merge** the `env` block from
+`deploy/otel/claude-code-settings.example.json` into the existing file
+(do not overwrite). On a fresh host, copy the example file directly.
+
+### Codex
+
+`~/.codex/config.toml` — append the `[otel]` block from
+`deploy/otel/codex-config.example.toml`. Create the file if absent.
+
+### Verify
+
+After each config change, start a new claude/codex session, then:
+
+```bash
+# Should increment after each session
+curl -s http://dookie:3100/health | jq .otlp_logs_received
+
+# Records should be searchable
+mcporter call --config config/mcporter.json syslog-mcp.search 'service:claude-code' limit=5
+```
+
+---
+
+## Rollback
+
+* **rsyslog drop-ins (Phase 3, 4):** delete the `.conf` from
+  `/etc/rsyslog.d/` and restart rsyslog. No data loss; future events stop
+  flowing.
+* **OTel client config (Phase 5):** unset the env keys (Claude) or remove
+  the `[otel]` block (Codex). Already-stored records remain.
+* **OTLP receiver (Phase 1):** revert the syslog-mcp container to a
+  pre-0.11 image. The receiver routes simply disappear; existing syslog
+  ingest continues unaffected.
+* **Migration v3 (Phase 2):** the composite index can be dropped with
+  `DROP INDEX idx_logs_app_name_received_at` if it causes any issue.
+  Tag-based retention purges become slower but otherwise still correct.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
 # Fleet Deployment — syslog-mcp expansion
 
 These artifacts deploy the operational side of epic
-[`syslog-mcp-6uoy`](#) (full-fleet log ingest + OTLP). Phase 1 (OTLP receiver)
+`syslog-mcp-6uoy` (full-fleet log ingest + OTLP). Phase 1 (OTLP receiver)
 and Phase 2 (enrichment + retention) are pure Rust changes already in the
 syslog-mcp binary; the files in this directory are the manual deployment
 steps for Phases 3–5.

--- a/deploy/otel/claude-code-settings.example.json
+++ b/deploy/otel/claude-code-settings.example.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Merge this 'env' block into your existing ~/.claude/settings.json — DO NOT overwrite the whole file. Endpoint targets the syslog-mcp host (currently dookie:3100). Verify Phase 1 is healthy first: curl -s http://dookie:3100/health | jq .otlp_logs_received",
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://dookie:3100",
+    "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "cumulative",
+    "OTEL_METRIC_EXPORT_INTERVAL": "10000",
+    "OTEL_LOGS_EXPORT_INTERVAL": "5000",
+    "OTEL_LOG_USER_PROMPTS": "1",
+    "OTEL_LOG_TOOL_DETAILS": "1"
+  }
+}

--- a/deploy/otel/claude-code-settings.example.json
+++ b/deploy/otel/claude-code-settings.example.json
@@ -1,11 +1,14 @@
 {
-  "_comment": "Merge this 'env' block into your existing ~/.claude/settings.json — DO NOT overwrite the whole file. Endpoint targets the syslog-mcp host (currently dookie:3100). Verify Phase 1 is healthy first: curl -s http://dookie:3100/health | jq .otlp_logs_received",
+  "_comment_merge": "Merge this 'env' block into your existing ~/.claude/settings.json — DO NOT overwrite the whole file. Endpoint targets the syslog-mcp host (currently dookie:3100). Verify Phase 1 is healthy first: curl -s http://dookie:3100/health | jq .otlp_logs_received",
+  "_comment_auth": "If you set SYSLOG_MCP_TOKEN on the receiver, every OTLP request must carry an Authorization header. Add OTEL_EXPORTER_OTLP_HEADERS=\"Authorization=Bearer YOUR_TOKEN\" to the env block below. Without it, the receiver returns 401 and the exporter retries forever.",
+  "_comment_privacy": "OTEL_LOG_USER_PROMPTS=1 sends verbatim prompt text. OTEL_LOG_TOOL_DETAILS=1 sends tool call output (file reads, command stdout). Both are stored as plaintext in syslog-mcp's SQLite database and FTS5-indexed. The receiver's defense-in-depth scrubber (SYSLOG_MCP_SCRUB_PROMPTS=true, default) redacts known credential patterns — best-effort, not a compliance control. Do not enable on shared/public networks.",
   "env": {
     "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
     "OTEL_METRICS_EXPORTER": "otlp",
     "OTEL_LOGS_EXPORTER": "otlp",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "http://dookie:3100",
+    "_OTEL_EXPORTER_OTLP_HEADERS_example": "Authorization=Bearer your_token_here",
     "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "cumulative",
     "OTEL_METRIC_EXPORT_INTERVAL": "10000",
     "OTEL_LOGS_EXPORT_INTERVAL": "5000",

--- a/deploy/otel/codex-config.example.toml
+++ b/deploy/otel/codex-config.example.toml
@@ -1,0 +1,15 @@
+# Append to ~/.codex/config.toml on each dev host (dookie, steamy-wsl, vivobook-wsl).
+# Endpoint targets the syslog-mcp host (currently dookie:3100). Phase 1 of the
+# OTLP receiver must be deployed first.
+#
+# Caveat: codex `exec` and `mcp-server` emit no telemetry. Only interactive
+# codex sessions do. The JSONL transcript pipeline (40-ai-transcripts.conf)
+# covers what OTel misses.
+#
+# trace_exporter is omitted because syslog-mcp's /v1/traces returns 404
+# (deferred — see CHANGELOG 0.11.0 for rationale).
+
+[otel]
+environment = "homelab"
+log_user_prompt = true
+exporter = { otlp-http = { endpoint = "http://dookie:3100/v1/logs", protocol = "binary" } }

--- a/deploy/rsyslog/10-imjournal.conf
+++ b/deploy/rsyslog/10-imjournal.conf
@@ -3,6 +3,18 @@
 # Required on all Ubuntu 22.04+ hosts (and WSL2 with [boot] systemd=true).
 # Without this, rsyslog only sees what /dev/log + imklog catch — most service
 # stderr never makes it into the forwarded stream.
+#
+# Ratelimit.Interval=0 / Ratelimit.Burst=0 disables rsyslog's per-input rate
+# limit. This is intentional: a misbehaving service that bursts thousands of
+# log lines should still be visible (that IS the diagnostic signal). The
+# storage-budget enforcement (SYSLOG_MCP_MAX_DB_SIZE_MB / MIN_FREE_DISK_MB)
+# acts as the actual ceiling on disk usage; per-input drops would just hide
+# the burst from operators while the writer keeps consuming.
+#
+# Trade-off: a runaway log producer can fill the channel + DB faster than
+# normal. Storage enforcement and tag-based retention bound the worst case.
+# If a specific noisy unit is known and unwanted, blacklist it inside
+# imjournal via Filter or via journalctl --vacuum settings on the source.
 
 module(load="imjournal"
        StateFile="/var/spool/rsyslog/imjournal.state"

--- a/deploy/rsyslog/10-imjournal.conf
+++ b/deploy/rsyslog/10-imjournal.conf
@@ -1,0 +1,10 @@
+# /etc/rsyslog.d/10-imjournal.conf
+# Bridge journald → rsyslog so systemd-managed services are visible to syslog-mcp.
+# Required on all Ubuntu 22.04+ hosts (and WSL2 with [boot] systemd=true).
+# Without this, rsyslog only sees what /dev/log + imklog catch — most service
+# stderr never makes it into the forwarded stream.
+
+module(load="imjournal"
+       StateFile="/var/spool/rsyslog/imjournal.state"
+       Ratelimit.Interval="0"
+       Ratelimit.Burst="0")

--- a/deploy/rsyslog/30-swag.conf
+++ b/deploy/rsyslog/30-swag.conf
@@ -1,0 +1,39 @@
+# /etc/rsyslog.d/30-swag.conf
+# Tail SWAG nginx access/error logs and fail2ban events.
+#
+# Deploy on: squirts only.
+#
+# REPLACE the three placeholder paths with actual filesystem paths on squirts:
+#   find /mnt /opt /srv -path '*/nginx/access.log' 2>/dev/null
+#   find /mnt /opt /srv -path '*/nginx/error.log' 2>/dev/null
+#   find /mnt /opt /srv -path '*/fail2ban/fail2ban.log' 2>/dev/null
+# Likely under /mnt/user/appdata/swag/log/...
+#
+# MaxMessageSize 64k handles long URLs + bot fingerprints in nginx access lines.
+# startmsg.regex on fail2ban anchors on the YYYY-MM-DD timestamp prefix so
+# multi-line ban/unban events don't fragment.
+
+$MaxMessageSize 64k
+module(load="imfile")
+
+input(type="imfile"
+      File="<PATH-TO-NGINX-ACCESS.LOG>"
+      Tag="swag-access"
+      Facility="local4"
+      Severity="info"
+      PersistStateInterval="100")
+
+input(type="imfile"
+      File="<PATH-TO-NGINX-ERROR.LOG>"
+      Tag="swag-error"
+      Facility="local4"
+      Severity="warning"
+      PersistStateInterval="100")
+
+input(type="imfile"
+      File="<PATH-TO-FAIL2BAN.LOG>"
+      Tag="fail2ban"
+      Facility="local5"
+      Severity="info"
+      startmsg.regex="^[0-9]{4}-[0-9]{2}-[0-9]{2}"
+      PersistStateInterval="100")

--- a/deploy/rsyslog/35-authelia.conf
+++ b/deploy/rsyslog/35-authelia.conf
@@ -1,0 +1,26 @@
+# /etc/rsyslog.d/35-authelia.conf
+# Tail Authelia's structured log file. We deliberately keep Authelia
+# file-based rather than redirecting to stdout so a syslog-mcp outage cannot
+# disturb a live auth stack.
+#
+# Deploy on: squirts only.
+#
+# REPLACE <PATH-TO-AUTHELIA.LOG> with the actual filesystem path on squirts:
+#   find /mnt /opt /srv -name 'authelia.log' 2>/dev/null
+# Likely under /mnt/user/appdata/authelia/config/authelia.log
+#
+# startmsg.regex='^time=' glomms multi-line panics + stack traces into a single
+# syslog message instead of fragmenting them.
+#
+# Severity reclassification (info → warning/err/crit) happens at syslog-mcp
+# ingest by parsing 'level=' from the message body.
+
+module(load="imfile")
+
+input(type="imfile"
+      File="<PATH-TO-AUTHELIA.LOG>"
+      Tag="authelia"
+      Facility="local5"
+      Severity="info"
+      startmsg.regex="^time="
+      PersistStateInterval="100")

--- a/deploy/rsyslog/35-authelia.conf
+++ b/deploy/rsyslog/35-authelia.conf
@@ -9,7 +9,7 @@
 #   find /mnt /opt /srv -name 'authelia.log' 2>/dev/null
 # Likely under /mnt/user/appdata/authelia/config/authelia.log
 #
-# startmsg.regex='^time=' glomms multi-line panics + stack traces into a single
+# startmsg.regex='^time=' gloms multi-line panics + stack traces into a single
 # syslog message instead of fragmenting them.
 #
 # Severity reclassification (info → warning/err/crit) happens at syslog-mcp

--- a/deploy/rsyslog/36-adguard.conf
+++ b/deploy/rsyslog/36-adguard.conf
@@ -1,0 +1,27 @@
+# /etc/rsyslog.d/36-adguard.conf
+# Tail AdGuard's JSON query log. High volume — deploy LAST after authelia
+# and SWAG configs are confirmed stable.
+#
+# Deploy on: squirts only.
+#
+# REPLACE <PATH-TO-QUERYLOG.JSON> with the actual filesystem path:
+#   find /mnt /opt /srv -name 'querylog.json' 2>/dev/null
+# Likely under /mnt/user/appdata/adguard/work/data/querylog.json
+#
+# Tag classification (adguard-blocked / adguard-allowed / adguard-rewrite)
+# happens at syslog-mcp ingest by parsing the JSON Result.IsFiltered and
+# Reason fields. Optionally set SYSLOG_MCP_ADGUARD_SOURCE_IP=<squirts-ip>
+# in syslog-mcp's environment to gate this enrichment to squirts only.
+#
+# Tag-based retention (Phase 2) purges adguard-allowed/query/rewrite at 7d
+# regardless of the global retention_days setting.
+
+$MaxMessageSize 32k
+module(load="imfile")
+
+input(type="imfile"
+      File="<PATH-TO-QUERYLOG.JSON>"
+      Tag="adguard-query"
+      Facility="local6"
+      Severity="info"
+      PersistStateInterval="500")

--- a/deploy/rsyslog/40-ai-transcripts.conf
+++ b/deploy/rsyslog/40-ai-transcripts.conf
@@ -1,0 +1,31 @@
+# /etc/rsyslog.d/40-ai-transcripts.conf
+# Tail claude/codex JSONL transcripts so syslog-mcp can correlate AI session
+# activity with infrastructure events by host + time. axon already has these
+# transcripts for semantic recall — this is the structured-query pipeline.
+#
+# Deploy on: dookie, steamy-wsl, vivobook-wsl (NOT squirts).
+#
+# MaxMessageSize 256k bumps from the 8KB default — tool results + large diffs
+# routinely blow past that and get truncated.
+#
+# addMetadata=on attaches the source filename (project path) so individual
+# claude projects can be filtered server-side.
+
+$MaxMessageSize 256k
+module(load="imfile")
+
+input(type="imfile"
+      File="/home/jacob/.claude/projects/*/*.jsonl"
+      Tag="claude-transcript"
+      Facility="local7"
+      Severity="info"
+      addMetadata="on"
+      PersistStateInterval="50")
+
+input(type="imfile"
+      File="/home/jacob/.codex/sessions/*.jsonl"
+      Tag="codex-transcript"
+      Facility="local7"
+      Severity="info"
+      addMetadata="on"
+      PersistStateInterval="50")

--- a/deploy/rsyslog/40-ai-transcripts.conf
+++ b/deploy/rsyslog/40-ai-transcripts.conf
@@ -14,8 +14,12 @@
 $MaxMessageSize 256k
 module(load="imfile")
 
+# REPLACE <USER-HOME> with the actual home directory of the user running
+# claude/codex (typically /home/<username> or /Users/<username> on macOS).
+# Example: /home/jacob/.claude/projects/*/*.jsonl
+
 input(type="imfile"
-      File="/home/jacob/.claude/projects/*/*.jsonl"
+      File="<USER-HOME>/.claude/projects/*/*.jsonl"
       Tag="claude-transcript"
       Facility="local7"
       Severity="info"
@@ -23,7 +27,7 @@ input(type="imfile"
       PersistStateInterval="50")
 
 input(type="imfile"
-      File="/home/jacob/.codex/sessions/*.jsonl"
+      File="<USER-HOME>/.codex/sessions/*.jsonl"
       Tag="codex-transcript"
       Facility="local7"
       Severity="info"

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,8 +8,9 @@ use axum::{
 };
 use serde::Deserialize;
 use serde_json::json;
-use subtle::ConstantTimeEq;
 use tower_http::cors::{Any, CorsLayer};
+
+use crate::auth::{bearer_token, token_matches};
 
 use crate::app::{
     CorrelateEventsRequest, GetErrorsRequest, SearchLogsRequest, SyslogService, TailLogsRequest,
@@ -220,35 +221,6 @@ fn cors_layer(port: u16) -> CorsLayer {
         ])
         .allow_methods([axum::http::Method::GET])
         .allow_headers(Any)
-}
-
-fn bearer_token(auth: &str) -> Option<&str> {
-    let mut parts = auth.split_whitespace();
-    let scheme = parts.next()?;
-    let token = parts.next()?;
-    if parts.next().is_some() || !scheme.eq_ignore_ascii_case("bearer") {
-        return None;
-    }
-    Some(token)
-}
-
-fn token_matches(provided: &str, expected: &str) -> bool {
-    const MAX_TOKEN_LEN: usize = 4096;
-    if provided.len() > MAX_TOKEN_LEN || expected.len() > MAX_TOKEN_LEN {
-        return false;
-    }
-
-    let mut provided_buf = [0_u8; MAX_TOKEN_LEN];
-    let mut expected_buf = [0_u8; MAX_TOKEN_LEN];
-    provided_buf[..provided.len()].copy_from_slice(provided.as_bytes());
-    expected_buf[..expected.len()].copy_from_slice(expected.as_bytes());
-
-    let bytes_match = provided_buf.ct_eq(&expected_buf).unwrap_u8() == 1;
-    let lengths_match = (provided.len() as u64)
-        .ct_eq(&(expected.len() as u64))
-        .unwrap_u8()
-        == 1;
-    bytes_match && lengths_match
 }
 
 #[cfg(test)]

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,36 @@
+//! Constant-time Bearer-token helpers shared by every auth-bearing surface
+//! (MCP, non-MCP API, OTLP). Single source of truth for token comparison
+//! avoids drift on a security-critical primitive.
+
+use subtle::ConstantTimeEq;
+
+/// Extract the token from an `Authorization: Bearer <token>` header value.
+/// Returns `None` if the value is malformed or uses a non-Bearer scheme.
+pub(crate) fn bearer_token(auth: &str) -> Option<&str> {
+    let mut parts = auth.split_whitespace();
+    let scheme = parts.next()?;
+    let token = parts.next()?;
+    if parts.next().is_some() || !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    Some(token)
+}
+
+/// Constant-time comparison of two token strings. Both length and bytes are
+/// compared in constant time to avoid leaking either via timing.
+pub(crate) fn token_matches(provided: &str, expected: &str) -> bool {
+    const MAX_TOKEN_LEN: usize = 4096;
+    if provided.len() > MAX_TOKEN_LEN || expected.len() > MAX_TOKEN_LEN {
+        return false;
+    }
+    let mut a = [0_u8; MAX_TOKEN_LEN];
+    let mut b = [0_u8; MAX_TOKEN_LEN];
+    a[..provided.len()].copy_from_slice(provided.as_bytes());
+    b[..expected.len()].copy_from_slice(expected.as_bytes());
+    let bytes_match = a.ct_eq(&b).unwrap_u8() == 1;
+    let lens_match = (provided.len() as u64)
+        .ct_eq(&(expected.len() as u64))
+        .unwrap_u8()
+        == 1;
+    bytes_match && lens_match
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,40 @@ pub struct Config {
     pub mcp: McpConfig,
     pub api: ApiConfig,
     pub docker_ingest: DockerIngestConfig,
+    pub enrichment: EnrichmentConfigToml,
+}
+
+/// Enrichment + scrubbing knobs. Loaded from `[enrichment]` in `config.toml`
+/// or from `SYSLOG_MCP_*` env vars at runtime startup.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EnrichmentConfigToml {
+    /// If set, only apply Authelia severity reclassification when an entry's
+    /// `source_ip` starts with this prefix. Prevents non-Authelia hosts from
+    /// spoofing severity by sending crafted messages with `tag=authelia`.
+    pub authelia_source_ip: Option<String>,
+    /// Same gating, for AdGuard JSON tag classification.
+    pub adguard_source_ip: Option<String>,
+    /// Best-effort credential scrubbing on AI-source records. Default true.
+    /// Set to false only if downstream consumers need raw prompt text and
+    /// you trust every tailnet node.
+    pub scrub_prompts: bool,
+    /// FTS5 incremental merge segment threshold. M=0 forces unconditional
+    /// merge after every purge cycle (recommended for the AdGuard delete
+    /// workload). Increase if M=0 holds the write lock too long on a large
+    /// index. Range: 0..=10000.
+    pub fts_merge_pages: u32,
+}
+
+impl Default for EnrichmentConfigToml {
+    fn default() -> Self {
+        Self {
+            authelia_source_ip: None,
+            adguard_source_ip: None,
+            scrub_prompts: true,
+            fts_merge_pages: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -358,6 +392,23 @@ impl Config {
 
         env_override_bool("SYSLOG_API_ENABLED", &mut config.api.enabled)?;
         env_override_opt_str("SYSLOG_API_TOKEN", &mut config.api.api_token);
+
+        env_override_opt_str(
+            "SYSLOG_MCP_AUTHELIA_SOURCE_IP",
+            &mut config.enrichment.authelia_source_ip,
+        );
+        env_override_opt_str(
+            "SYSLOG_MCP_ADGUARD_SOURCE_IP",
+            &mut config.enrichment.adguard_source_ip,
+        );
+        env_override_bool(
+            "SYSLOG_MCP_SCRUB_PROMPTS",
+            &mut config.enrichment.scrub_prompts,
+        )?;
+        env_override_parse(
+            "SYSLOG_MCP_FTS_MERGE_PAGES",
+            &mut config.enrichment.fts_merge_pages,
+        )?;
 
         env_override_bool(
             "SYSLOG_DOCKER_INGEST_ENABLED",

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,6 +409,12 @@ impl Config {
             "SYSLOG_MCP_FTS_MERGE_PAGES",
             &mut config.enrichment.fts_merge_pages,
         )?;
+        if config.enrichment.fts_merge_pages > 10_000 {
+            return Err(anyhow::anyhow!(
+                "SYSLOG_MCP_FTS_MERGE_PAGES must be in 0..=10000, got {}",
+                config.enrichment.fts_merge_pages
+            ));
+        }
 
         env_override_bool(
             "SYSLOG_DOCKER_INGEST_ENABLED",

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,7 +8,8 @@ mod queries;
 
 pub use ingest::insert_logs_batch;
 pub use maintenance::{
-    enforce_storage_budget, get_storage_metrics, purge_old_logs, DiskSpaceProbe,
+    enforce_storage_budget, get_storage_metrics, purge_by_tag_window, purge_old_logs,
+    DiskSpaceProbe,
 };
 pub use models::{
     DbStats, DockerCheckpoint, ErrorSummaryEntry, HostEntry, LogBatchEntry, LogEntry, SearchParams,

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -142,7 +142,9 @@ pub fn enforce_storage_budget_with_probe(
         // (DELETE trigger is intentionally absent).
         // drop the connection before checkpoint_wal_and_incremental_vacuum to
         // avoid pool exhaustion when pool_size = 1.
-        fts_incremental_merge(pool, deleted_rows);
+        // Hardcoded M=0 here — storage enforcement is rare, force unconditional
+        // merge. Tunable M only matters for the regular retention path.
+        fts_incremental_merge(pool, deleted_rows, 0);
 
         checkpoint_wal_and_incremental_vacuum(pool)?;
     }
@@ -173,17 +175,22 @@ pub fn enforce_storage_budget_with_probe(
 /// fragmented FTS index.
 ///
 /// Best-effort: errors are logged but never propagated.
-fn fts_incremental_merge(pool: &DbPool, deleted_rows: usize) {
-    // Budget one merge=500,250 call per 5 000 deleted rows (rough heuristic),
+fn fts_incremental_merge(pool: &DbPool, deleted_rows: usize, merge_pages: u32) {
+    // Budget one merge=500,M call per 5 000 deleted rows (rough heuristic),
     // with a floor of 1 and a ceiling of 20 to bound wall-clock time.
     let iterations = deleted_rows.div_ceil(5000).clamp(1, 20);
     let mut consecutive_failures: u32 = 0;
+    // M=0 forces unconditional merge regardless of segment count, which is
+    // the right choice after bulk DELETEs (level-0 segments may be too few
+    // to satisfy the default M=250 threshold). Operators can raise M via
+    // SYSLOG_MCP_FTS_MERGE_PAGES if M=0 holds the write lock too long on a
+    // very large index — config rollback rather than binary rollback.
+    let merge_stmt = format!("INSERT INTO logs_fts(logs_fts) VALUES('merge=500,{merge_pages}');");
 
     for i in 0..iterations {
         match pool.get() {
             Ok(conn) => {
-                match conn.execute_batch("INSERT INTO logs_fts(logs_fts) VALUES('merge=500,250');")
-                {
+                match conn.execute_batch(&merge_stmt) {
                     Ok(()) => {
                         consecutive_failures = 0;
                         tracing::trace!(
@@ -246,10 +253,17 @@ fn fts_incremental_merge(pool: &DbPool, deleted_rows: usize) {
 /// Uses chunked DELETEs (10 000 rows per iteration) so the WAL write lock is
 /// released between chunks, letting the batch writer proceed without timing out
 /// or overflowing its 1 000-entry cap.  After all chunks complete, an
-/// incremental FTS5 merge is issued instead of a full rebuild — `merge=500,250`
+/// incremental FTS5 merge is issued instead of a full rebuild — `merge=500,M`
 /// processes at most a bounded number of index pages per call and holds the
 /// write lock for milliseconds rather than seconds.
-pub fn purge_old_logs(pool: &DbPool, retention_days: u32) -> Result<usize> {
+///
+/// **High-severity exemption:** rows with `severity IN ('err','crit','alert','emerg')`
+/// are excluded from time-based purge — they are never aged out by retention.
+/// They CAN still be deleted by `enforce_storage_budget` under disk pressure
+/// (oldest-first, no severity filter). Permanent err+ retention is therefore
+/// only guaranteed if the DB never breaches `max_db_size_mb` or
+/// `min_free_disk_mb`. See CLAUDE.md "Retention" for the policy interaction.
+pub fn purge_old_logs(pool: &DbPool, retention_days: u32, fts_merge_pages: u32) -> Result<usize> {
     if retention_days == 0 {
         return Ok(0);
     }
@@ -273,7 +287,10 @@ pub fn purge_old_logs(pool: &DbPool, retention_days: u32) -> Result<usize> {
         let conn = pool.get()?;
         let chunk = conn.execute(
             "DELETE FROM logs WHERE id IN (
-                 SELECT id FROM logs WHERE received_at < ?1 LIMIT 10000
+                 SELECT id FROM logs
+                 WHERE received_at < ?1
+                   AND severity NOT IN ('err', 'crit', 'alert', 'emerg')
+                 LIMIT 10000
              )",
             params![cutoff],
         )?;
@@ -287,7 +304,7 @@ pub fn purge_old_logs(pool: &DbPool, retention_days: u32) -> Result<usize> {
 
     // Incremental FTS merge — much shorter write-lock duration than full rebuild.
     if total_deleted > 0 {
-        fts_incremental_merge(pool, total_deleted);
+        fts_incremental_merge(pool, total_deleted, fts_merge_pages);
     }
 
     // Passive WAL checkpoint: attempt to move WAL pages into the main DB file
@@ -300,6 +317,72 @@ pub fn purge_old_logs(pool: &DbPool, retention_days: u32) -> Result<usize> {
     }
 
     tracing::info!(deleted = total_deleted, cutoff = %cutoff, "Purged old logs");
+    Ok(total_deleted)
+}
+
+/// Delete rows for a single `app_name` older than `max_days`.
+///
+/// Same chunked-DELETE pattern as [`purge_old_logs`] (10 000 rows per
+/// iteration with the WAL lock released between chunks). Rows with
+/// `severity IN ('err','crit','alert','emerg')` are excluded — high-severity
+/// log entries are protected from time-based purge regardless of source.
+///
+/// Designed for short-retention tags (e.g. `adguard-allowed` at 7 days)
+/// running on the new composite index `(app_name, received_at)` introduced
+/// by Migration 3. **MUST run before [`purge_old_logs`]** in the maintenance
+/// task to avoid SQLite write-lock contention from concurrent chunked
+/// DELETEs over the same table.
+///
+/// Uses [`fts_incremental_merge`] after the loop because FTS5 DELETE triggers
+/// were intentionally dropped in Migration 1 — phantoms otherwise accumulate.
+pub fn purge_by_tag_window(
+    pool: &DbPool,
+    app_name: &str,
+    max_days: u32,
+    fts_merge_pages: u32,
+) -> Result<usize> {
+    if max_days == 0 {
+        return Ok(0);
+    }
+
+    let cutoff = Utc::now()
+        .checked_sub_signed(chrono::TimeDelta::days(max_days as i64))
+        .ok_or_else(|| anyhow::anyhow!("date arithmetic overflow for max_days={max_days}"))?
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    let mut total_deleted: usize = 0;
+    loop {
+        let conn = pool.get()?;
+        let chunk = conn.execute(
+            "DELETE FROM logs WHERE id IN (
+                 SELECT id FROM logs
+                 WHERE app_name = ?1
+                   AND received_at < ?2
+                   AND severity NOT IN ('err', 'crit', 'alert', 'emerg')
+                 LIMIT 10000
+             )",
+            params![app_name, cutoff],
+        )?;
+        total_deleted += chunk;
+        drop(conn);
+        if chunk == 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    if total_deleted > 0 {
+        fts_incremental_merge(pool, total_deleted, fts_merge_pages);
+    }
+
+    tracing::info!(
+        app_name,
+        max_days,
+        deleted = total_deleted,
+        cutoff = %cutoff,
+        "Purged tag window"
+    );
     Ok(total_deleted)
 }
 
@@ -325,6 +408,25 @@ fn delete_oldest_logs_chunk(pool: &DbPool, chunk_size: usize) -> Result<DeletedC
             .collect::<rusqlite::Result<Vec<_>>>()?;
         result
     };
+
+    // Pre-flight: count high-severity rows in the chunk so we can warn the
+    // operator that disk-pressure cleanup is overriding the time-based
+    // retention exemption for err+ logs.
+    let high_severity_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM logs \
+         WHERE id IN (SELECT id FROM logs ORDER BY received_at ASC, id ASC LIMIT ?1) \
+           AND severity IN ('err', 'crit', 'alert', 'emerg')",
+        [chunk_size as i64],
+        |row| row.get(0),
+    )?;
+    if high_severity_count > 0 {
+        tracing::warn!(
+            high_severity_count,
+            chunk_size,
+            "Storage enforcement deleting high-severity rows — \
+             disk pressure overrides time-based retention exemption"
+        );
+    }
 
     // Delete the oldest chunk using a subquery — O(1) SQL string size regardless
     // of chunk_size, no expression depth issues.

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -231,3 +231,163 @@ fn test_enforce_storage_budget_is_noop_when_limits_disabled() {
     assert_eq!(outcome.deleted_rows, 0);
     assert!(!outcome.write_blocked);
 }
+
+// ---- purge_by_tag_window ----
+
+fn make_tagged(ts: &str, host: &str, severity: &str, app: &str, msg: &str) -> LogBatchEntry {
+    LogBatchEntry {
+        timestamp: ts.to_string(),
+        hostname: host.to_string(),
+        facility: None,
+        severity: severity.to_string(),
+        app_name: Some(app.to_string()),
+        process_id: None,
+        message: msg.to_string(),
+        raw: msg.to_string(),
+        source_ip: "127.0.0.1:514".to_string(),
+        docker_checkpoint: None,
+    }
+}
+
+#[test]
+fn test_purge_by_tag_window_zero_days_is_noop() {
+    let (pool, _dir) = test_pool();
+    let entries = vec![make_tagged(
+        "2020-01-01T00:00:00Z",
+        "h",
+        "info",
+        "adguard-allowed",
+        "old",
+    )];
+    insert_logs_batch(&pool, &entries).unwrap();
+
+    let deleted = super::purge_by_tag_window(&pool, "adguard-allowed", 0, 0).unwrap();
+    assert_eq!(deleted, 0, "max_days=0 must be a no-op");
+
+    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    assert_eq!(remaining.len(), 1, "row must still be present");
+}
+
+#[test]
+fn test_purge_by_tag_window_only_targets_named_tag() {
+    let (pool, _dir) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            make_tagged(
+                "2020-01-01T00:00:00Z",
+                "h",
+                "info",
+                "adguard-allowed",
+                "old-allowed",
+            ),
+            make_tagged("2020-01-01T00:00:00Z", "h", "info", "nginx", "old-nginx"),
+            make_tagged("2020-01-01T00:00:00Z", "h", "info", "kernel", "old-kernel"),
+        ],
+    )
+    .unwrap();
+    // Backdate received_at past the 7-day window
+    update_received_at(&pool, "old-allowed", "2020-01-01T00:00:00Z");
+    update_received_at(&pool, "old-nginx", "2020-01-01T00:00:00Z");
+    update_received_at(&pool, "old-kernel", "2020-01-01T00:00:00Z");
+
+    let deleted = super::purge_by_tag_window(&pool, "adguard-allowed", 7, 0).unwrap();
+    assert_eq!(deleted, 1, "only the adguard-allowed row must be deleted");
+
+    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    let messages: Vec<&str> = remaining.iter().map(|r| r.message.as_str()).collect();
+    assert!(messages.contains(&"old-nginx"), "nginx must survive");
+    assert!(messages.contains(&"old-kernel"), "kernel must survive");
+    assert!(
+        !messages.contains(&"old-allowed"),
+        "adguard-allowed must be gone"
+    );
+}
+
+#[test]
+fn test_purge_by_tag_window_excludes_high_severity_rows() {
+    let (pool, _dir) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            make_tagged(
+                "2020-01-01T00:00:00Z",
+                "h",
+                "info",
+                "adguard-allowed",
+                "info-old",
+            ),
+            make_tagged(
+                "2020-01-01T00:00:00Z",
+                "h",
+                "err",
+                "adguard-allowed",
+                "err-old",
+            ),
+            make_tagged(
+                "2020-01-01T00:00:00Z",
+                "h",
+                "crit",
+                "adguard-allowed",
+                "crit-old",
+            ),
+        ],
+    )
+    .unwrap();
+    update_received_at(&pool, "info-old", "2020-01-01T00:00:00Z");
+    update_received_at(&pool, "err-old", "2020-01-01T00:00:00Z");
+    update_received_at(&pool, "crit-old", "2020-01-01T00:00:00Z");
+
+    let deleted = super::purge_by_tag_window(&pool, "adguard-allowed", 7, 0).unwrap();
+    assert_eq!(deleted, 1, "only the info row should be purged");
+
+    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    let messages: Vec<&str> = remaining.iter().map(|r| r.message.as_str()).collect();
+    assert!(
+        messages.contains(&"err-old"),
+        "err must be exempt from time-based purge"
+    );
+    assert!(
+        messages.contains(&"crit-old"),
+        "crit must be exempt from time-based purge"
+    );
+}
+
+#[test]
+fn test_purge_by_tag_window_respects_cutoff_boundary() {
+    let (pool, _dir) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            make_tagged(
+                "2020-01-01T00:00:00Z",
+                "h",
+                "info",
+                "adguard-allowed",
+                "old",
+            ),
+            make_tagged(
+                "2020-01-01T00:00:00Z",
+                "h",
+                "info",
+                "adguard-allowed",
+                "fresh",
+            ),
+        ],
+    )
+    .unwrap();
+    // 'old' is past the 7-day window, 'fresh' is well inside it
+    update_received_at(&pool, "old", "2020-01-01T00:00:00Z");
+    update_received_at(
+        &pool,
+        "fresh",
+        &chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+    );
+
+    let deleted = super::purge_by_tag_window(&pool, "adguard-allowed", 7, 0).unwrap();
+    assert_eq!(deleted, 1, "only the old row should be deleted");
+
+    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    let messages: Vec<&str> = remaining.iter().map(|r| r.message.as_str()).collect();
+    assert!(messages.contains(&"fresh"), "fresh row must survive");
+}

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -83,7 +83,7 @@ fn test_purge_old_logs_removes_old() {
     .unwrap();
     drop(conn);
 
-    let deleted = purge_old_logs(&pool, 90).unwrap();
+    let deleted = purge_old_logs(&pool, 90, 0).unwrap();
     assert_eq!(deleted, 1, "should have deleted exactly the old entry");
 
     let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
@@ -97,7 +97,7 @@ fn test_purge_zero_retention_noop() {
     let entries = vec![make_entry("2020-01-01T00:00:00Z", "host-a", "info", "old")];
     insert_logs_batch(&pool, &entries).unwrap();
 
-    let deleted = purge_old_logs(&pool, 0).unwrap();
+    let deleted = purge_old_logs(&pool, 0, 0).unwrap();
     assert_eq!(deleted, 0, "retention_days=0 should be a no-op");
 }
 

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -166,6 +166,44 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
         tracing::info!("Migration 2: created docker_ingest_checkpoints table");
     }
 
+    // Migration 3: composite index on (app_name, received_at).
+    //
+    // The new `purge_by_tag_window` function deletes rows by `app_name` within
+    // a `received_at` window (e.g. all `adguard-allowed` older than 7 days).
+    // Without this composite index, each chunked DELETE scans the entire
+    // app_name partition before applying the time filter — pathological at
+    // AdGuard volumes.
+    //
+    // First-run cost: on a multi-million-row database the CREATE INDEX may
+    // take several minutes and holds the write lock for that duration. The
+    // /health endpoint will not respond and syslog UDP packets may be dropped
+    // at the kernel buffer during that window. Operators upgrading on a
+    // populated DB should plan for a brief health-check gap.
+    let migration_3_applied: bool = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_migrations WHERE version = 3",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+        > 0;
+    if !migration_3_applied {
+        tracing::info!(
+            "Migration 3: starting CREATE INDEX idx_logs_app_name_received_at \
+             — may take several minutes on large databases, write lock held"
+        );
+        let started = std::time::Instant::now();
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_logs_app_name_received_at \
+                 ON logs(app_name, received_at);
+             INSERT INTO schema_migrations (version) VALUES (3);",
+        )?;
+        tracing::info!(
+            elapsed_ms = started.elapsed().as_millis(),
+            "Migration 3: composite index (app_name, received_at) created"
+        );
+    }
+
     tracing::info!(path = %config.db_path.display(), "Database initialized");
     Ok(pool)
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -5,8 +5,17 @@ use tokio::sync::mpsc;
 use crate::config::{StorageConfig, SyslogConfig};
 use crate::db::{self, DbPool};
 use crate::syslog;
+use crate::syslog::enrichment::EnrichmentConfig;
 
 pub const WRITE_CHANNEL_CAPACITY: usize = 10_000;
+
+/// Lightweight error type for [`IngestTx::try_send`] — the entry is dropped on
+/// backpressure rather than returned to the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrySendErr {
+    Full,
+    Closed,
+}
 
 #[derive(Clone)]
 pub(crate) struct IngestTx {
@@ -21,8 +30,27 @@ impl IngestTx {
         self.tx.send(entry).await
     }
 
+    /// Non-blocking send. Returns `Err(TrySendErr::Full)` when the channel is
+    /// at capacity so the OTLP HTTP handler can return 503 instead of awaiting
+    /// and holding the connection open. The dropped entry is not returned —
+    /// the caller's contract is "best effort, drop on backpressure."
+    pub(crate) fn try_send(&self, entry: db::LogBatchEntry) -> Result<(), TrySendErr> {
+        match self.tx.try_send(entry) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(TrySendErr::Full),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(TrySendErr::Closed),
+        }
+    }
+
     pub(crate) fn sender(&self) -> mpsc::Sender<db::LogBatchEntry> {
         self.tx.clone()
+    }
+
+    /// Test-only constructor: builds an `IngestTx` from a raw sender so tests
+    /// don't have to spawn a real batch writer.
+    #[cfg(test)]
+    pub(crate) fn from_sender_for_test(tx: mpsc::Sender<db::LogBatchEntry>) -> Self {
+        Self { tx }
     }
 }
 
@@ -32,6 +60,7 @@ pub(crate) fn start_writer(
     storage_state: Arc<Mutex<Option<db::StorageBudgetState>>>,
     batch_size: usize,
     flush_interval_ms: u64,
+    enrichment: EnrichmentConfig,
 ) -> IngestTx {
     let (tx, rx) = mpsc::channel::<db::LogBatchEntry>(WRITE_CHANNEL_CAPACITY);
     tokio::spawn(async move {
@@ -42,6 +71,7 @@ pub(crate) fn start_writer(
             storage_state,
             batch_size,
             tokio::time::Duration::from_millis(flush_interval_ms),
+            enrichment,
         )
         .await;
     });
@@ -53,6 +83,7 @@ pub(crate) fn start_writer_from_syslog_config(
     storage: StorageConfig,
     pool: Arc<DbPool>,
     storage_state: Arc<Mutex<Option<db::StorageBudgetState>>>,
+    enrichment: EnrichmentConfig,
 ) -> IngestTx {
     start_writer(
         storage,
@@ -60,5 +91,6 @@ pub(crate) fn start_writer_from_syslog_config(
         storage_state,
         syslog.batch_size,
         syslog.flush_interval,
+        enrichment,
     )
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -46,6 +46,13 @@ impl IngestTx {
         self.tx.clone()
     }
 
+    /// Best-effort current channel capacity (slots currently free). Used by
+    /// the OTLP handler to pre-flight a multi-record batch and reject with
+    /// 503 *before* any partial enqueue, avoiding duplicate-on-retry.
+    pub(crate) fn capacity(&self) -> usize {
+        self.tx.capacity()
+    }
+
     /// Test-only constructor: builds an `IngestTx` from a raw sender so tests
     /// don't have to spawn a real batch writer.
     #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod otlp;
 pub mod runtime;
 pub mod syslog;
 
+pub(crate) mod auth;
+
 pub(crate) mod db;
 pub(crate) mod docker_ingest;
 pub(crate) mod ingest;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod app;
 pub mod config;
 pub mod mcp;
+pub mod otlp;
 pub mod runtime;
 pub mod syslog;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,14 @@ async fn serve_mcp() -> Result<()> {
     }
     app = app.merge(runtime.otlp_router());
     info!("OTLP receiver mounted at /v1/logs (and /v1/metrics → 200, /v1/traces → 404)");
+    if runtime.config.mcp.api_token.is_none() && !runtime.config.mcp.host.starts_with("127.") {
+        tracing::warn!(
+            bind = %runtime.config.mcp.bind_addr(),
+            "OTLP /v1/logs is mounted WITHOUT authentication on a non-loopback bind. \
+             Anyone reachable on this address can write log records. \
+             Set SYSLOG_MCP_TOKEN to require Bearer auth."
+        );
+    }
     app = app.layer(tower_http::trace::TraceLayer::new_for_http());
 
     let mcp_bind = runtime.config.mcp.bind_addr();

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,15 +71,21 @@ async fn serve_mcp() -> Result<()> {
         })?);
         info!("Non-MCP API mounted under /api");
     }
+    app = app.merge(runtime.otlp_router());
+    info!("OTLP receiver mounted at /v1/logs (and /v1/metrics → 200, /v1/traces → 404)");
     app = app.layer(tower_http::trace::TraceLayer::new_for_http());
 
     let mcp_bind = runtime.config.mcp.bind_addr();
     let listener = tokio::net::TcpListener::bind(&mcp_bind).await?;
     info!(bind = %mcp_bind, "MCP server listening");
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // OTLP handler needs ConnectInfo<SocketAddr> for source_ip provenance.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
 
     Ok(())
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use crate::app::SyslogService;
 use crate::config::McpConfig;
+use crate::otlp::OtlpCounters;
 
 mod rmcp_server;
 mod routes;
@@ -16,4 +19,5 @@ pub use routes::router;
 pub struct AppState {
     pub service: SyslogService,
     pub config: McpConfig,
+    pub otlp_counters: Arc<OtlpCounters>,
 }

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -31,6 +31,7 @@ fn test_state() -> (AppState, Arc<DbPool>, tempfile::TempDir) {
             allowed_hosts: Vec::new(),
             allowed_origins: Vec::new(),
         },
+        otlp_counters: Arc::new(crate::otlp::OtlpCounters::default()),
     };
     (state, pool, dir)
 }

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 use axum::{
@@ -132,16 +133,24 @@ fn token_matches(provided: &str, expected: &str) -> bool {
 }
 
 /// Health check — lightweight probe that verifies DB connectivity without
-/// running COUNT(*) over the entire logs table.
+/// running COUNT(*) over the entire logs table. Also surfaces OTLP receiver
+/// counters so operators can see ingest activity at a glance.
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let started = Instant::now();
+    let logs_received = state.otlp_counters.logs_received.load(Ordering::Relaxed);
+    let decode_errors = state.otlp_counters.decode_errors.load(Ordering::Relaxed);
     match state.service.health_check().await {
         Ok(()) => {
             tracing::debug!(
                 elapsed_ms = started.elapsed().as_millis(),
                 "Health check passed"
             );
-            Json(json!({ "status": "ok" })).into_response()
+            Json(json!({
+                "status": "ok",
+                "otlp_logs_received": logs_received,
+                "otlp_decode_errors": decode_errors,
+            }))
+            .into_response()
         }
         Err(e) => {
             tracing::error!(
@@ -151,7 +160,11 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
             );
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "status": "error" })),
+                Json(json!({
+                    "status": "error",
+                    "otlp_logs_received": logs_received,
+                    "otlp_decode_errors": decode_errors,
+                })),
             )
                 .into_response()
         }

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -10,11 +10,12 @@ use axum::{
     Router,
 };
 use serde_json::json;
-use subtle::ConstantTimeEq;
 use tower_http::{
     cors::{Any, CorsLayer},
     limit::RequestBodyLimitLayer,
 };
+
+use crate::auth::{bearer_token, token_matches};
 
 use super::rmcp_server::allowed_origins;
 use super::AppState;
@@ -101,35 +102,6 @@ fn cors_layer(config: &crate::config::McpConfig) -> CorsLayer {
         .allow_origin(origins)
         .allow_methods([Method::POST, Method::GET])
         .allow_headers(Any)
-}
-
-fn bearer_token(auth: &str) -> Option<&str> {
-    let mut parts = auth.split_whitespace();
-    let scheme = parts.next()?;
-    let token = parts.next()?;
-    if parts.next().is_some() || !scheme.eq_ignore_ascii_case("bearer") {
-        return None;
-    }
-    Some(token)
-}
-
-fn token_matches(provided: &str, expected: &str) -> bool {
-    const MAX_TOKEN_LEN: usize = 4096;
-    if provided.len() > MAX_TOKEN_LEN || expected.len() > MAX_TOKEN_LEN {
-        return false;
-    }
-
-    let mut provided_buf = [0_u8; MAX_TOKEN_LEN];
-    let mut expected_buf = [0_u8; MAX_TOKEN_LEN];
-    provided_buf[..provided.len()].copy_from_slice(provided.as_bytes());
-    expected_buf[..expected.len()].copy_from_slice(expected.as_bytes());
-
-    let bytes_match = provided_buf.ct_eq(&expected_buf).unwrap_u8() == 1;
-    let lengths_match = (provided.len() as u64)
-        .ct_eq(&(expected.len() as u64))
-        .unwrap_u8()
-        == 1;
-    bytes_match && lengths_match
 }
 
 /// Health check — lightweight probe that verifies DB connectivity without

--- a/src/mcp/routes_tests.rs
+++ b/src/mcp/routes_tests.rs
@@ -23,6 +23,7 @@ fn test_state_with_token(token: Option<String>) -> (AppState, tempfile::TempDir)
                 allowed_hosts: Vec::new(),
                 allowed_origins: Vec::new(),
             },
+            otlp_counters: Arc::new(crate::otlp::OtlpCounters::default()),
         },
         dir,
     )

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -21,6 +21,7 @@ fn test_state_with_token(token: Option<String>) -> (AppState, tempfile::TempDir)
                 allowed_hosts: Vec::new(),
                 allowed_origins: Vec::new(),
             },
+            otlp_counters: Arc::new(crate::otlp::OtlpCounters::default()),
         },
         dir,
     )

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -1,0 +1,331 @@
+//! OTLP/HTTP receiver — accepts OpenTelemetry log records over HTTP and feeds
+//! them into the existing syslog-mcp ingest pipeline. Logs only — `/v1/traces`
+//! returns 404 (deferred) and `/v1/metrics` returns 200 + discards.
+//!
+//! Mounted on the same axum server as MCP. Body limit: 4 MiB. Optional Bearer
+//! auth via the same `SYSLOG_MCP_API_TOKEN` as MCP.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use axum::{
+    extract::{ConnectInfo, State},
+    http::{header::RETRY_AFTER, HeaderMap, HeaderValue, StatusCode},
+    middleware::{from_fn, Next},
+    response::{IntoResponse, Json},
+    routing::post,
+    Router,
+};
+use bytes::Bytes;
+use opentelemetry_proto::tonic::{
+    collector::logs::v1::ExportLogsServiceRequest,
+    common::v1::{any_value::Value as AnyValueKind, AnyValue},
+};
+use prost::Message;
+use serde_json::json;
+use subtle::ConstantTimeEq;
+use tower_http::limit::RequestBodyLimitLayer;
+
+use crate::db::LogBatchEntry;
+use crate::ingest::IngestTx;
+
+/// Per-request body cap. Matches the OpenTelemetry Collector default for
+/// HTTP receivers. Larger payloads receive 413 + `Retry-After: 86400`.
+pub const OTLP_BODY_LIMIT_BYTES: usize = 4 * 1024 * 1024;
+
+/// Atomic counters for the OTLP receiver, surfaced via `/health`.
+#[derive(Debug, Default)]
+pub struct OtlpCounters {
+    pub logs_received: AtomicU64,
+    pub decode_errors: AtomicU64,
+}
+
+/// Shared state for every OTLP route.
+#[derive(Clone)]
+pub struct OtlpState {
+    pub(crate) ingest: IngestTx,
+    pub api_token: Option<String>,
+    pub counters: Arc<OtlpCounters>,
+}
+
+impl OtlpState {
+    pub(crate) fn new(
+        ingest: IngestTx,
+        api_token: Option<String>,
+        counters: Arc<OtlpCounters>,
+    ) -> Self {
+        Self {
+            ingest,
+            api_token,
+            counters,
+        }
+    }
+}
+
+/// Build the OTLP router. Mounts `/v1/logs`, `/v1/metrics`, `/v1/traces` on the
+/// same axum server as MCP.
+pub fn router(state: OtlpState) -> Router {
+    Router::new()
+        .route("/v1/logs", post(logs_handler))
+        .route("/v1/metrics", post(metrics_handler))
+        .route("/v1/traces", post(traces_handler))
+        .layer(RequestBodyLimitLayer::new(OTLP_BODY_LIMIT_BYTES))
+        .layer(from_fn(add_retry_after_on_413))
+        .with_state(state)
+}
+
+/// Tower middleware: attach `Retry-After: 86400` to any 413 response so OTLP
+/// exporters back off instead of hammering the endpoint on retry.
+async fn add_retry_after_on_413(
+    req: axum::extract::Request,
+    next: Next,
+) -> axum::response::Response {
+    let mut response = next.run(req).await;
+    if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        response
+            .headers_mut()
+            .insert(RETRY_AFTER, HeaderValue::from_static("86400"));
+    }
+    response
+}
+
+async fn logs_handler(
+    State(state): State<OtlpState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    if !is_authorized(&state, &headers) {
+        return unauthorized();
+    }
+
+    // prost decode is CPU-bound; isolate from the runtime via spawn_blocking.
+    let body_for_decode = body.clone();
+    let decoded =
+        tokio::task::spawn_blocking(move || ExportLogsServiceRequest::decode(body_for_decode))
+            .await;
+
+    let req = match decoded {
+        Ok(Ok(req)) => req,
+        Ok(Err(err)) => {
+            state.counters.decode_errors.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(error = %err, source_ip = %peer, "OTLP /v1/logs decode failed");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "decode_failed", "message": err.to_string()})),
+            )
+                .into_response();
+        }
+        Err(err) => {
+            state.counters.decode_errors.fetch_add(1, Ordering::Relaxed);
+            tracing::error!(error = %err, "OTLP decode task panicked");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal"})),
+            )
+                .into_response();
+        }
+    };
+
+    let entries = build_entries(&req, peer);
+    let count = entries.len();
+
+    // try_send each entry. Any Full result aborts the request with 503 so
+    // OTel exporters back off instead of growing the in-memory queue.
+    for entry in entries {
+        if state.ingest.try_send(entry).is_err() {
+            tracing::warn!(
+                source_ip = %peer,
+                "OTLP write channel full — returning 503"
+            );
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"error": "channel_full"})),
+            )
+                .into_response();
+        }
+    }
+
+    state
+        .counters
+        .logs_received
+        .fetch_add(count as u64, Ordering::Relaxed);
+    tracing::info!(records = count, source_ip = %peer, "OTLP logs ingested");
+    StatusCode::OK.into_response()
+}
+
+async fn metrics_handler(
+    State(state): State<OtlpState>,
+    headers: HeaderMap,
+    _body: Bytes,
+) -> axum::response::Response {
+    if !is_authorized(&state, &headers) {
+        return unauthorized();
+    }
+    StatusCode::OK.into_response()
+}
+
+async fn traces_handler() -> axum::response::Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "error": "traces_not_supported",
+            "message": "OTLP traces deferred. Use /v1/logs only."
+        })),
+    )
+        .into_response()
+}
+
+/// Walk the OTLP request and produce one `LogBatchEntry` per `LogRecord`.
+fn build_entries(req: &ExportLogsServiceRequest, peer: SocketAddr) -> Vec<LogBatchEntry> {
+    let received_iso = chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%S%.3fZ")
+        .to_string();
+    let source_ip = peer.to_string();
+
+    let mut out = Vec::new();
+    for resource_logs in &req.resource_logs {
+        let resource_attrs: HashMap<&str, &AnyValue> = resource_logs
+            .resource
+            .as_ref()
+            .map(|r| {
+                r.attributes
+                    .iter()
+                    .filter_map(|kv| kv.value.as_ref().map(|v| (kv.key.as_str(), v)))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let hostname = resource_attrs
+            .get("host.name")
+            .and_then(|v| any_value_to_string(v))
+            .unwrap_or_default();
+        let service_name = resource_attrs
+            .get("service.name")
+            .and_then(|v| any_value_to_string(v));
+        let service_version = resource_attrs
+            .get("service.version")
+            .and_then(|v| any_value_to_string(v));
+
+        for scope_logs in &resource_logs.scope_logs {
+            for log in &scope_logs.log_records {
+                let timestamp = format_otlp_timestamp(log.time_unix_nano)
+                    .unwrap_or_else(|| received_iso.clone());
+                let severity = severity_from_number(log.severity_number).to_string();
+                let message = log
+                    .body
+                    .as_ref()
+                    .and_then(any_value_to_string)
+                    .unwrap_or_default();
+                let raw = service_version.clone().unwrap_or_default();
+
+                out.push(LogBatchEntry {
+                    timestamp,
+                    hostname: hostname.clone(),
+                    facility: Some("otlp".to_string()),
+                    severity,
+                    app_name: service_name.clone(),
+                    process_id: None,
+                    message,
+                    raw,
+                    source_ip: source_ip.clone(),
+                    docker_checkpoint: None,
+                });
+            }
+        }
+    }
+    out
+}
+
+fn format_otlp_timestamp(time_unix_nano: u64) -> Option<String> {
+    if time_unix_nano == 0 {
+        return None;
+    }
+    let secs = (time_unix_nano / 1_000_000_000) as i64;
+    let nanos = (time_unix_nano % 1_000_000_000) as u32;
+    chrono::DateTime::<chrono::Utc>::from_timestamp(secs, nanos)
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+}
+
+/// OTLP `SeverityNumber` (0–24) → syslog severity string.
+///
+/// 0 (UNSPECIFIED) and any unrecognised value fall through to `info` rather
+/// than dropping the record.
+fn severity_from_number(n: i32) -> &'static str {
+    match n {
+        1..=4 => "debug",
+        5..=8 => "debug",
+        9..=12 => "info",
+        13..=16 => "warning",
+        17..=20 => "err",
+        21..=24 => "crit",
+        _ => "info",
+    }
+}
+
+/// Stringify any `AnyValue` variant for storage in `message` / attribute fields.
+/// Composite types render as a placeholder rather than expanding inline.
+fn any_value_to_string(v: &AnyValue) -> Option<String> {
+    match v.value.as_ref()? {
+        AnyValueKind::StringValue(s) => Some(s.clone()),
+        AnyValueKind::BoolValue(b) => Some(b.to_string()),
+        AnyValueKind::IntValue(i) => Some(i.to_string()),
+        AnyValueKind::DoubleValue(f) => Some(f.to_string()),
+        AnyValueKind::BytesValue(b) => Some(format!("[{} bytes]", b.len())),
+        AnyValueKind::ArrayValue(arr) => Some(format!("[array len={}]", arr.values.len())),
+        AnyValueKind::KvlistValue(kv) => Some(format!("[kvlist len={}]", kv.values.len())),
+    }
+}
+
+fn is_authorized(state: &OtlpState, headers: &HeaderMap) -> bool {
+    let Some(expected) = state.api_token.as_deref() else {
+        return true;
+    };
+    let Some(auth) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+    else {
+        return false;
+    };
+    bearer_token(auth).is_some_and(|tok| token_matches(tok, expected))
+}
+
+fn bearer_token(auth: &str) -> Option<&str> {
+    let mut parts = auth.split_whitespace();
+    let scheme = parts.next()?;
+    let token = parts.next()?;
+    if parts.next().is_some() || !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    Some(token)
+}
+
+fn token_matches(provided: &str, expected: &str) -> bool {
+    const MAX_TOKEN_LEN: usize = 4096;
+    if provided.len() > MAX_TOKEN_LEN || expected.len() > MAX_TOKEN_LEN {
+        return false;
+    }
+    let mut a = [0_u8; MAX_TOKEN_LEN];
+    let mut b = [0_u8; MAX_TOKEN_LEN];
+    a[..provided.len()].copy_from_slice(provided.as_bytes());
+    b[..expected.len()].copy_from_slice(expected.as_bytes());
+    let bytes_match = a.ct_eq(&b).unwrap_u8() == 1;
+    let lens_match = (provided.len() as u64)
+        .ct_eq(&(expected.len() as u64))
+        .unwrap_u8()
+        == 1;
+    bytes_match && lens_match
+}
+
+fn unauthorized() -> axum::response::Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({"error": "unauthorized"})),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+#[path = "otlp_tests.rs"]
+mod tests;

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -25,9 +25,9 @@ use opentelemetry_proto::tonic::{
 };
 use prost::Message;
 use serde_json::json;
-use subtle::ConstantTimeEq;
 use tower_http::limit::RequestBodyLimitLayer;
 
+use crate::auth::{bearer_token, token_matches};
 use crate::db::LogBatchEntry;
 use crate::ingest::IngestTx;
 
@@ -254,13 +254,12 @@ fn format_otlp_timestamp(time_unix_nano: u64) -> Option<String> {
 /// than dropping the record.
 fn severity_from_number(n: i32) -> &'static str {
     match n {
-        1..=4 => "debug",
-        5..=8 => "debug",
+        1..=8 => "debug", // OTLP TRACE (1..=4) and DEBUG (5..=8) both map here
         9..=12 => "info",
         13..=16 => "warning",
         17..=20 => "err",
         21..=24 => "crit",
-        _ => "info",
+        _ => "info", // 0=UNSPECIFIED and out-of-range fall back to info
     }
 }
 
@@ -289,33 +288,6 @@ fn is_authorized(state: &OtlpState, headers: &HeaderMap) -> bool {
         return false;
     };
     bearer_token(auth).is_some_and(|tok| token_matches(tok, expected))
-}
-
-fn bearer_token(auth: &str) -> Option<&str> {
-    let mut parts = auth.split_whitespace();
-    let scheme = parts.next()?;
-    let token = parts.next()?;
-    if parts.next().is_some() || !scheme.eq_ignore_ascii_case("bearer") {
-        return None;
-    }
-    Some(token)
-}
-
-fn token_matches(provided: &str, expected: &str) -> bool {
-    const MAX_TOKEN_LEN: usize = 4096;
-    if provided.len() > MAX_TOKEN_LEN || expected.len() > MAX_TOKEN_LEN {
-        return false;
-    }
-    let mut a = [0_u8; MAX_TOKEN_LEN];
-    let mut b = [0_u8; MAX_TOKEN_LEN];
-    a[..provided.len()].copy_from_slice(provided.as_bytes());
-    b[..expected.len()].copy_from_slice(expected.as_bytes());
-    let bytes_match = a.ct_eq(&b).unwrap_u8() == 1;
-    let lens_match = (provided.len() as u64)
-        .ct_eq(&(expected.len() as u64))
-        .unwrap_u8()
-        == 1;
-    bytes_match && lens_match
 }
 
 fn unauthorized() -> axum::response::Response {

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -139,19 +139,54 @@ async fn logs_handler(
     let entries = build_entries(&req, peer);
     let count = entries.len();
 
-    // try_send each entry. Any Full result aborts the request with 503 so
-    // OTel exporters back off instead of growing the in-memory queue.
+    // Pre-flight capacity check: reject the WHOLE request with 503 if the
+    // channel can't fit it. Without this, partial accept (entries 0..N
+    // queued, N+1 hits Full, return 503) leads to OTel exporter retry of
+    // the full batch — duplicating the rows already accepted. See review
+    // threads PRRT_*ALWfA / *ALb_p / *ALYDZ.
+    if state.ingest.capacity() < count {
+        tracing::warn!(
+            source_ip = %peer,
+            requested = count,
+            available = state.ingest.capacity(),
+            "OTLP write channel insufficient capacity — returning 503 (no partial accept)"
+        );
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "channel_full"})),
+        )
+            .into_response();
+    }
+
+    // Capacity reservation is best-effort (concurrent senders may consume
+    // slots between check and send). On Full mid-loop we still 503, which
+    // can in the worst case duplicate a few records on retry, but the
+    // pre-flight makes the common case clean.
     for entry in entries {
-        if state.ingest.try_send(entry).is_err() {
-            tracing::warn!(
-                source_ip = %peer,
-                "OTLP write channel full — returning 503"
-            );
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(json!({"error": "channel_full"})),
-            )
-                .into_response();
+        match state.ingest.try_send(entry) {
+            Ok(()) => {}
+            Err(crate::ingest::TrySendErr::Full) => {
+                tracing::warn!(
+                    source_ip = %peer,
+                    "OTLP write channel filled mid-batch — returning 503"
+                );
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(json!({"error": "channel_full"})),
+                )
+                    .into_response();
+            }
+            Err(crate::ingest::TrySendErr::Closed) => {
+                tracing::error!(
+                    source_ip = %peer,
+                    "OTLP write channel CLOSED — batch writer task is dead"
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"error": "writer_unavailable"})),
+                )
+                    .into_response();
+            }
         }
     }
 

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -3,7 +3,8 @@
 //! returns 404 (deferred) and `/v1/metrics` returns 200 + discards.
 //!
 //! Mounted on the same axum server as MCP. Body limit: 4 MiB. Optional Bearer
-//! auth via the same `SYSLOG_MCP_API_TOKEN` as MCP.
+//! auth via the same `SYSLOG_MCP_TOKEN` as MCP (`SYSLOG_MCP_API_TOKEN` is
+//! accepted as a deprecated alias).
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -64,8 +65,9 @@ impl OtlpState {
     }
 }
 
-/// Build the OTLP router. Mounts `/v1/logs`, `/v1/metrics`, `/v1/traces` on the
-/// same axum server as MCP.
+/// Build the OTLP router. Mounts `/v1/logs` (functional ingest),
+/// `/v1/metrics` (200 + discard), `/v1/traces` (404 — deferred) on the same
+/// axum server as MCP.
 pub fn router(state: OtlpState) -> Router {
     Router::new()
         .route("/v1/logs", post(logs_handler))
@@ -98,6 +100,11 @@ async fn logs_handler(
     body: Bytes,
 ) -> axum::response::Response {
     if !is_authorized(&state, &headers) {
+        tracing::warn!(
+            source_ip = %peer,
+            has_auth = headers.contains_key(axum::http::header::AUTHORIZATION),
+            "OTLP /v1/logs unauthorized"
+        );
         return unauthorized();
     }
 

--- a/src/otlp_tests.rs
+++ b/src/otlp_tests.rs
@@ -1,0 +1,284 @@
+//! Tests for the OTLP HTTP receiver (logs handler, severity mapping,
+//! AnyValue extraction, auth gate, status-code contract).
+
+use super::*;
+
+use std::sync::atomic::Ordering;
+
+use opentelemetry_proto::tonic::{
+    collector::logs::v1::ExportLogsServiceRequest,
+    common::v1::{any_value::Value as AnyValueKind, AnyValue, KeyValue},
+    logs::v1::{LogRecord, ResourceLogs, ScopeLogs},
+    resource::v1::Resource,
+};
+
+fn av_string(s: &str) -> AnyValue {
+    AnyValue {
+        value: Some(AnyValueKind::StringValue(s.to_string())),
+    }
+}
+
+fn kv(key: &str, value: AnyValue) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(value),
+    }
+}
+
+fn sample_request(
+    host: &str,
+    service: &str,
+    body: &str,
+    severity: i32,
+) -> ExportLogsServiceRequest {
+    ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            resource: Some(Resource {
+                attributes: vec![
+                    kv("host.name", av_string(host)),
+                    kv("service.name", av_string(service)),
+                ],
+                dropped_attributes_count: 0,
+                entity_refs: vec![],
+            }),
+            scope_logs: vec![ScopeLogs {
+                scope: None,
+                log_records: vec![LogRecord {
+                    time_unix_nano: 1_700_000_000_000_000_000,
+                    observed_time_unix_nano: 0,
+                    severity_number: severity,
+                    severity_text: String::new(),
+                    body: Some(av_string(body)),
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    flags: 0,
+                    trace_id: vec![],
+                    span_id: vec![],
+                    event_name: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    }
+}
+
+// ---- severity mapping ----
+
+#[test]
+fn severity_unspecified_falls_back_to_info() {
+    assert_eq!(severity_from_number(0), "info");
+    assert_eq!(severity_from_number(99), "info");
+    assert_eq!(severity_from_number(-1), "info");
+}
+
+#[test]
+fn severity_buckets_match_otlp_spec() {
+    assert_eq!(severity_from_number(1), "debug"); // TRACE
+    assert_eq!(severity_from_number(5), "debug"); // DEBUG
+    assert_eq!(severity_from_number(9), "info"); // INFO
+    assert_eq!(severity_from_number(13), "warning"); // WARN
+    assert_eq!(severity_from_number(17), "err"); // ERROR
+    assert_eq!(severity_from_number(21), "crit"); // FATAL
+}
+
+// ---- AnyValue extraction ----
+
+#[test]
+fn any_value_string() {
+    assert_eq!(any_value_to_string(&av_string("hi")).as_deref(), Some("hi"));
+}
+
+#[test]
+fn any_value_none_returns_none() {
+    let v = AnyValue { value: None };
+    assert!(any_value_to_string(&v).is_none());
+}
+
+#[test]
+fn any_value_int_and_bool_stringify() {
+    let int_val = AnyValue {
+        value: Some(AnyValueKind::IntValue(42)),
+    };
+    assert_eq!(any_value_to_string(&int_val).as_deref(), Some("42"));
+    let bool_val = AnyValue {
+        value: Some(AnyValueKind::BoolValue(true)),
+    };
+    assert_eq!(any_value_to_string(&bool_val).as_deref(), Some("true"));
+}
+
+// ---- build_entries ----
+
+#[test]
+fn build_entries_extracts_resource_attrs() {
+    let peer = "127.0.0.1:12345".parse().unwrap();
+    let req = sample_request("dookie", "claude-code", "tool_call started", 9);
+    let entries = build_entries(&req, peer);
+    assert_eq!(entries.len(), 1);
+    let e = &entries[0];
+    assert_eq!(e.hostname, "dookie");
+    assert_eq!(e.app_name.as_deref(), Some("claude-code"));
+    assert_eq!(e.message, "tool_call started");
+    assert_eq!(e.severity, "info");
+    assert_eq!(e.facility.as_deref(), Some("otlp"));
+    assert_eq!(e.source_ip, "127.0.0.1:12345");
+}
+
+#[test]
+fn build_entries_missing_host_name_uses_empty_string() {
+    let peer = "127.0.0.1:1".parse().unwrap();
+    let req = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            resource: Some(Resource {
+                attributes: vec![],
+                dropped_attributes_count: 0,
+                entity_refs: vec![],
+            }),
+            scope_logs: vec![ScopeLogs {
+                scope: None,
+                log_records: vec![LogRecord {
+                    time_unix_nano: 0,
+                    observed_time_unix_nano: 0,
+                    severity_number: 9,
+                    severity_text: String::new(),
+                    body: Some(av_string("orphan")),
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    flags: 0,
+                    trace_id: vec![],
+                    span_id: vec![],
+                    event_name: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    };
+    let entries = build_entries(&req, peer);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].hostname, "");
+    assert!(entries[0].app_name.is_none());
+}
+
+#[test]
+fn build_entries_no_panic_on_empty_body() {
+    let peer = "127.0.0.1:1".parse().unwrap();
+    let req = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            resource: None,
+            scope_logs: vec![ScopeLogs {
+                scope: None,
+                log_records: vec![LogRecord {
+                    time_unix_nano: 0,
+                    observed_time_unix_nano: 0,
+                    severity_number: 9,
+                    severity_text: String::new(),
+                    body: None,
+                    attributes: vec![],
+                    dropped_attributes_count: 0,
+                    flags: 0,
+                    trace_id: vec![],
+                    span_id: vec![],
+                    event_name: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    };
+    let entries = build_entries(&req, peer);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].message, "");
+}
+
+#[test]
+fn build_entries_handles_multiple_resource_logs() {
+    let peer = "10.0.0.1:9999".parse().unwrap();
+    let req = ExportLogsServiceRequest {
+        resource_logs: vec![
+            sample_request("dookie", "claude-code", "msg one", 9)
+                .resource_logs
+                .into_iter()
+                .next()
+                .unwrap(),
+            sample_request("squirts", "codex", "msg two", 17)
+                .resource_logs
+                .into_iter()
+                .next()
+                .unwrap(),
+        ],
+    };
+    let entries = build_entries(&req, peer);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].hostname, "dookie");
+    assert_eq!(entries[1].hostname, "squirts");
+    assert_eq!(entries[1].severity, "err");
+}
+
+// ---- auth gate ----
+
+fn state_with_token(token: Option<&str>) -> OtlpState {
+    let (tx, _rx) = tokio::sync::mpsc::channel::<crate::db::LogBatchEntry>(10);
+    let ingest = crate::ingest::IngestTx::from_sender_for_test(tx);
+    OtlpState::new(
+        ingest,
+        token.map(String::from),
+        Arc::new(OtlpCounters::default()),
+    )
+}
+
+#[test]
+fn auth_disabled_when_no_token() {
+    let state = state_with_token(None);
+    let headers = HeaderMap::new();
+    assert!(is_authorized(&state, &headers));
+}
+
+#[test]
+fn auth_required_with_correct_bearer() {
+    let state = state_with_token(Some("secret"));
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        HeaderValue::from_static("Bearer secret"),
+    );
+    assert!(is_authorized(&state, &headers));
+}
+
+#[test]
+fn auth_rejects_wrong_token() {
+    let state = state_with_token(Some("secret"));
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        HeaderValue::from_static("Bearer wrong"),
+    );
+    assert!(!is_authorized(&state, &headers));
+}
+
+#[test]
+fn auth_rejects_missing_header() {
+    let state = state_with_token(Some("secret"));
+    let headers = HeaderMap::new();
+    assert!(!is_authorized(&state, &headers));
+}
+
+#[test]
+fn auth_rejects_non_bearer_scheme() {
+    let state = state_with_token(Some("secret"));
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        HeaderValue::from_static("Basic secret"),
+    );
+    assert!(!is_authorized(&state, &headers));
+}
+
+// ---- counters ----
+
+#[test]
+fn counters_default_to_zero() {
+    let counters = OtlpCounters::default();
+    assert_eq!(counters.logs_received.load(Ordering::Relaxed), 0);
+    assert_eq!(counters.decode_errors.load(Ordering::Relaxed), 0);
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,6 +9,8 @@ use crate::app::SyslogService;
 use crate::config::Config;
 use crate::db::{self, DbPool, StorageBudgetState};
 use crate::ingest::IngestTx;
+use crate::otlp::{self, OtlpCounters, OtlpState};
+use crate::syslog::enrichment::EnrichmentConfig;
 use crate::{docker_ingest, mcp, syslog};
 
 pub struct RuntimeCore {
@@ -18,6 +20,7 @@ pub struct RuntimeCore {
     service: SyslogService,
     maintenance_permit: Arc<Semaphore>,
     ingest: IngestTx,
+    otlp_counters: Arc<OtlpCounters>,
 }
 
 pub struct MaintenanceHandles {
@@ -83,11 +86,18 @@ impl RuntimeCore {
             );
         }
         let service = SyslogService::new(Arc::clone(&pool), config.storage.clone());
+        let enrichment = EnrichmentConfig {
+            authelia_source_ip: config.enrichment.authelia_source_ip.clone(),
+            adguard_source_ip: config.enrichment.adguard_source_ip.clone(),
+            scrub_prompts: config.enrichment.scrub_prompts,
+            api_token: config.mcp.api_token.clone(),
+        };
         let ingest = crate::ingest::start_writer_from_syslog_config(
             &config.syslog,
             config.storage.clone(),
             Arc::clone(&pool),
             Arc::clone(&storage_state),
+            enrichment,
         );
         Ok(Self {
             config,
@@ -96,6 +106,7 @@ impl RuntimeCore {
             service,
             maintenance_permit: Arc::new(Semaphore::new(1)),
             ingest,
+            otlp_counters: Arc::new(OtlpCounters::default()),
         })
     }
 
@@ -103,10 +114,21 @@ impl RuntimeCore {
         self.service.clone()
     }
 
+    /// Build the OTLP router with shared counters and the MCP API token (if any).
+    pub fn otlp_router(&self) -> axum::Router {
+        let state = OtlpState::new(
+            self.ingest.clone(),
+            self.config.mcp.api_token.clone(),
+            Arc::clone(&self.otlp_counters),
+        );
+        otlp::router(state)
+    }
+
     pub fn mcp_state(&self) -> mcp::AppState {
         mcp::AppState {
             service: self.service(),
             config: self.config.mcp.clone(),
+            otlp_counters: Arc::clone(&self.otlp_counters),
         }
     }
 
@@ -136,6 +158,7 @@ impl RuntimeCore {
         }
         let purge_pool = Arc::clone(&self.pool);
         let limiter = Arc::clone(&self.maintenance_permit);
+        let fts_merge_pages = self.config.enrichment.fts_merge_pages;
         let handle = tokio::spawn(async move {
             let mut interval = background_interval(tokio::time::Duration::from_secs(3600));
             loop {
@@ -147,9 +170,16 @@ impl RuntimeCore {
                 };
                 let pool = Arc::clone(&purge_pool);
                 tracing::debug!(retention_days, "Retention purge tick started");
+                // Tag-based purge runs FIRST so the global purge below scans
+                // a smaller working set and FTS merge work consolidates.
+                // Hardcoded 7-day windows for AdGuard tags. Other tags fall
+                // through to the global retention_days policy.
                 match tokio::task::spawn_blocking(move || {
                     let _permit = permit;
-                    db::purge_old_logs(&pool, retention_days)
+                    db::purge_by_tag_window(&pool, "adguard-allowed", 7, fts_merge_pages)?;
+                    db::purge_by_tag_window(&pool, "adguard-query", 7, fts_merge_pages)?;
+                    db::purge_by_tag_window(&pool, "adguard-rewrite", 7, fts_merge_pages)?;
+                    db::purge_old_logs(&pool, retention_days, fts_merge_pages)
                 })
                 .await
                 .map_err(|e| anyhow::anyhow!("spawn_blocking error: {e}"))

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -186,29 +186,35 @@ impl RuntimeCore {
                     // transient SQLITE_BUSY on one tag must NOT abort the
                     // others or the global retention purge — that would stall
                     // all retention for an hour.
+                    let mut tag_deleted: usize = 0;
                     for tag in ADGUARD_RETENTION_TAGS {
-                        if let Err(e) = db::purge_by_tag_window(
+                        match db::purge_by_tag_window(
                             &pool,
                             tag,
                             ADGUARD_RETENTION_DAYS,
                             fts_merge_pages,
                         ) {
-                            tracing::error!(
+                            Ok(n) => tag_deleted += n,
+                            Err(e) => tracing::error!(
                                 tag,
                                 error = %e,
                                 "Tag-window purge failed; continuing"
-                            );
+                            ),
                         }
                     }
-                    db::purge_old_logs(&pool, retention_days, fts_merge_pages)
+                    let global_deleted =
+                        db::purge_old_logs(&pool, retention_days, fts_merge_pages)?;
+                    Ok::<(usize, usize), anyhow::Error>((tag_deleted, global_deleted))
                 })
                 .await
                 .map_err(|e| anyhow::anyhow!("spawn_blocking error: {e}"))
                 .and_then(|r| r)
                 {
-                    Ok(deleted) => tracing::info!(
+                    Ok((tag_deleted, global_deleted)) => tracing::info!(
                         retention_days,
-                        deleted,
+                        tag_deleted,
+                        global_deleted,
+                        total_deleted = tag_deleted + global_deleted,
                         elapsed_ms = started.elapsed().as_millis(),
                         "Retention purge tick completed"
                     ),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -47,6 +47,12 @@ pub(crate) fn background_interval(period: tokio::time::Duration) -> tokio::time:
     tokio::time::interval_at(tokio::time::Instant::now() + period, period)
 }
 
+/// Tags whose retention is hard-capped at 7 days regardless of the global
+/// `retention_days` setting. AdGuard query volume would otherwise dominate
+/// the FTS5 index at homelab volumes (50k+ DNS queries/day).
+const ADGUARD_RETENTION_TAGS: &[&str] = &["adguard-allowed", "adguard-query", "adguard-rewrite"];
+const ADGUARD_RETENTION_DAYS: u32 = 7;
+
 impl RuntimeCore {
     pub fn load() -> Result<Self> {
         Self::for_server(Config::load()?)
@@ -176,9 +182,14 @@ impl RuntimeCore {
                 // through to the global retention_days policy.
                 match tokio::task::spawn_blocking(move || {
                     let _permit = permit;
-                    db::purge_by_tag_window(&pool, "adguard-allowed", 7, fts_merge_pages)?;
-                    db::purge_by_tag_window(&pool, "adguard-query", 7, fts_merge_pages)?;
-                    db::purge_by_tag_window(&pool, "adguard-rewrite", 7, fts_merge_pages)?;
+                    for tag in ADGUARD_RETENTION_TAGS {
+                        db::purge_by_tag_window(
+                            &pool,
+                            tag,
+                            ADGUARD_RETENTION_DAYS,
+                            fts_merge_pages,
+                        )?;
+                    }
                     db::purge_old_logs(&pool, retention_days, fts_merge_pages)
                 })
                 .await

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -182,13 +182,23 @@ impl RuntimeCore {
                 // through to the global retention_days policy.
                 match tokio::task::spawn_blocking(move || {
                     let _permit = permit;
+                    // Tag-window purges are independent maintenance ops. A
+                    // transient SQLITE_BUSY on one tag must NOT abort the
+                    // others or the global retention purge — that would stall
+                    // all retention for an hour.
                     for tag in ADGUARD_RETENTION_TAGS {
-                        db::purge_by_tag_window(
+                        if let Err(e) = db::purge_by_tag_window(
                             &pool,
                             tag,
                             ADGUARD_RETENTION_DAYS,
                             fts_merge_pages,
-                        )?;
+                        ) {
+                            tracing::error!(
+                                tag,
+                                error = %e,
+                                "Tag-window purge failed; continuing"
+                            );
+                        }
                     }
                     db::purge_old_logs(&pool, retention_days, fts_merge_pages)
                 })

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -20,8 +20,11 @@ pub async fn start_with_storage_state(
     pool: Arc<DbPool>,
     storage_state: Arc<Mutex<Option<db::StorageBudgetState>>>,
 ) -> Result<()> {
-    // No-op enrichment for the legacy convenience entry point — production
-    // runtime uses RuntimeCore which builds enrichment from Config.
+    // Default enrichment for the legacy convenience entry point: Authelia
+    // and AdGuard reclassification are still applied (gating is "ungated"
+    // when no source-IP prefix is configured), but secret scrubbing stays
+    // on (default). Production runtime uses RuntimeCore which builds
+    // enrichment from Config including operator overrides.
     let ingest_tx = ingest::start_writer_from_syslog_config(
         &config,
         storage,

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -7,6 +7,7 @@ use crate::config::{StorageConfig, SyslogConfig};
 use crate::db::{self, DbPool};
 use crate::ingest;
 
+pub(crate) mod enrichment;
 mod listener;
 mod parser;
 pub(crate) mod writer;
@@ -19,7 +20,15 @@ pub async fn start_with_storage_state(
     pool: Arc<DbPool>,
     storage_state: Arc<Mutex<Option<db::StorageBudgetState>>>,
 ) -> Result<()> {
-    let ingest_tx = ingest::start_writer_from_syslog_config(&config, storage, pool, storage_state);
+    // No-op enrichment for the legacy convenience entry point — production
+    // runtime uses RuntimeCore which builds enrichment from Config.
+    let ingest_tx = ingest::start_writer_from_syslog_config(
+        &config,
+        storage,
+        pool,
+        storage_state,
+        crate::syslog::enrichment::EnrichmentConfig::default(),
+    );
     start_listeners(config, ingest_tx.sender()).await
 }
 

--- a/src/syslog/enrichment.rs
+++ b/src/syslog/enrichment.rs
@@ -86,21 +86,24 @@ const AI_SOURCES: &[&str] = &[
     "codex",
 ];
 
-/// Minimal AdGuard query log row. We deliberately use named fields with
-/// `default` so unknown JSON keys are dropped without allocation.
+/// Minimal AdGuard query log row. AdGuard emits PascalCase JSON keys; the
+/// container-level `rename_all` keeps Rust field names idiomatic snake_case.
+/// `default` per field tolerates partial / future-incompatible payloads.
 #[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 struct AdGuardQuery {
-    #[serde(rename = "Result", default)]
+    #[serde(default)]
     result: AdGuardResult,
-    #[serde(rename = "Upstream", default)]
+    #[serde(default)]
     upstream: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 struct AdGuardResult {
-    #[serde(rename = "IsFiltered", default)]
+    #[serde(default)]
     is_filtered: bool,
-    #[serde(rename = "Reason", default)]
+    #[serde(default)]
     reason: String,
 }
 

--- a/src/syslog/enrichment.rs
+++ b/src/syslog/enrichment.rs
@@ -18,6 +18,7 @@
 //! costs 10–50 ms each and would saturate the writer at any non-trivial
 //! volume.
 
+use std::borrow::Cow;
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -62,12 +63,15 @@ static SECRET_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
         r"\bsk-ant-api03-[A-Za-z0-9_\-]{20,}\b",
         // OpenAI project keys
         r"\bsk-proj-[A-Za-z0-9_\-]{20,}\b",
-        // Generic Bearer tokens in Authorization headers
-        r"(?i)Authorization:\s*Bearer\s+[A-Za-z0-9._\-]+",
-        // password=value, api_key=value, secret=value
-        r"(?i)\b(?:password|api[_-]?key|secret)\s*[:=]\s*[^\s,;\}\]]+",
-        // PEM private key block (any line containing the BEGIN marker)
-        r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
+        // Standalone JWTs (3 base64url segments separated by `.`)
+        r"\beyJ[A-Za-z0-9_\-]{8,}\.eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\b",
+        // Bearer tokens in Authorization headers (broad token charset incl. base64 +/=)
+        r"(?i)Authorization:\s*Bearer\s+[A-Za-z0-9._+/=\-]+",
+        // password=value / api_key=value / secret=value (handles quoted values)
+        r#"(?i)\b(?:password|api[_-]?key|secret)\s*[:=]\s*"?[^\s,;\}\]"]+"?"#,
+        // PEM private key block — match the WHOLE block including key body. (?s)
+        // makes `.` cross newlines; lazy `.+?` stops at the first END marker.
+        r"(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.+?-----END [A-Z ]*PRIVATE KEY-----",
     ];
     raw.into_iter()
         .map(|p| Regex::new(p).expect("static secret pattern"))
@@ -172,17 +176,22 @@ fn is_ai_source(app_name: &str) -> bool {
 /// Replace any token matching the secret pattern set with `[REDACTED]`. The
 /// raw API token (if configured) is appended as a literal pattern so a leaked
 /// copy in tool output is scrubbed before storage.
+///
+/// Common case (no match) returns `Cow::Borrowed` and allocates nothing —
+/// hot-path optimization for AI bursts where most messages have no secrets.
 fn scrub_secrets(message: &str, api_token: Option<&str>) -> String {
-    let mut out = message.to_string();
+    let mut out: Cow<str> = Cow::Borrowed(message);
     for re in SECRET_PATTERNS.iter() {
-        out = re.replace_all(&out, "[REDACTED]").to_string();
+        if let Cow::Owned(replaced) = re.replace_all(&out, "[REDACTED]") {
+            out = Cow::Owned(replaced);
+        }
     }
     if let Some(token) = api_token {
         if !token.is_empty() && out.contains(token) {
-            out = out.replace(token, "[REDACTED]");
+            out = Cow::Owned(out.replace(token, "[REDACTED]"));
         }
     }
-    out
+    out.into_owned()
 }
 
 #[cfg(test)]

--- a/src/syslog/enrichment.rs
+++ b/src/syslog/enrichment.rs
@@ -1,0 +1,190 @@
+//! Pre-insert enrichment for syslog batch entries.
+//!
+//! Two responsibilities:
+//! 1. **Source-aware reclassification** — parse Authelia `level=` into a real
+//!    syslog severity, classify AdGuard query results into
+//!    `adguard-blocked` / `adguard-allowed` / `adguard-rewrite`.
+//! 2. **Best-effort secret scrubbing** for AI-source records (claude/codex
+//!    transcripts and OTLP records carrying their service.name) so accidental
+//!    credential pastes don't end up FTS5-indexed.
+//!
+//! The scrubber is **defense-in-depth, not a compliance control** — regex has
+//! structural bypass classes (multi-line wrapping, encoding obfuscation,
+//! token formats not in the pattern list). Set `SYSLOG_MCP_SCRUB_PROMPTS=false`
+//! to disable.
+//!
+//! All regex patterns are compiled exactly once via `LazyLock` because
+//! enrichment runs on the batch-writer hot path: per-record `Regex::new`
+//! costs 10–50 ms each and would saturate the writer at any non-trivial
+//! volume.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+use serde::Deserialize;
+
+use crate::db::LogBatchEntry;
+
+/// Configuration for the enrichment pipeline. Built from environment variables
+/// at runtime startup; cloned into the batch writer.
+#[derive(Debug, Clone, Default)]
+pub struct EnrichmentConfig {
+    /// If `Some`, only apply Authelia enrichment when the entry's `source_ip`
+    /// starts with this prefix. If `None`, apply to any entry whose
+    /// `app_name` matches.
+    pub authelia_source_ip: Option<String>,
+    /// Same gating, for AdGuard.
+    pub adguard_source_ip: Option<String>,
+    /// When `true`, redact known secret patterns from AI-source messages.
+    pub scrub_prompts: bool,
+    /// Optional API token value to add to the redaction set so a leaked token
+    /// in tool output is scrubbed before FTS5 indexes it.
+    pub api_token: Option<String>,
+}
+
+// --- compiled once at module load ----------------------------------------
+
+/// Captures `level=...` from Authelia structured log lines.
+static AUTHELIA_LEVEL: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\blevel=([A-Za-z]+)").expect("static regex"));
+
+/// Patterns scrubbed from AI-source message bodies. Each matches the entire
+/// secret token; the matched text is replaced with `[REDACTED]`.
+static SECRET_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    let raw = [
+        // AWS access keys: AKIA, ASIA (STS), AGPA (group), AROA (role), AIDA (user)
+        r"\b(?:AKIA|ASIA|AGPA|AROA|AIDA)[0-9A-Z]{16}\b",
+        // GitHub tokens: gh[pousr]_<base62>
+        r"\bgh[pousr]_[A-Za-z0-9]{36,}\b",
+        // GitHub fine-grained PATs
+        r"\bgithub_pat_[A-Za-z0-9_]{20,}\b",
+        // Anthropic
+        r"\bsk-ant-api03-[A-Za-z0-9_\-]{20,}\b",
+        // OpenAI project keys
+        r"\bsk-proj-[A-Za-z0-9_\-]{20,}\b",
+        // Generic Bearer tokens in Authorization headers
+        r"(?i)Authorization:\s*Bearer\s+[A-Za-z0-9._\-]+",
+        // password=value, api_key=value, secret=value
+        r"(?i)\b(?:password|api[_-]?key|secret)\s*[:=]\s*[^\s,;\}\]]+",
+        // PEM private key block (any line containing the BEGIN marker)
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
+    ];
+    raw.into_iter()
+        .map(|p| Regex::new(p).expect("static secret pattern"))
+        .collect()
+});
+
+/// AI-source `app_name` values whose message bodies are eligible for scrubbing.
+const AI_SOURCES: &[&str] = &[
+    "claude-transcript",
+    "codex-transcript",
+    "claude-code",
+    "codex",
+];
+
+/// Minimal AdGuard query log row. We deliberately use named fields with
+/// `default` so unknown JSON keys are dropped without allocation.
+#[derive(Debug, Default, Deserialize)]
+struct AdGuardQuery {
+    #[serde(rename = "Result", default)]
+    result: AdGuardResult,
+    #[serde(rename = "Upstream", default)]
+    upstream: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct AdGuardResult {
+    #[serde(rename = "IsFiltered", default)]
+    is_filtered: bool,
+    #[serde(rename = "Reason", default)]
+    reason: String,
+}
+
+/// Apply enrichment to one entry. Pure function — never panics, never logs at
+/// `error`. Parse failures fall through, leaving the entry unchanged.
+pub(crate) fn enrich_entry(mut entry: LogBatchEntry, config: &EnrichmentConfig) -> LogBatchEntry {
+    if matches_app(&entry, "authelia")
+        && source_ip_matches(&entry, config.authelia_source_ip.as_deref())
+    {
+        if let Some(level_severity) = extract_authelia_level(&entry.message) {
+            entry.severity = level_severity.to_string();
+        }
+    }
+
+    if matches_app(&entry, "adguard-query")
+        && source_ip_matches(&entry, config.adguard_source_ip.as_deref())
+    {
+        if let Some(new_app) = classify_adguard(&entry.message) {
+            entry.app_name = Some(new_app.to_string());
+        }
+    }
+
+    if config.scrub_prompts && entry.app_name.as_deref().is_some_and(is_ai_source) {
+        entry.message = scrub_secrets(&entry.message, config.api_token.as_deref());
+    }
+
+    entry
+}
+
+fn matches_app(entry: &LogBatchEntry, expected: &str) -> bool {
+    entry.app_name.as_deref() == Some(expected)
+}
+
+fn source_ip_matches(entry: &LogBatchEntry, configured_prefix: Option<&str>) -> bool {
+    match configured_prefix {
+        Some(prefix) if !prefix.is_empty() => entry.source_ip.starts_with(prefix),
+        // Unset: apply to all matching app_name. Less safe but simpler default.
+        _ => true,
+    }
+}
+
+fn extract_authelia_level(message: &str) -> Option<&'static str> {
+    let cap = AUTHELIA_LEVEL.captures(message)?;
+    let level = cap.get(1)?.as_str();
+    Some(match level.to_ascii_lowercase().as_str() {
+        "trace" | "debug" => "debug",
+        "info" => "info",
+        "warn" | "warning" => "warning",
+        "error" => "err",
+        "fatal" | "panic" => "crit",
+        _ => return None,
+    })
+}
+
+fn classify_adguard(message: &str) -> Option<&'static str> {
+    let parsed: AdGuardQuery = serde_json::from_str(message).ok()?;
+    if parsed.result.reason.contains("Rewrite") {
+        return Some("adguard-rewrite");
+    }
+    if parsed.result.is_filtered {
+        return Some("adguard-blocked");
+    }
+    if !parsed.upstream.is_empty() {
+        return Some("adguard-allowed");
+    }
+    None
+}
+
+fn is_ai_source(app_name: &str) -> bool {
+    AI_SOURCES.contains(&app_name)
+}
+
+/// Replace any token matching the secret pattern set with `[REDACTED]`. The
+/// raw API token (if configured) is appended as a literal pattern so a leaked
+/// copy in tool output is scrubbed before storage.
+fn scrub_secrets(message: &str, api_token: Option<&str>) -> String {
+    let mut out = message.to_string();
+    for re in SECRET_PATTERNS.iter() {
+        out = re.replace_all(&out, "[REDACTED]").to_string();
+    }
+    if let Some(token) = api_token {
+        if !token.is_empty() && out.contains(token) {
+            out = out.replace(token, "[REDACTED]");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "enrichment_tests.rs"]
+mod tests;

--- a/src/syslog/enrichment.rs
+++ b/src/syslog/enrichment.rs
@@ -137,11 +137,29 @@ fn matches_app(entry: &LogBatchEntry, expected: &str) -> bool {
     entry.app_name.as_deref() == Some(expected)
 }
 
+/// Match `entry.source_ip` against an operator-configured prefix at the
+/// IP-octet boundary. Plain `starts_with` would let an attacker on
+/// `10.0.0.10` (or `10.0.0.123`) pass a gate configured for `10.0.0.1`
+/// because `"10.0.0.10:1234".starts_with("10.0.0.1")` is true. Two cases:
+///
+/// * **Subnet prefix** ending with `.` (e.g. `"10.0.0."`): match any IP
+///   in the subnet — the byte after the prefix must be a digit (next octet).
+/// * **Exact host** without trailing dot (e.g. `"10.0.0.5"`): match only
+///   that IP — extract the IP portion of `"<ip>:<port>"` and require equality.
+///
+/// `None` or empty prefix preserves the legacy "apply to all matching
+/// app_name" default.
 fn source_ip_matches(entry: &LogBatchEntry, configured_prefix: Option<&str>) -> bool {
-    match configured_prefix {
-        Some(prefix) if !prefix.is_empty() => entry.source_ip.starts_with(prefix),
-        // Unset: apply to all matching app_name. Less safe but simpler default.
-        _ => true,
+    let Some(prefix) = configured_prefix.filter(|p| !p.is_empty()) else {
+        return true;
+    };
+    let ip_only = entry.source_ip.split(':').next().unwrap_or("");
+    if prefix.ends_with('.') {
+        // Subnet match: prefix is a partial dotted-quad like "10.0.0."
+        ip_only.starts_with(prefix)
+    } else {
+        // Exact-host match: prefix is a full IP literal
+        ip_only == prefix
     }
 }
 

--- a/src/syslog/enrichment_tests.rs
+++ b/src/syslog/enrichment_tests.rs
@@ -84,6 +84,37 @@ fn authelia_source_ip_gating_allows_matching() {
     assert_eq!(out.severity, "err");
 }
 
+/// Regression: prefix `10.0.0.1` must NOT match a spoofer at `10.0.0.10`.
+/// Plain `starts_with` would have, allowing an attacker one IP off from the
+/// configured authelia host to inject `level=` reclassifications.
+#[test]
+fn authelia_source_ip_gating_blocks_prefix_collision() {
+    let cfg = EnrichmentConfig {
+        authelia_source_ip: Some("10.0.0.1".into()),
+        ..Default::default()
+    };
+    // Attacker on 10.0.0.10 — would pass naive starts_with(10.0.0.1)
+    let e = entry("authelia", "level=err msg=spoof", "10.0.0.10:1234", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(
+        out.severity, "info",
+        "prefix-collision must not bypass gate"
+    );
+}
+
+/// Subnet match: prefix ending in `.` (e.g. `10.0.0.`) matches any host in
+/// that octet boundary.
+#[test]
+fn authelia_source_ip_gating_subnet_match_with_trailing_dot() {
+    let cfg = EnrichmentConfig {
+        authelia_source_ip: Some("10.0.0.".into()),
+        ..Default::default()
+    };
+    let e = entry("authelia", "level=warn msg=ok", "10.0.0.42:9000", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.severity, "warning");
+}
+
 // ---- adguard tag classification ----
 
 #[test]

--- a/src/syslog/enrichment_tests.rs
+++ b/src/syslog/enrichment_tests.rs
@@ -1,0 +1,234 @@
+//! Tests for the enrichment pipeline.
+
+use super::*;
+
+fn entry(app: &str, msg: &str, source_ip: &str, severity: &str) -> LogBatchEntry {
+    LogBatchEntry {
+        timestamp: "2026-05-07T00:00:00.000Z".to_string(),
+        hostname: "test".to_string(),
+        facility: None,
+        severity: severity.to_string(),
+        app_name: Some(app.to_string()),
+        process_id: None,
+        message: msg.to_string(),
+        raw: String::new(),
+        source_ip: source_ip.to_string(),
+        docker_checkpoint: None,
+    }
+}
+
+// ---- authelia severity parsing ----
+
+#[test]
+fn authelia_level_warn_promotes_severity() {
+    let cfg = EnrichmentConfig::default();
+    let e = entry(
+        "authelia",
+        "time=2026-05-07 level=warn msg=\"failed login\"",
+        "10.0.0.1:1234",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.severity, "warning");
+}
+
+#[test]
+fn authelia_level_error_promotes_severity() {
+    let cfg = EnrichmentConfig::default();
+    let e = entry("authelia", "level=error msg=test", "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.severity, "err");
+}
+
+#[test]
+fn authelia_no_level_keeps_severity() {
+    let cfg = EnrichmentConfig::default();
+    let e = entry("authelia", "no level field here", "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.severity, "info");
+}
+
+#[test]
+fn authelia_unknown_level_keeps_severity() {
+    let cfg = EnrichmentConfig::default();
+    let e = entry("authelia", "level=galaxy", "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.severity, "info");
+}
+
+#[test]
+fn authelia_source_ip_gating_blocks_non_matching() {
+    let cfg = EnrichmentConfig {
+        authelia_source_ip: Some("192.168.1.10".into()),
+        ..Default::default()
+    };
+    let e = entry("authelia", "level=error msg=foo", "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    // Severity must NOT be promoted because source IP doesn't match.
+    assert_eq!(out.severity, "info");
+}
+
+#[test]
+fn authelia_source_ip_gating_allows_matching() {
+    let cfg = EnrichmentConfig {
+        authelia_source_ip: Some("192.168.1.10".into()),
+        ..Default::default()
+    };
+    let e = entry(
+        "authelia",
+        "level=error msg=foo",
+        "192.168.1.10:5000",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.severity, "err");
+}
+
+// ---- adguard tag classification ----
+
+#[test]
+fn adguard_filtered_becomes_blocked() {
+    let cfg = EnrichmentConfig::default();
+    let body = r#"{"QH":"ads.example.com","Result":{"IsFiltered":true,"Reason":"FilteredBlackList"},"Upstream":""}"#;
+    let e = entry("adguard-query", body, "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.app_name.as_deref(), Some("adguard-blocked"));
+}
+
+#[test]
+fn adguard_unfiltered_with_upstream_becomes_allowed() {
+    let cfg = EnrichmentConfig::default();
+    let body =
+        r#"{"QH":"github.com","Result":{"IsFiltered":false,"Reason":""},"Upstream":"9.9.9.9:53"}"#;
+    let e = entry("adguard-query", body, "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.app_name.as_deref(), Some("adguard-allowed"));
+}
+
+#[test]
+fn adguard_rewrite_classified() {
+    let cfg = EnrichmentConfig::default();
+    let body =
+        r#"{"QH":"local.lan","Result":{"IsFiltered":false,"Reason":"Rewrite"},"Upstream":""}"#;
+    let e = entry("adguard-query", body, "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.app_name.as_deref(), Some("adguard-rewrite"));
+}
+
+#[test]
+fn adguard_malformed_json_passes_through() {
+    let cfg = EnrichmentConfig::default();
+    let e = entry("adguard-query", "{not json", "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.app_name.as_deref(), Some("adguard-query"));
+}
+
+#[test]
+fn adguard_source_ip_gating_blocks_spoof() {
+    let cfg = EnrichmentConfig {
+        adguard_source_ip: Some("192.168.1.20".into()),
+        ..Default::default()
+    };
+    let body = r#"{"Result":{"IsFiltered":true},"Upstream":""}"#;
+    let e = entry("adguard-query", body, "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.app_name.as_deref(), Some("adguard-query"));
+}
+
+// ---- non-target apps unchanged ----
+
+#[test]
+fn non_authelia_non_adguard_passes_unchanged() {
+    let cfg = EnrichmentConfig::default();
+    let e = entry("nginx", "level=error this is nginx", "10.0.0.1:1", "info");
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.severity, "info");
+    assert_eq!(out.app_name.as_deref(), Some("nginx"));
+}
+
+// ---- secret scrubbing ----
+
+#[test]
+fn scrub_aws_access_key() {
+    let cfg = EnrichmentConfig {
+        scrub_prompts: true,
+        ..Default::default()
+    };
+    let e = entry(
+        "claude-code",
+        "Found AKIAIOSFODNN7EXAMPLE in the env file",
+        "10.0.0.1:1",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert!(out.message.contains("[REDACTED]"));
+    assert!(!out.message.contains("AKIAIOSFODNN7EXAMPLE"));
+}
+
+#[test]
+fn scrub_github_token() {
+    let cfg = EnrichmentConfig {
+        scrub_prompts: true,
+        ..Default::default()
+    };
+    let e = entry(
+        "claude-transcript",
+        "use token ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa here",
+        "10.0.0.1:1",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert!(out.message.contains("[REDACTED]"));
+    assert!(!out.message.contains("ghp_aaaa"));
+}
+
+#[test]
+fn scrub_api_token_value() {
+    let cfg = EnrichmentConfig {
+        scrub_prompts: true,
+        api_token: Some("super-secret-token-value-123".into()),
+        ..Default::default()
+    };
+    let e = entry(
+        "claude-code",
+        "the token is super-secret-token-value-123 do not share",
+        "10.0.0.1:1",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert!(!out.message.contains("super-secret-token-value-123"));
+    assert!(out.message.contains("[REDACTED]"));
+}
+
+#[test]
+fn scrub_disabled_leaves_message_untouched() {
+    let cfg = EnrichmentConfig {
+        scrub_prompts: false,
+        ..Default::default()
+    };
+    let e = entry(
+        "claude-code",
+        "AKIAIOSFODNN7EXAMPLE in plain text",
+        "10.0.0.1:1",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert!(out.message.contains("AKIAIOSFODNN7EXAMPLE"));
+}
+
+#[test]
+fn scrub_skips_non_ai_source() {
+    let cfg = EnrichmentConfig {
+        scrub_prompts: true,
+        ..Default::default()
+    };
+    let e = entry(
+        "nginx",
+        "AKIAIOSFODNN7EXAMPLE in nginx log",
+        "10.0.0.1:1",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    // nginx is not in AI_SOURCES, scrubber doesn't touch it
+    assert!(out.message.contains("AKIAIOSFODNN7EXAMPLE"));
+}

--- a/src/syslog/writer.rs
+++ b/src/syslog/writer.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info};
 
+use super::enrichment::{enrich_entry, EnrichmentConfig};
 use crate::config::StorageConfig;
 use crate::db::{self, DbPool};
 
@@ -19,6 +20,7 @@ pub(crate) async fn batch_writer(
     storage_state: Arc<Mutex<Option<db::StorageBudgetState>>>,
     batch_size: usize,
     flush_interval: tokio::time::Duration,
+    enrichment: EnrichmentConfig,
 ) {
     let mut batch: Vec<db::LogBatchEntry> = Vec::with_capacity(batch_size);
     let mut storage_blocked = false;
@@ -60,6 +62,7 @@ pub(crate) async fn batch_writer(
                                     &mut batch,
                                     &mut storage_blocked,
                                     &mut summary,
+                                    &enrichment,
                                 )
                                 .await;
                             }
@@ -83,6 +86,7 @@ pub(crate) async fn batch_writer(
                 &mut batch,
                 &mut storage_blocked,
                 &mut summary,
+                &enrichment,
             )
             .await;
         }
@@ -102,9 +106,15 @@ pub(super) async fn flush_batch(
     batch: &mut Vec<db::LogBatchEntry>,
     storage_blocked: &mut bool,
     summary: &mut IngestSummary,
+    enrichment: &EnrichmentConfig,
 ) {
     let pool = Arc::clone(pool);
-    let batch_to_write = std::mem::take(batch);
+    // Enrichment runs in the async context (cheap regex/JSON work) so the
+    // spawn_blocking call below stays focused on the SQL write.
+    let batch_to_write: Vec<db::LogBatchEntry> = std::mem::take(batch)
+        .into_iter()
+        .map(|e| enrich_entry(e, enrichment))
+        .collect();
     let count = batch_to_write.len();
     let started = Instant::now();
     debug!(count, "Attempting batch flush");

--- a/src/syslog/writer_tests.rs
+++ b/src/syslog/writer_tests.rs
@@ -56,6 +56,7 @@ async fn flush_batch_retains_entries_while_storage_is_write_blocked() {
         &mut batch,
         &mut storage_blocked,
         &mut summary,
+        &crate::syslog::enrichment::EnrichmentConfig::default(),
     )
     .await;
 
@@ -81,6 +82,7 @@ async fn flush_batch_resumes_after_storage_recovers() {
         &mut batch,
         &mut storage_blocked,
         &mut summary,
+        &crate::syslog::enrichment::EnrichmentConfig::default(),
     )
     .await;
 

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -548,7 +548,7 @@ run_docker_mode() {
   # Build image
   section "Docker — Build"
   log_info "Building Docker image ${IMAGE_NAME}..."
-  if ! docker build -t "${IMAGE_NAME}" "${project_dir}"; then
+  if ! docker build -f "${project_dir}/config/Dockerfile" -t "${IMAGE_NAME}" "${project_dir}"; then
     log_error "Docker build failed"
     return 2
   fi


### PR DESCRIPTION
## Summary

Implements the [`syslog-mcp-6uoy`](https://github.com/jmagar/syslog-mcp/issues?q=syslog-mcp-6uoy) epic: **full-fleet log ingestion + OTLP/HTTP receiver**.

This is the result of running `/lavra-design` end-to-end (brainstorm → plan → 5-agent research → revise → CEO review → 4-agent engineering review → lock) followed by the implementation, all in this worktree.

### Phase 1 — OTLP HTTP receiver (`src/otlp.rs`)

- `POST /v1/logs` — decodes `ExportLogsServiceRequest` protobuf, builds `LogBatchEntry` per record, sends via existing `IngestTx::try_send` (HTTP 503 on full channel)
- `POST /v1/metrics` — 200 OK + discard
- `POST /v1/traces` — 404 (deferred — span flattening discards parent_span_id/duration; FTS5 cannot meaningfully query hex IDs)
- `RequestBodyLimitLayer(4 MiB)` with `Retry-After: 86400` on 413 to prevent OTel exporter retry storms
- Optional Bearer auth via existing `SYSLOG_MCP_API_TOKEN`
- Peer IP captured via `ConnectInfo<SocketAddr>` and stored as `source_ip` (mirrors syslog provenance — OTLP `host.name` is client-asserted)
- `prost::decode` wrapped in `spawn_blocking` to avoid runtime starvation
- `/health` extended with `otlp_logs_received` and `otlp_decode_errors` counters

### Phase 2 — Ingest enrichment + tag-based retention

- `src/syslog/enrichment.rs`: pre-insert transform with `LazyLock<Regex>` (per-record `Regex::new` would block `spawn_blocking` for 10–50 ms each — research-flagged P0)
- Authelia: parse `level=` from message body → severity reclassification
- AdGuard: parse JSON → tag classification (`adguard-blocked` / `adguard-allowed` / `adguard-rewrite`)
- Source-IP gating via `SYSLOG_MCP_AUTHELIA_SOURCE_IP` / `SYSLOG_MCP_ADGUARD_SOURCE_IP` (prevents severity/tag spoofing)
- Best-effort secret scrubbing on AI-source records (`SYSLOG_MCP_SCRUB_PROMPTS=true` by default) — 8 pattern classes plus the API token literal
- Migration v3: composite index `(app_name, received_at)` so tag-based DELETE is O(rows-deleted), not O(rows-in-tag-partition × chunks)
- `purge_by_tag_window` for AdGuard 7d retention
- `purge_old_logs` excludes `severity IN ('err','crit','alert','emerg')` from time-based purge
- `enforce_storage_budget` warns when disk pressure deletes high-severity rows (documented policy interaction)
- Configurable FTS5 merge via `SYSLOG_MCP_FTS_MERGE_PAGES` (default 0 = unconditional merge)

### Phases 3–5 — Deploy artifacts (`deploy/`)

Pure ops work that requires SSH access to remote hosts; the artifacts are committed but **manual SSH deployment is required**:

- `deploy/rsyslog/`: `10-imjournal.conf`, `40-ai-transcripts.conf`, `30-swag.conf`, `35-authelia.conf`, `36-adguard.conf`
- `deploy/otel/`: `claude-code-settings.example.json`, `codex-config.example.toml`
- `deploy/README.md`: step-by-step runbook

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 187 passed (170 existing + 15 OTLP + 17 enrichment)
- [ ] Smoke test: `curl -X POST http://localhost:3100/v1/logs` with valid protobuf returns 200 (will run after deploy)
- [ ] `/health` shows `otlp_logs_received` incrementing after first claude session
- [ ] AdGuard query log entries get reclassified to `adguard-blocked` / `adguard-allowed` / `adguard-rewrite` after Phase 2 deploys
- [ ] Migration v3 on production DB: time the `CREATE INDEX` and confirm health gap is acceptable

## Migration / rollout notes

- **Migration v3 is the only operational risk**. On a multi-million-row database the `CREATE INDEX` call may hold the write lock for several minutes. `/health` will not respond and syslog UDP packets may drop during that window. Plan for a brief outage when first restarting on this version.
- **Phase 1 is rollback-safe** — revert the binary, OTLP routes disappear, syslog ingest unaffected.
- **Phase 2 is rollback-safe** — `DROP INDEX idx_logs_app_name_received_at` reverses the index; tag purges become slower but still correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OTLP/HTTP logs receiver with enrichment and tag‑based retention for full‑fleet ingest and safer storage. Updates deploy artifacts and retention reporting, and fixes the Docker build path used in CI.

- **New Features**
  - OTLP receiver: `POST /v1/logs` ingests; `/v1/metrics` 200 + discard; `/v1/traces` 404. 4 MiB cap with `Retry-After: 86400`; optional Bearer auth via `SYSLOG_MCP_TOKEN` (alias `SYSLOG_MCP_API_TOKEN`). Pre‑flight capacity check rejects whole batches with 503; 500 if writer is dead. Source IP captured; `/health` exposes `otlp_logs_received` and `otlp_decode_errors`. Unauthorized requests log peer and auth‑header presence; startup warns if unauthenticated on non‑loopback.
  - Ingest enrichment: Authelia `level=` → severity; AdGuard JSON → `adguard-blocked/allowed/rewrite`. Strict source‑IP gating (exact host or subnet via trailing‑dot prefix). Secret scrubbing expanded (PEM blocks, JWTs, broader Bearer charset, AWS/GitHub/OpenAI/Anthropic, token literal) with a fast no‑alloc path.
  - Retention: 7‑day windows for AdGuard tags; high‑severity rows excluded from time‑based purge. Per‑tag purge errors are logged and do not abort the cycle. Retention tick now reports `tag_deleted`, `global_deleted`, and `total` separately. Configurable FTS5 merge via `SYSLOG_MCP_FTS_MERGE_PAGES`.
  - Hardening: centralized constant‑time Bearer helpers used across OTLP, MCP, and API.
  - Deploy artifacts: rsyslog drop‑ins and OTel client examples under `deploy/` with path placeholders and guidance for `OTEL_EXPORTER_OTLP_HEADERS`. Added rationale for disabling `imjournal` rate‑limits. Dependencies: `opentelemetry-proto`, `prost`, `regex`.
  - CI: Docker builds now point to `config/Dockerfile` in `.github/workflows/docker-publish.yml` and `tests/test_live.sh`.

- **Migration**
  - First run on 0.11.0 creates index `logs(app_name, received_at)`; expect a brief write‑lock on large DBs (`/health` gap, possible UDP drops).
  - Apply rsyslog and OTel client configs from `deploy/` on target hosts.
  - Optional envs: `SYSLOG_MCP_AUTHELIA_SOURCE_IP`, `SYSLOG_MCP_ADGUARD_SOURCE_IP`, `SYSLOG_MCP_SCRUB_PROMPTS` (default true), `SYSLOG_MCP_FTS_MERGE_PAGES` (validated 0..=10000, default 0).

<sup>Written for commit f63aa167499a07fef26da999c7ef200456a39171. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OTLP HTTP receiver for ingesting OpenTelemetry logs with protobuf support
  * Syslog enrichment: Authelia log level parsing and AdGuard log classification
  * Secret scrubbing for AI-generated records with configurable toggle
  * Tag-based retention rules for AdGuard categories
  * Configurable FTS merge strategy for performance tuning

* **Changed**
  * Enhanced health metrics with OTLP ingest and decode counters
  * Request backpressure handling returns 503 instead of blocking
  * Maintenance task reordering to reduce SQLite contention
  * New composite index for improved retention query performance

* **Documentation**
  * Deployment guides for manual rollout phases
  * Example configurations for OpenTelemetry clients

<!-- end of auto-generated comment: release notes by coderabbit.ai -->