### PR TITLE
feat: 11 new syslog MCP actions for log intelligence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`tail` placeholder index**: Severity-IN block in `tail_logs` now advances the placeholder index, preventing latent `?N` collisions if future filters are appended after it.
 - **`anomalies` ranking**: Hosts active in the recent window with no baseline (`recent_count > 0 && baseline_count == 0`) now sort to the top of the response, matching the docstring's promise to flag new-but-active hosts.
 - **`source_ips` dispatch**: `tool_list_source_ips` now accepts `(state, args)` for parity with the other action handlers, so future filters won't silently swallow client args.
+- **App response boundary**: New action responses now use app-layer DTOs instead of exporting database model types directly.
+- **Action documentation**: Added the new `search`, `tail`, and `errors` parameters to MCP docs and expanded the syslog skill reference for every new action.
+- **Test comments/helpers**: Clarified smoke/live script action inventories and removed duplicated source-IP test fixture setup.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-07
+
+### Added
+
+- **Eleven new `syslog` actions** for log intelligence beyond raw search/tail:
+  - `apps` — distinct application names with log/host counts and first/last seen (mirror of `hosts` for the `app_name` dimension).
+  - `source_ips` — distinct source identifiers with hostname breakdown; supports spoof detection on hostname-spoofable formats (e.g. UniFi CEF).
+  - `timeline` — bucketed counts (`minute`/`hour`/`day`) over a time range, optionally split by `hostname` / `severity` / `app_name`.
+  - `patterns` — cluster near-duplicate messages by template (numbers, IPv4, UUIDs, long hex strings normalised to placeholders); returns top templates with counts, sample, and host distribution.
+  - `context` — surrounding logs around a single point of interest by `log_id` or `hostname`+`timestamp`.
+  - `get` — fetch one log by `id`, including the unparsed `raw` syslog frame.
+  - `ingest_rate` — recent throughput (last 1m / 5m / 15m using `received_at`) plus current `write_blocked` flag and optional per-host buckets.
+  - `silent_hosts` — hosts whose `last_seen` is older than `silent_minutes` ago, with their typical inter-arrival interval.
+  - `clock_skew` — per-host distribution of `received_at - timestamp` (seconds), sorted by absolute mean.
+  - `anomalies` — per-host comparison of recent volume/error count against a baseline window; returns ratio and Poisson-style z-score.
+  - `compare` — side-by-side summary of two time ranges (volume, error count, severity mix, top hosts/apps) with deltas.
+- **New filters on existing actions**:
+  - `search` accepts `facility` and `process_id`.
+  - `tail` accepts `severity_min` (returns entries at or above the threshold).
+  - `errors` accepts `group_by=app_name` for hostname x app_name x severity grouping.
+- **`logs.raw` column is now exposed** via the new `get` action.
+
+### Changed
+
+- `tail_logs` query and `get_error_summary` query gained additional parameters (`severity_in`, `group_by_app`); internal callers updated.
+- Help text (`syslog help`) expanded to cover all 19 actions and updated parameters.
+
 ## [0.14.2] - 2026-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-05-07
+
+### Fixed
+
+- **Timestamp normalization**: All time-window query bounds (`correlate`, `context`, `compare`, `anomalies`) and stored `timestamp` from the syslog and Docker parsers now produce the canonical `Z`-suffixed RFC3339 form (`rfc3339_z` helper, lifted to `app::time`). Previously, mixed `+00:00`/`Z` forms could silently drop boundary rows under SQLite TEXT comparison.
+- **`compare` panic**: Replaced four `.expect("required field")` calls on parsed user input with `parse_required_timestamp`, returning a clean `InvalidInput` error instead of panicking the request thread.
+- **`tail` placeholder index**: Severity-IN block in `tail_logs` now advances the placeholder index, preventing latent `?N` collisions if future filters are appended after it.
+- **`anomalies` ranking**: Hosts active in the recent window with no baseline (`recent_count > 0 && baseline_count == 0`) now sort to the top of the response, matching the docstring's promise to flag new-but-active hosts.
+- **`source_ips` dispatch**: `tool_list_source_ips` now accepts `(state, args)` for parity with the other action handlers, so future filters won't silently swallow client args.
+
+### Changed
+
+- **`normalize_template`** (`db::patterns` helper) is no longer re-exported at the crate root; it is `pub(super)` and only reachable from inside the `analytics` module.
+- **Test assertion tightened**: `context` neighbor bounds are now strict (`<` / `>`) for the id-anchored case, matching the documented contract.
+
 ## [0.15.0] - 2026-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -41,6 +41,11 @@ just test-live
 
 The smoke test (`scripts/smoke-test.sh`) exercises all `syslog` actions via mcporter.
 
+Action registry covered by live/script references: `search`, `tail`, `errors`,
+`hosts`, `correlate`, `stats`, `status`, `apps`, `source_ips`, `timeline`,
+`patterns`, `context`, `get`, `ingest_rate`, `silent_hosts`, `clock_skew`,
+`anomalies`, `compare`, `help`.
+
 ### mcporter-based testing
 
 ```bash
@@ -53,6 +58,17 @@ mcporter call --config config/mcporter.json syslog.syslog action=status
 mcporter call --config config/mcporter.json syslog.syslog action=tail n=10
 mcporter call --config config/mcporter.json syslog.syslog action=search query=error limit=5
 mcporter call --config config/mcporter.json syslog.syslog action=hosts
+mcporter call --config config/mcporter.json syslog.syslog action=apps
+mcporter call --config config/mcporter.json syslog.syslog action=source_ips
+mcporter call --config config/mcporter.json syslog.syslog action=timeline
+mcporter call --config config/mcporter.json syslog.syslog action=patterns
+mcporter call --config config/mcporter.json syslog.syslog action=context hostname=host timestamp=2026-01-01T00:00:00Z
+mcporter call --config config/mcporter.json syslog.syslog action=get id=1
+mcporter call --config config/mcporter.json syslog.syslog action=ingest_rate
+mcporter call --config config/mcporter.json syslog.syslog action=silent_hosts
+mcporter call --config config/mcporter.json syslog.syslog action=clock_skew
+mcporter call --config config/mcporter.json syslog.syslog action=anomalies
+mcporter call --config config/mcporter.json syslog.syslog action=compare a_from=2026-01-01T00:00:00Z a_to=2026-01-01T01:00:00Z b_from=2026-01-01T01:00:00Z b_to=2026-01-01T02:00:00Z
 ```
 
 ### curl-based testing

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -14,6 +14,17 @@ syslog-mcp exposes one read-only MCP tool named `syslog`. The required
 | `correlate` | Cross-host event correlation in a time window |
 | `stats` | Database statistics and storage health |
 | `status` | Lightweight runtime and DB health |
+| `apps` | Distinct application names with log and host counts |
+| `source_ips` | Distinct source identifiers with hostname breakdown |
+| `timeline` | Bucketed counts over time |
+| `patterns` | Near-duplicate message template clusters |
+| `context` | Surrounding logs around a log id or timestamp |
+| `get` | One log entry by id, including raw frame |
+| `ingest_rate` | Recent ingest throughput and write-block state |
+| `silent_hosts` | Hosts whose last_seen is older than a threshold |
+| `clock_skew` | Per-host received_at minus timestamp distribution |
+| `anomalies` | Recent vs baseline volume/error comparison |
+| `compare` | Side-by-side comparison of two time ranges |
 | `help` | Markdown reference for all actions |
 
 ## syslog search

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -33,7 +33,7 @@ Full-text search across all syslog messages. Uses SQLite FTS5 with porter stemmi
 
 Required argument: `action = "search"`
 
-Optional arguments: `query`, `hostname`, `source_ip`, `severity`, `app_name`, `from`, `to`, `limit`.
+Optional arguments: `query`, `hostname`, `source_ip`, `severity`, `app_name`, `facility`, `process_id`, `from`, `to`, `limit`.
 
 ## syslog tail
 
@@ -41,7 +41,7 @@ Get the N most recent log entries. Equivalent to `tail -f` across all hosts.
 
 Required argument: `action = "tail"`
 
-Optional arguments: `hostname`, `source_ip`, `app_name`, `n`.
+Optional arguments: `hostname`, `source_ip`, `app_name`, `severity_min`, `n`.
 
 ## syslog errors
 
@@ -49,7 +49,9 @@ Get a summary of errors and warnings across all hosts in a time window, grouped 
 
 Required argument: `action = "errors"`
 
-Optional arguments: `from`, `to`.
+Optional arguments: `from`, `to`, `group_by`.
+
+`group_by` currently supports `app_name` for hostname + app + severity grouping.
 
 ## syslog hosts
 

--- a/plugins/skills/syslog/SKILL.md
+++ b/plugins/skills/syslog/SKILL.md
@@ -20,6 +20,17 @@ A single MCP tool, `mcp__syslog__syslog`, dispatches on a required `action` argu
 | `correlate` | Cross-host event correlation in a time window |
 | `stats` | Database statistics |
 | `status` | Lightweight runtime and DB health |
+| `apps` | Distinct app names with log and host counts |
+| `source_ips` | Source identifiers with hostname breakdown |
+| `timeline` | Bucketed counts over time |
+| `patterns` | Near-duplicate message template clusters |
+| `context` | Surrounding logs around an event |
+| `get` | One log by id, including raw frame |
+| `ingest_rate` | Recent ingest throughput |
+| `silent_hosts` | Hosts quiet beyond a threshold |
+| `clock_skew` | Per-host clock skew distribution |
+| `anomalies` | Recent vs baseline volume/error comparison |
+| `compare` | Compare two time ranges |
 | `help` | Canonical in-tree action reference (use as ground truth if this doc drifts) |
 
 **Always prefer the MCP tool**. Fall back to HTTP only when MCP is unavailable.

--- a/plugins/skills/syslog/SKILL.md
+++ b/plugins/skills/syslog/SKILL.md
@@ -52,6 +52,8 @@ FTS5 search across all syslog messages with porter stemming.
 | `source_ip` | string | Exact source identifier — `IP:port` for syslog, `docker://host/container/stream` for Docker ingest. The only network-verified identity (hostname can be spoofed in CEF/UniFi messages). |
 | `severity` | string | One of: emerg, alert, crit, err, warning, notice, info, debug |
 | `app_name` | string | Filter by application (e.g. sshd, dockerd, kernel) |
+| `facility` | string | Filter by syslog facility |
+| `process_id` | string | Filter by process id from the syslog frame |
 | `from` | string | Start time (ISO 8601, e.g. `2025-01-15T00:00:00Z`) |
 | `to` | string | End time (ISO 8601) |
 | `limit` | integer | Max results (default 100, max 1000) |
@@ -63,6 +65,7 @@ mcp__syslog__syslog(action="search", query="kernel panic")
 mcp__syslog__syslog(action="search", query="OOM AND killer", limit=50)
 mcp__syslog__syslog(action="search", query='"authentication failure"')
 mcp__syslog__syslog(action="search", query="error", hostname="unraid", severity="err")
+mcp__syslog__syslog(action="search", facility="auth", process_id="1234", limit=20)
 mcp__syslog__syslog(action="search", query="connection refused",
                     from="2025-01-15T00:00:00Z", to="2025-01-15T23:59:59Z")
 mcp__syslog__syslog(action="search", query="docker*")
@@ -86,12 +89,14 @@ Most recent N log entries across all hosts, like `tail -f` but multi-host.
 | `hostname` | string | Filter to a specific host |
 | `source_ip` | string | Filter by exact source identifier (see `search`) |
 | `app_name` | string | Filter to a specific application |
+| `severity_min` | string | Minimum severity to return; `warning` returns warning and worse |
 | `n` | integer | Number of entries (default 50, max 500) |
 
 ```
 mcp__syslog__syslog(action="tail", n=20)
 mcp__syslog__syslog(action="tail", hostname="unraid", n=50)
 mcp__syslog__syslog(action="tail", app_name="dockerd", n=30)
+mcp__syslog__syslog(action="tail", severity_min="warning", n=50)
 ```
 
 ---
@@ -104,10 +109,12 @@ Errors and warnings grouped by hostname and severity with counts. Best for quick
 |-------|------|-------------|
 | `from` | string | Start time (ISO 8601). Defaults to all time. |
 | `to` | string | End time (ISO 8601). Defaults to now. |
+| `group_by` | string | Optional secondary grouping. Currently supports `app_name`. |
 
 ```
 mcp__syslog__syslog(action="errors")
 mcp__syslog__syslog(action="errors", from="2025-01-15T13:00:00Z", to="2025-01-15T14:00:00Z")
+mcp__syslog__syslog(action="errors", group_by="app_name")
 ```
 
 **Response shape:**
@@ -207,6 +214,185 @@ mcp__syslog__syslog(action="status")
 ```
 
 **Response fields:** `status`, `db_ok`, `runtime_observability`, and `otlp`.
+
+---
+
+### `action="apps"` — Applications seen in logs
+
+Distinct non-empty `app_name` values with log count, host count, and first/last received times.
+
+| param | type | description |
+|-------|------|-------------|
+| `hostname` | string | Optional host filter |
+
+```
+mcp__syslog__syslog(action="apps")
+mcp__syslog__syslog(action="apps", hostname="unraid")
+```
+
+---
+
+### `action="source_ips"` — Source identity breakdown
+
+Network sender identifiers with counts and the top hostnames each source claimed.
+
+```
+mcp__syslog__syslog(action="source_ips")
+```
+
+Use `source_ip` as the trusted sender identity when a syslog hostname can be spoofed.
+
+---
+
+### `action="timeline"` — Bucketed log counts
+
+Counts logs into minute, hour, or day buckets, optionally grouped by host, severity, or app.
+
+| param | type | description |
+|-------|------|-------------|
+| `bucket` | string | `minute`, `hour`, or `day` (default `hour`) |
+| `group_by` | string | Optional: `hostname`, `severity`, or `app_name` |
+| `from` | string | Start time (ISO 8601) |
+| `to` | string | End time (ISO 8601) |
+| `hostname` | string | Exact host filter |
+| `app_name` | string | Exact app filter |
+| `severity_min` | string | Minimum severity to include |
+
+```
+mcp__syslog__syslog(action="timeline", bucket="hour", group_by="severity")
+mcp__syslog__syslog(action="timeline", bucket="minute", severity_min="warning")
+```
+
+---
+
+### `action="patterns"` — Message template clusters
+
+Clusters near-duplicate messages after normalizing variable values such as numbers, IPs, UUIDs, and long hex strings.
+
+| param | type | description |
+|-------|------|-------------|
+| `from` | string | Start time (ISO 8601) |
+| `to` | string | End time (ISO 8601) |
+| `hostname` | string | Exact host filter |
+| `app_name` | string | Exact app filter |
+| `severity_min` | string | Minimum severity to include |
+| `scan_limit` | integer | Rows scanned before clustering (default 10000, max 50000) |
+| `top_n` | integer | Max returned templates (default 20, max 200) |
+
+```
+mcp__syslog__syslog(action="patterns", severity_min="warning", top_n=10)
+```
+
+---
+
+### `action="context"` — Surrounding logs
+
+Returns logs before and after a reference event. Anchor by `log_id` when available, or by `hostname` plus `timestamp`.
+
+| param | type | description |
+|-------|------|-------------|
+| `log_id` | integer | Stable row id anchor |
+| `hostname` | string | Required with `timestamp` when `log_id` is omitted |
+| `timestamp` | string | Required with `hostname` when `log_id` is omitted |
+| `before` | integer | Entries before the reference (default 10, max 500) |
+| `after` | integer | Entries after the reference (default 10, max 500) |
+
+```
+mcp__syslog__syslog(action="context", log_id=123, before=20, after=20)
+```
+
+---
+
+### `action="get"` — Fetch one log by id
+
+Returns a single log entry including its raw frame.
+
+| param | type | description |
+|-------|------|-------------|
+| `id` | integer | Required log row id |
+
+```
+mcp__syslog__syslog(action="get", id=123)
+```
+
+---
+
+### `action="ingest_rate"` — Recent ingest throughput
+
+Returns last 1m/5m/15m ingest counts and per-second rates, plus write-block state.
+
+| param | type | description |
+|-------|------|-------------|
+| `by_host` | boolean | Include per-host bucket counts |
+
+```
+mcp__syslog__syslog(action="ingest_rate")
+mcp__syslog__syslog(action="ingest_rate", by_host=true)
+```
+
+---
+
+### `action="silent_hosts"` — Quiet hosts
+
+Lists hosts whose `last_seen` is older than the configured threshold.
+
+| param | type | description |
+|-------|------|-------------|
+| `silent_minutes` | integer | Silence threshold (default 30, max 10080) |
+
+```
+mcp__syslog__syslog(action="silent_hosts", silent_minutes=60)
+```
+
+---
+
+### `action="clock_skew"` — Sender clock skew
+
+Compares each host's syslog timestamp with server receive time.
+
+| param | type | description |
+|-------|------|-------------|
+| `since` | string | Start time for samples. Defaults to the last 24 hours. |
+
+```
+mcp__syslog__syslog(action="clock_skew")
+```
+
+---
+
+### `action="anomalies"` — Recent vs baseline host activity
+
+Compares recent per-host volume and error counts against a preceding baseline window. Hosts with recent logs and zero baseline sort to the top as new active hosts.
+
+| param | type | description |
+|-------|------|-------------|
+| `recent_minutes` | integer | Recent window (default 15, max 1440) |
+| `baseline_minutes` | integer | Baseline window before recent window (default 360, max 10080) |
+
+```
+mcp__syslog__syslog(action="anomalies", recent_minutes=30, baseline_minutes=720)
+```
+
+---
+
+### `action="compare"` — Compare two ranges
+
+Compares total logs, total errors, severity distribution, top hosts, and top apps across two time ranges.
+
+| param | type | description |
+|-------|------|-------------|
+| `a_from` | string | Required start of range A |
+| `a_to` | string | Required end of range A |
+| `b_from` | string | Required start of range B |
+| `b_to` | string | Required end of range B |
+
+```
+mcp__syslog__syslog(action="compare",
+                    a_from="2025-01-15T00:00:00Z",
+                    a_to="2025-01-15T12:00:00Z",
+                    b_from="2025-01-15T12:00:00Z",
+                    b_to="2025-01-16T00:00:00Z")
+```
 
 ---
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -9,7 +9,7 @@
 #
 # Requirements: mcporter, nc, curl, python3
 #
-# Action coverage reference:
+# Action inventory reference (not every action is exercised by this smoke test):
 #   mcp_call search, mcp_call tail, mcp_call errors, mcp_call hosts,
 #   mcp_call correlate, mcp_call stats, mcp_call status, mcp_call apps,
 #   mcp_call source_ips, mcp_call timeline, mcp_call patterns, mcp_call context,

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -8,6 +8,13 @@
 #   bash scripts/smoke-test.sh --skip-seed   # if data already exists
 #
 # Requirements: mcporter, nc, curl, python3
+#
+# Action coverage reference:
+#   mcp_call search, mcp_call tail, mcp_call errors, mcp_call hosts,
+#   mcp_call correlate, mcp_call stats, mcp_call status, mcp_call apps,
+#   mcp_call source_ips, mcp_call timeline, mcp_call patterns, mcp_call context,
+#   mcp_call get, mcp_call ingest_rate, mcp_call silent_hosts,
+#   mcp_call clock_skew, mcp_call anomalies, mcp_call compare, mcp_call help
 
 set -euo pipefail
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -81,6 +81,8 @@ struct SearchQuery {
     source_ip: Option<String>,
     severity: Option<String>,
     app_name: Option<String>,
+    facility: Option<String>,
+    process_id: Option<String>,
     from: Option<String>,
     to: Option<String>,
     limit: Option<u32>,
@@ -99,6 +101,8 @@ async fn search(
                 source_ip: query.source_ip,
                 severity: query.severity,
                 app_name: query.app_name,
+                facility: query.facility,
+                process_id: query.process_id,
                 from: query.from,
                 to: query.to,
                 limit: query.limit,
@@ -112,6 +116,7 @@ struct TailQuery {
     hostname: Option<String>,
     source_ip: Option<String>,
     app_name: Option<String>,
+    severity_min: Option<String>,
     n: Option<u32>,
 }
 
@@ -123,6 +128,7 @@ async fn tail(State(state): State<ApiState>, Query(query): Query<TailQuery>) -> 
                 hostname: query.hostname,
                 source_ip: query.source_ip,
                 app_name: query.app_name,
+                severity_min: query.severity_min,
                 n: query.n,
             })
             .await,
@@ -133,6 +139,7 @@ async fn tail(State(state): State<ApiState>, Query(query): Query<TailQuery>) -> 
 struct ErrorQuery {
     from: Option<String>,
     to: Option<String>,
+    group_by: Option<String>,
 }
 
 async fn errors(
@@ -145,6 +152,7 @@ async fn errors(
             .get_errors(GetErrorsRequest {
                 from: query.from,
                 to: query.to,
+                group_by: query.group_by,
             })
             .await,
     )

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,9 +7,14 @@ mod time;
 pub use correlate::severity_at_or_above;
 pub use error::{ServiceError, ServiceResult};
 pub use models::{
-    CorrelateEventsRequest, CorrelateEventsResponse, CorrelatedHost, DbStats, ErrorSummaryEntry,
-    GetErrorsRequest, GetErrorsResponse, HostEntry, ListHostsResponse, LogEntry, SearchLogsRequest,
-    SearchLogsResponse, TailLogsRequest,
+    AnomaliesRequest, AnomaliesResponse, ClockSkewRequest, ClockSkewResponse, CompareRequest,
+    CompareResponse, ContextRequest, ContextResponse, CorrelateEventsRequest,
+    CorrelateEventsResponse, CorrelatedHost, DbStats, ErrorSummaryEntry, GetErrorsRequest,
+    GetErrorsResponse, GetLogRequest, GetLogResponse, HostEntry, IngestRateRequest,
+    IngestRateResponse, ListAppsRequest, ListAppsResponse, ListHostsResponse,
+    ListSourceIpsResponse, LogEntry, PatternsRequest, PatternsResponse, SearchLogsRequest,
+    SearchLogsResponse, SilentHostsRequest, SilentHostsResponse, TailLogsRequest, TimelineRequest,
+    TimelineResponse,
 };
 pub use service::SyslogService;
 pub use time::parse_optional_timestamp;

--- a/src/app/mod_tests.rs
+++ b/src/app/mod_tests.rs
@@ -17,7 +17,7 @@ fn module_reexports_request_types_and_helpers() {
         parse_optional_timestamp(Some("2026-01-01T01:00:00+01:00"), "from")
             .unwrap()
             .as_deref(),
-        Some("2026-01-01T00:00:00+00:00")
+        Some("2026-01-01T00:00:00.000Z")
     );
     assert_eq!(
         severity_at_or_above("err").unwrap(),

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -40,6 +40,8 @@ pub struct SearchLogsRequest {
     pub source_ip: Option<String>,
     pub severity: Option<String>,
     pub app_name: Option<String>,
+    pub facility: Option<String>,
+    pub process_id: Option<String>,
     pub from: Option<String>,
     pub to: Option<String>,
     pub limit: Option<u32>,
@@ -56,12 +58,17 @@ pub struct TailLogsRequest {
     pub hostname: Option<String>,
     pub source_ip: Option<String>,
     pub app_name: Option<String>,
+    /// Minimum severity to return (e.g. `warning` returns warning + worse).
+    pub severity_min: Option<String>,
     pub n: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorSummaryEntry {
     pub hostname: String,
+    /// Optional secondary grouping key (e.g. app_name) when `group_by` is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_name: Option<String>,
     pub severity: String,
     pub count: i64,
 }
@@ -70,16 +77,19 @@ impl From<db::ErrorSummaryEntry> for ErrorSummaryEntry {
     fn from(value: db::ErrorSummaryEntry) -> Self {
         Self {
             hostname: value.hostname,
+            app_name: value.app_name,
             severity: value.severity,
             count: value.count,
         }
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GetErrorsRequest {
     pub from: Option<String>,
     pub to: Option<String>,
+    /// Secondary grouping key. Currently supports `app_name`.
+    pub group_by: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -173,6 +183,161 @@ impl From<db::DbStats> for DbStats {
             phantom_fts_rows: value.phantom_fts_rows,
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// New analytics actions
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ListAppsRequest {
+    pub hostname: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListAppsResponse {
+    pub apps: Vec<db::AppEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListSourceIpsResponse {
+    pub source_ips: Vec<db::SourceIpEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TimelineRequest {
+    pub bucket: Option<String>,
+    pub group_by: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub hostname: Option<String>,
+    pub app_name: Option<String>,
+    pub severity_min: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelineResponse {
+    pub bucket: String,
+    pub group_by: Option<String>,
+    pub points: Vec<db::TimelinePoint>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PatternsRequest {
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub hostname: Option<String>,
+    pub app_name: Option<String>,
+    pub severity_min: Option<String>,
+    pub scan_limit: Option<u32>,
+    pub top_n: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatternsResponse {
+    pub patterns: Vec<db::PatternEntry>,
+    pub scanned: i64,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContextRequest {
+    pub log_id: Option<i64>,
+    pub hostname: Option<String>,
+    pub timestamp: Option<String>,
+    pub before: Option<u32>,
+    pub after: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextResponse {
+    pub reference: LogEntry,
+    pub before: Vec<LogEntry>,
+    pub after: Vec<LogEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GetLogRequest {
+    pub id: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetLogResponse {
+    pub log: db::LogEntryWithRaw,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IngestRateRequest {
+    pub by_host: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IngestRateResponse {
+    pub now: String,
+    pub buckets: db::IngestRateBuckets,
+    pub write_blocked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub by_host: Option<Vec<db::IngestRatePerHost>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SilentHostsRequest {
+    /// Hosts whose `last_seen` is older than `silent_minutes` ago (default 30).
+    pub silent_minutes: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SilentHostsResponse {
+    pub silent_minutes: u32,
+    pub cutoff: String,
+    pub now: String,
+    pub hosts: Vec<db::SilentHostEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClockSkewRequest {
+    pub since: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClockSkewResponse {
+    pub since: String,
+    pub hosts: Vec<db::ClockSkewEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AnomaliesRequest {
+    /// Recent window in minutes (default 15, max 1440).
+    pub recent_minutes: Option<u32>,
+    /// Baseline window in minutes preceding the recent window (default 360, max 10080).
+    pub baseline_minutes: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnomaliesResponse {
+    pub recent_from: String,
+    pub recent_to: String,
+    pub baseline_from: String,
+    pub baseline_to: String,
+    pub recent_minutes: u32,
+    pub baseline_minutes: u32,
+    pub hosts: Vec<db::AnomalyEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CompareRequest {
+    pub a_from: String,
+    pub a_to: String,
+    pub b_from: String,
+    pub b_to: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompareResponse {
+    pub a: db::RangeSummary,
+    pub b: db::RangeSummary,
+    pub delta_total_logs: i64,
+    pub delta_total_errors: i64,
 }
 
 #[cfg(test)]

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -196,12 +196,71 @@ pub struct ListAppsRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListAppsResponse {
-    pub apps: Vec<db::AppEntry>,
+    pub apps: Vec<AppEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppEntry {
+    pub app_name: String,
+    pub log_count: i64,
+    pub host_count: i64,
+    pub first_seen: String,
+    pub last_seen: String,
+}
+
+impl From<db::AppEntry> for AppEntry {
+    fn from(value: db::AppEntry) -> Self {
+        Self {
+            app_name: value.app_name,
+            log_count: value.log_count,
+            host_count: value.host_count,
+            first_seen: value.first_seen,
+            last_seen: value.last_seen,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListSourceIpsResponse {
-    pub source_ips: Vec<db::SourceIpEntry>,
+    pub source_ips: Vec<SourceIpEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceIpHostBreakdown {
+    pub hostname: String,
+    pub log_count: i64,
+}
+
+impl From<db::SourceIpHostBreakdown> for SourceIpHostBreakdown {
+    fn from(value: db::SourceIpHostBreakdown) -> Self {
+        Self {
+            hostname: value.hostname,
+            log_count: value.log_count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceIpEntry {
+    pub source_ip: String,
+    pub log_count: i64,
+    pub host_count: i64,
+    pub first_seen: String,
+    pub last_seen: String,
+    pub hostnames: Vec<SourceIpHostBreakdown>,
+}
+
+impl From<db::SourceIpEntry> for SourceIpEntry {
+    fn from(value: db::SourceIpEntry) -> Self {
+        Self {
+            source_ip: value.source_ip,
+            log_count: value.log_count,
+            host_count: value.host_count,
+            first_seen: value.first_seen,
+            last_seen: value.last_seen,
+            hostnames: value.hostnames.into_iter().map(Into::into).collect(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -219,7 +278,25 @@ pub struct TimelineRequest {
 pub struct TimelineResponse {
     pub bucket: String,
     pub group_by: Option<String>,
-    pub points: Vec<db::TimelinePoint>,
+    pub points: Vec<TimelinePoint>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimelinePoint {
+    pub bucket: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    pub count: i64,
+}
+
+impl From<db::TimelinePoint> for TimelinePoint {
+    fn from(value: db::TimelinePoint) -> Self {
+        Self {
+            bucket: value.bucket,
+            group: value.group,
+            count: value.count,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -235,9 +312,34 @@ pub struct PatternsRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PatternsResponse {
-    pub patterns: Vec<db::PatternEntry>,
+    pub patterns: Vec<PatternEntry>,
     pub scanned: i64,
     pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatternEntry {
+    pub template: String,
+    pub count: i64,
+    pub host_count: i64,
+    pub sample: String,
+    pub first_seen: String,
+    pub last_seen: String,
+    pub hostnames: Vec<String>,
+}
+
+impl From<db::PatternEntry> for PatternEntry {
+    fn from(value: db::PatternEntry) -> Self {
+        Self {
+            template: value.template,
+            count: value.count,
+            host_count: value.host_count,
+            sample: value.sample,
+            first_seen: value.first_seen,
+            last_seen: value.last_seen,
+            hostnames: value.hostnames,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -256,14 +358,47 @@ pub struct ContextResponse {
     pub after: Vec<LogEntry>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetLogRequest {
     pub id: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetLogResponse {
-    pub log: db::LogEntryWithRaw,
+    pub log: LogEntryWithRaw,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogEntryWithRaw {
+    pub id: i64,
+    pub timestamp: String,
+    pub hostname: String,
+    pub facility: Option<String>,
+    pub severity: String,
+    pub app_name: Option<String>,
+    pub process_id: Option<String>,
+    pub message: String,
+    pub raw: String,
+    pub received_at: String,
+    pub source_ip: String,
+}
+
+impl From<db::LogEntryWithRaw> for LogEntryWithRaw {
+    fn from(value: db::LogEntryWithRaw) -> Self {
+        Self {
+            id: value.id,
+            timestamp: value.timestamp,
+            hostname: value.hostname,
+            facility: value.facility,
+            severity: value.severity,
+            app_name: value.app_name,
+            process_id: value.process_id,
+            message: value.message,
+            raw: value.raw,
+            received_at: value.received_at,
+            source_ip: value.source_ip,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -274,10 +409,52 @@ pub struct IngestRateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IngestRateResponse {
     pub now: String,
-    pub buckets: db::IngestRateBuckets,
+    pub buckets: IngestRateBuckets,
     pub write_blocked: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub by_host: Option<Vec<db::IngestRatePerHost>>,
+    pub by_host: Option<Vec<IngestRatePerHost>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IngestRateBuckets {
+    pub last_1m: i64,
+    pub last_5m: i64,
+    pub last_15m: i64,
+    pub per_sec_1m: f64,
+    pub per_sec_5m: f64,
+    pub per_sec_15m: f64,
+}
+
+impl From<db::IngestRateBuckets> for IngestRateBuckets {
+    fn from(value: db::IngestRateBuckets) -> Self {
+        Self {
+            last_1m: value.last_1m,
+            last_5m: value.last_5m,
+            last_15m: value.last_15m,
+            per_sec_1m: value.per_sec_1m,
+            per_sec_5m: value.per_sec_5m,
+            per_sec_15m: value.per_sec_15m,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IngestRatePerHost {
+    pub hostname: String,
+    pub last_1m: i64,
+    pub last_5m: i64,
+    pub last_15m: i64,
+}
+
+impl From<db::IngestRatePerHost> for IngestRatePerHost {
+    fn from(value: db::IngestRatePerHost) -> Self {
+        Self {
+            hostname: value.hostname,
+            last_1m: value.last_1m,
+            last_5m: value.last_5m,
+            last_15m: value.last_15m,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -291,7 +468,30 @@ pub struct SilentHostsResponse {
     pub silent_minutes: u32,
     pub cutoff: String,
     pub now: String,
-    pub hosts: Vec<db::SilentHostEntry>,
+    pub hosts: Vec<SilentHostEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SilentHostEntry {
+    pub hostname: String,
+    pub first_seen: String,
+    pub last_seen: String,
+    pub log_count: i64,
+    pub typical_interval_secs: Option<f64>,
+    pub silent_for_secs: i64,
+}
+
+impl From<db::SilentHostEntry> for SilentHostEntry {
+    fn from(value: db::SilentHostEntry) -> Self {
+        Self {
+            hostname: value.hostname,
+            first_seen: value.first_seen,
+            last_seen: value.last_seen,
+            log_count: value.log_count,
+            typical_interval_secs: value.typical_interval_secs,
+            silent_for_secs: value.silent_for_secs,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -302,7 +502,28 @@ pub struct ClockSkewRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClockSkewResponse {
     pub since: String,
-    pub hosts: Vec<db::ClockSkewEntry>,
+    pub hosts: Vec<ClockSkewEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClockSkewEntry {
+    pub hostname: String,
+    pub samples: i64,
+    pub avg_skew_secs: f64,
+    pub min_skew_secs: f64,
+    pub max_skew_secs: f64,
+}
+
+impl From<db::ClockSkewEntry> for ClockSkewEntry {
+    fn from(value: db::ClockSkewEntry) -> Self {
+        Self {
+            hostname: value.hostname,
+            samples: value.samples,
+            avg_skew_secs: value.avg_skew_secs,
+            min_skew_secs: value.min_skew_secs,
+            max_skew_secs: value.max_skew_secs,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -321,10 +542,39 @@ pub struct AnomaliesResponse {
     pub baseline_to: String,
     pub recent_minutes: u32,
     pub baseline_minutes: u32,
-    pub hosts: Vec<db::AnomalyEntry>,
+    pub hosts: Vec<AnomalyEntry>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnomalyEntry {
+    pub hostname: String,
+    pub recent_count: i64,
+    pub baseline_count: i64,
+    pub recent_per_min: f64,
+    pub baseline_per_min: f64,
+    pub ratio: Option<f64>,
+    pub z_score: Option<f64>,
+    pub recent_errors: i64,
+    pub baseline_errors: i64,
+}
+
+impl From<db::AnomalyEntry> for AnomalyEntry {
+    fn from(value: db::AnomalyEntry) -> Self {
+        Self {
+            hostname: value.hostname,
+            recent_count: value.recent_count,
+            baseline_count: value.baseline_count,
+            recent_per_min: value.recent_per_min,
+            baseline_per_min: value.baseline_per_min,
+            ratio: value.ratio,
+            z_score: value.z_score,
+            recent_errors: value.recent_errors,
+            baseline_errors: value.baseline_errors,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompareRequest {
     pub a_from: String,
     pub a_to: String,
@@ -334,10 +584,35 @@ pub struct CompareRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompareResponse {
-    pub a: db::RangeSummary,
-    pub b: db::RangeSummary,
+    pub a: RangeSummary,
+    pub b: RangeSummary,
     pub delta_total_logs: i64,
     pub delta_total_errors: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RangeSummary {
+    pub from: String,
+    pub to: String,
+    pub total_logs: i64,
+    pub total_errors: i64,
+    pub by_severity: Vec<(String, i64)>,
+    pub top_hosts: Vec<(String, i64)>,
+    pub top_apps: Vec<(String, i64)>,
+}
+
+impl From<db::RangeSummary> for RangeSummary {
+    fn from(value: db::RangeSummary) -> Self {
+        Self {
+            from: value.from,
+            to: value.to,
+            total_logs: value.total_logs,
+            total_errors: value.total_errors,
+            by_severity: value.by_severity,
+            top_hosts: value.top_hosts,
+            top_apps: value.top_apps,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/app/models_tests.rs
+++ b/src/app/models_tests.rs
@@ -26,6 +26,7 @@ fn log_entry_conversion_preserves_network_sender_identity() {
 fn summary_and_host_conversions_preserve_counts() {
     let summary = ErrorSummaryEntry::from(db::ErrorSummaryEntry {
         hostname: "host-a".into(),
+        app_name: None,
         severity: "err".into(),
         count: 7,
     });

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1,8 +1,17 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::TimeDelta;
+use chrono::{DateTime, SecondsFormat, TimeDelta, Utc};
 use tokio::sync::Semaphore;
+
+/// Format a UTC instant in the same shape SQLite uses for `received_at`
+/// (`%Y-%m-%dT%H:%M:%fZ`), so lexicographic TEXT comparisons line up at
+/// boundary instants. `to_rfc3339()` on its own produces `+00:00` form,
+/// which sorts strictly less than the stored `Z` form character-by-character
+/// and would silently drop equal-instant rows from boundary windows.
+fn rfc3339_z(dt: DateTime<Utc>) -> String {
+    dt.to_rfc3339_opts(SecondsFormat::Millis, true)
+}
 
 use super::correlate::{group_by_host, severity_at_or_above};
 use super::models::{
@@ -294,6 +303,21 @@ impl SyslogService {
     pub async fn context(&self, req: ContextRequest) -> ServiceResult<ContextResponse> {
         let before = req.before.unwrap_or(10).min(500);
         let after = req.after.unwrap_or(10).min(500);
+
+        // When the caller anchors via hostname+timestamp, parse and re-emit the
+        // timestamp through the same path used elsewhere in the service so
+        // `2026-01-01T00:00:00Z` and `2026-01-01T00:00:00+00:00` (and offset
+        // forms like `+02:00`) compare correctly against stored RFC3339 values
+        // — TEXT comparisons in SQLite would otherwise treat them as different.
+        let synthetic_timestamp = if req.log_id.is_none() {
+            match req.timestamp.as_deref() {
+                Some(raw) => Some(parse_required_timestamp(raw, "timestamp")?.to_rfc3339()),
+                None => None,
+            }
+        } else {
+            None
+        };
+
         let resolved = self
             .run_db(move |pool| -> anyhow::Result<_> {
                 let (reference, hostname, timestamp, id): (LogEntry, String, String, Option<i64>) =
@@ -319,7 +343,7 @@ impl SyslogService {
                                 "Either `log_id` or both `hostname` + `timestamp` are required"
                             )
                         })?;
-                        let timestamp = req.timestamp.clone().ok_or_else(|| {
+                        let timestamp = synthetic_timestamp.ok_or_else(|| {
                             anyhow::anyhow!(
                                 "Either `log_id` or both `hostname` + `timestamp` are required"
                             )
@@ -370,11 +394,11 @@ impl SyslogService {
     }
 
     pub async fn ingest_rate(&self, req: IngestRateRequest) -> ServiceResult<IngestRateResponse> {
-        let now_dt = chrono::Utc::now();
-        let now = now_dt.to_rfc3339();
-        let cut_1m = (now_dt - chrono::Duration::seconds(60)).to_rfc3339();
-        let cut_5m = (now_dt - chrono::Duration::seconds(300)).to_rfc3339();
-        let cut_15m = (now_dt - chrono::Duration::seconds(900)).to_rfc3339();
+        let now_dt = Utc::now();
+        let now = rfc3339_z(now_dt);
+        let cut_1m = rfc3339_z(now_dt - chrono::Duration::seconds(60));
+        let cut_5m = rfc3339_z(now_dt - chrono::Duration::seconds(300));
+        let cut_15m = rfc3339_z(now_dt - chrono::Duration::seconds(900));
         let want_by_host = req.by_host.unwrap_or(false);
 
         let storage = self.storage.clone();
@@ -410,10 +434,10 @@ impl SyslogService {
         req: SilentHostsRequest,
     ) -> ServiceResult<SilentHostsResponse> {
         let silent_minutes = req.silent_minutes.unwrap_or(30).min(60 * 24 * 7);
-        let now_dt = chrono::Utc::now();
-        let now = now_dt.to_rfc3339();
+        let now_dt = Utc::now();
+        let now = rfc3339_z(now_dt);
         let cutoff_dt = now_dt - chrono::Duration::minutes(i64::from(silent_minutes));
-        let cutoff = cutoff_dt.to_rfc3339();
+        let cutoff = rfc3339_z(cutoff_dt);
         let now_unix = now_dt.timestamp();
         let cutoff_q = cutoff.clone();
         let hosts = self
@@ -428,10 +452,11 @@ impl SyslogService {
     }
 
     pub async fn clock_skew(&self, req: ClockSkewRequest) -> ServiceResult<ClockSkewResponse> {
+        // Compared against `received_at`, which SQLite stores in `Z` form, so
+        // emit the canonical Z-form regardless of input shape.
         let since_str = match req.since {
-            Some(s) => parse_optional_timestamp(Some(&s), "since")?
-                .expect("parse_optional_timestamp returns Some when input is Some"),
-            None => (chrono::Utc::now() - chrono::Duration::hours(24)).to_rfc3339(),
+            Some(s) => rfc3339_z(parse_required_timestamp(&s, "since")?),
+            None => rfc3339_z(Utc::now() - chrono::Duration::hours(24)),
         };
         let q = since_str.clone();
         let hosts = self.run_db(move |pool| db::clock_skew(pool, &q)).await?;

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1,17 +1,8 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::{DateTime, SecondsFormat, TimeDelta, Utc};
+use chrono::{TimeDelta, Utc};
 use tokio::sync::Semaphore;
-
-/// Format a UTC instant in the same shape SQLite uses for `received_at`
-/// (`%Y-%m-%dT%H:%M:%fZ`), so lexicographic TEXT comparisons line up at
-/// boundary instants. `to_rfc3339()` on its own produces `+00:00` form,
-/// which sorts strictly less than the stored `Z` form character-by-character
-/// and would silently drop equal-instant rows from boundary windows.
-fn rfc3339_z(dt: DateTime<Utc>) -> String {
-    dt.to_rfc3339_opts(SecondsFormat::Millis, true)
-}
 
 use super::correlate::{group_by_host, severity_at_or_above};
 use super::models::{
@@ -23,7 +14,7 @@ use super::models::{
     SearchLogsRequest, SearchLogsResponse, SilentHostsRequest, SilentHostsResponse,
     TailLogsRequest, TimelineRequest, TimelineResponse,
 };
-use super::time::{parse_optional_timestamp, parse_required_timestamp};
+use super::time::{parse_optional_timestamp, parse_required_timestamp, rfc3339_z};
 use super::{ServiceError, ServiceResult};
 use crate::config::StorageConfig;
 use crate::db::{self, Bucket, ContextRef, DbPool, SearchParams, TimelineGroupBy};
@@ -168,8 +159,8 @@ impl SyslogService {
         let ref_dt = parse_required_timestamp(&req.reference_time, "reference_time")?;
         let delta = TimeDelta::try_minutes(i64::from(window))
             .ok_or_else(|| ServiceError::InvalidInput("duration overflow".into()))?;
-        let from = (ref_dt - delta).to_rfc3339();
-        let to = (ref_dt + delta).to_rfc3339();
+        let from = rfc3339_z(ref_dt - delta);
+        let to = rfc3339_z(ref_dt + delta);
         let limit = req.limit.unwrap_or(500).min(999);
         let params = SearchParams {
             query: req.query,
@@ -311,7 +302,7 @@ impl SyslogService {
         // — TEXT comparisons in SQLite would otherwise treat them as different.
         let synthetic_timestamp = if req.log_id.is_none() {
             match req.timestamp.as_deref() {
-                Some(raw) => Some(parse_required_timestamp(raw, "timestamp")?.to_rfc3339()),
+                Some(raw) => Some(rfc3339_z(parse_required_timestamp(raw, "timestamp")?)),
                 None => None,
             }
         } else {
@@ -470,12 +461,12 @@ impl SyslogService {
         let recent_minutes = req.recent_minutes.unwrap_or(15).clamp(1, 60 * 24);
         let baseline_minutes = req.baseline_minutes.unwrap_or(360).clamp(1, 60 * 24 * 7);
         let now_dt = chrono::Utc::now();
-        let recent_to = now_dt.to_rfc3339();
+        let recent_to = rfc3339_z(now_dt);
         let recent_from_dt = now_dt - chrono::Duration::minutes(i64::from(recent_minutes));
-        let recent_from = recent_from_dt.to_rfc3339();
+        let recent_from = rfc3339_z(recent_from_dt);
         let baseline_to = recent_from.clone();
         let baseline_from =
-            (recent_from_dt - chrono::Duration::minutes(i64::from(baseline_minutes))).to_rfc3339();
+            rfc3339_z(recent_from_dt - chrono::Duration::minutes(i64::from(baseline_minutes)));
 
         let rf = recent_from.clone();
         let rt = recent_to.clone();
@@ -498,12 +489,10 @@ impl SyslogService {
     }
 
     pub async fn compare(&self, req: CompareRequest) -> ServiceResult<CompareResponse> {
-        let a_from =
-            parse_optional_timestamp(Some(&req.a_from), "a_from")?.expect("required field");
-        let a_to = parse_optional_timestamp(Some(&req.a_to), "a_to")?.expect("required field");
-        let b_from =
-            parse_optional_timestamp(Some(&req.b_from), "b_from")?.expect("required field");
-        let b_to = parse_optional_timestamp(Some(&req.b_to), "b_to")?.expect("required field");
+        let a_from = rfc3339_z(parse_required_timestamp(&req.a_from, "a_from")?);
+        let a_to = rfc3339_z(parse_required_timestamp(&req.a_to, "a_to")?);
+        let b_from = rfc3339_z(parse_required_timestamp(&req.b_from, "b_from")?);
+        let b_to = rfc3339_z(parse_required_timestamp(&req.b_to, "b_to")?);
 
         let a_from_q = a_from.clone();
         let a_to_q = a_to.clone();

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -6,13 +6,18 @@ use tokio::sync::Semaphore;
 
 use super::correlate::{group_by_host, severity_at_or_above};
 use super::models::{
-    CorrelateEventsRequest, CorrelateEventsResponse, DbStats, GetErrorsRequest, GetErrorsResponse,
-    ListHostsResponse, LogEntry, SearchLogsRequest, SearchLogsResponse, TailLogsRequest,
+    AnomaliesRequest, AnomaliesResponse, ClockSkewRequest, ClockSkewResponse, CompareRequest,
+    CompareResponse, ContextRequest, ContextResponse, CorrelateEventsRequest,
+    CorrelateEventsResponse, DbStats, GetErrorsRequest, GetErrorsResponse, GetLogRequest,
+    GetLogResponse, IngestRateRequest, IngestRateResponse, ListAppsRequest, ListAppsResponse,
+    ListHostsResponse, ListSourceIpsResponse, LogEntry, PatternsRequest, PatternsResponse,
+    SearchLogsRequest, SearchLogsResponse, SilentHostsRequest, SilentHostsResponse,
+    TailLogsRequest, TimelineRequest, TimelineResponse,
 };
 use super::time::{parse_optional_timestamp, parse_required_timestamp};
 use super::{ServiceError, ServiceResult};
 use crate::config::StorageConfig;
-use crate::db::{self, DbPool, SearchParams};
+use crate::db::{self, Bucket, ContextRef, DbPool, SearchParams, TimelineGroupBy};
 
 const DB_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -75,6 +80,8 @@ impl SyslogService {
             severity,
             severity_in: None,
             app_name: req.app_name,
+            facility: req.facility,
+            process_id: req.process_id,
             from: parse_optional_timestamp(req.from.as_deref(), "from")?,
             to: parse_optional_timestamp(req.to.as_deref(), "to")?,
             limit: req.limit,
@@ -90,6 +97,10 @@ impl SyslogService {
     }
 
     pub async fn tail_logs(&self, req: TailLogsRequest) -> ServiceResult<SearchLogsResponse> {
+        let severity_in = match req.severity_min.as_deref() {
+            Some(min) => Some(severity_at_or_above(min)?),
+            None => None,
+        };
         let logs = self
             .run_db(move |pool| {
                 db::tail_logs(
@@ -97,6 +108,7 @@ impl SyslogService {
                     req.hostname.as_deref(),
                     req.source_ip.as_deref(),
                     req.app_name.as_deref(),
+                    severity_in.as_deref(),
                     req.n.unwrap_or(50),
                 )
             })
@@ -111,8 +123,19 @@ impl SyslogService {
     pub async fn get_errors(&self, req: GetErrorsRequest) -> ServiceResult<GetErrorsResponse> {
         let from = parse_optional_timestamp(req.from.as_deref(), "from")?;
         let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
+        let group_by_app = match req.group_by.as_deref() {
+            None => false,
+            Some("app_name") | Some("app") => true,
+            Some(other) => {
+                return Err(ServiceError::InvalidInput(format!(
+                    "Invalid group_by '{other}'. Supported: app_name"
+                )))
+            }
+        };
         let rows = self
-            .run_db(move |pool| db::get_error_summary(pool, from.as_deref(), to.as_deref()))
+            .run_db(move |pool| {
+                db::get_error_summary(pool, from.as_deref(), to.as_deref(), group_by_app)
+            })
             .await?;
         Ok(GetErrorsResponse {
             summary: rows.into_iter().map(Into::into).collect(),
@@ -146,6 +169,8 @@ impl SyslogService {
             severity: None,
             severity_in: Some(severity_levels),
             app_name: None,
+            facility: None,
+            process_id: None,
             from: Some(from.clone()),
             to: Some(to.clone()),
             limit: Some(limit + 1),
@@ -179,6 +204,302 @@ impl SyslogService {
             .await?
             .into();
         Ok(stats)
+    }
+
+    pub async fn list_apps(&self, req: ListAppsRequest) -> ServiceResult<ListAppsResponse> {
+        let apps = self
+            .run_db(move |pool| db::list_apps(pool, req.hostname.as_deref()))
+            .await?;
+        Ok(ListAppsResponse { apps })
+    }
+
+    pub async fn list_source_ips(&self) -> ServiceResult<ListSourceIpsResponse> {
+        let source_ips = self.run_db(db::list_source_ips).await?;
+        Ok(ListSourceIpsResponse { source_ips })
+    }
+
+    pub async fn timeline(&self, req: TimelineRequest) -> ServiceResult<TimelineResponse> {
+        let bucket_str = req.bucket.unwrap_or_else(|| "hour".into());
+        let bucket = Bucket::parse(&bucket_str).ok_or_else(|| {
+            ServiceError::InvalidInput(format!(
+                "Invalid bucket '{bucket_str}'. Expected: minute, hour, day"
+            ))
+        })?;
+        let group_by = match req.group_by.as_deref() {
+            None => TimelineGroupBy::None,
+            Some(g) => TimelineGroupBy::parse(g).ok_or_else(|| {
+                ServiceError::InvalidInput(format!(
+                    "Invalid group_by '{g}'. Expected: hostname, severity, app_name"
+                ))
+            })?,
+        };
+        let from = parse_optional_timestamp(req.from.as_deref(), "from")?;
+        let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
+        let severity_in = match req.severity_min.as_deref() {
+            Some(min) => Some(severity_at_or_above(min)?),
+            None => None,
+        };
+        let group_by_label = req.group_by.clone();
+        let points = self
+            .run_db(move |pool| {
+                db::timeline(
+                    pool,
+                    bucket,
+                    group_by,
+                    from.as_deref(),
+                    to.as_deref(),
+                    req.hostname.as_deref(),
+                    req.app_name.as_deref(),
+                    severity_in.as_deref(),
+                )
+            })
+            .await?;
+        Ok(TimelineResponse {
+            bucket: bucket_str,
+            group_by: group_by_label,
+            points,
+        })
+    }
+
+    pub async fn patterns(&self, req: PatternsRequest) -> ServiceResult<PatternsResponse> {
+        let from = parse_optional_timestamp(req.from.as_deref(), "from")?;
+        let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
+        let severity_in = match req.severity_min.as_deref() {
+            Some(min) => Some(severity_at_or_above(min)?),
+            None => None,
+        };
+        let scan_limit = req.scan_limit.unwrap_or(10_000);
+        let top_n = req.top_n.unwrap_or(20).min(200);
+        let (patterns, scanned, truncated) = self
+            .run_db(move |pool| {
+                db::patterns(
+                    pool,
+                    from.as_deref(),
+                    to.as_deref(),
+                    req.hostname.as_deref(),
+                    req.app_name.as_deref(),
+                    severity_in.as_deref(),
+                    scan_limit,
+                    top_n,
+                )
+            })
+            .await?;
+        Ok(PatternsResponse {
+            patterns,
+            scanned,
+            truncated,
+        })
+    }
+
+    pub async fn context(&self, req: ContextRequest) -> ServiceResult<ContextResponse> {
+        let before = req.before.unwrap_or(10).min(500);
+        let after = req.after.unwrap_or(10).min(500);
+        let resolved = self
+            .run_db(move |pool| -> anyhow::Result<_> {
+                let (reference, hostname, timestamp, id): (LogEntry, String, String, i64) =
+                    if let Some(id) = req.log_id {
+                        let row = db::fetch_log_by_id(pool, id)?
+                            .ok_or_else(|| anyhow::anyhow!("No log found for id {id}"))?;
+                        let entry = LogEntry {
+                            id: row.id,
+                            timestamp: row.timestamp.clone(),
+                            hostname: row.hostname.clone(),
+                            facility: row.facility.clone(),
+                            severity: row.severity.clone(),
+                            app_name: row.app_name.clone(),
+                            process_id: row.process_id.clone(),
+                            message: row.message.clone(),
+                            received_at: row.received_at.clone(),
+                            source_ip: row.source_ip.clone(),
+                        };
+                        (entry, row.hostname, row.timestamp, row.id)
+                    } else {
+                        let hostname = req.hostname.clone().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Either `log_id` or both `hostname` + `timestamp` are required"
+                            )
+                        })?;
+                        let timestamp = req.timestamp.clone().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "Either `log_id` or both `hostname` + `timestamp` are required"
+                            )
+                        })?;
+                        let synthetic = LogEntry {
+                            id: 0,
+                            timestamp: timestamp.clone(),
+                            hostname: hostname.clone(),
+                            facility: None,
+                            severity: String::new(),
+                            app_name: None,
+                            process_id: None,
+                            message: "<reference timestamp>".into(),
+                            received_at: timestamp.clone(),
+                            source_ip: String::new(),
+                        };
+                        (synthetic, hostname, timestamp, i64::MAX)
+                    };
+
+                let (before_rows, after_rows) = db::context_around(
+                    pool,
+                    &ContextRef {
+                        id,
+                        hostname,
+                        timestamp,
+                    },
+                    before,
+                    after,
+                )?;
+                Ok((reference, before_rows, after_rows))
+            })
+            .await?;
+        let (reference, before_rows, after_rows) = resolved;
+        Ok(ContextResponse {
+            reference,
+            before: before_rows.into_iter().map(Into::into).collect(),
+            after: after_rows.into_iter().map(Into::into).collect(),
+        })
+    }
+
+    pub async fn get_log(&self, req: GetLogRequest) -> ServiceResult<GetLogResponse> {
+        let id = req.id;
+        let row = self
+            .run_db(move |pool| db::fetch_log_by_id(pool, id))
+            .await?
+            .ok_or_else(|| ServiceError::InvalidInput(format!("No log found for id {id}")))?;
+        Ok(GetLogResponse { log: row })
+    }
+
+    pub async fn ingest_rate(&self, req: IngestRateRequest) -> ServiceResult<IngestRateResponse> {
+        let now_dt = chrono::Utc::now();
+        let now = now_dt.to_rfc3339();
+        let cut_1m = (now_dt - chrono::Duration::seconds(60)).to_rfc3339();
+        let cut_5m = (now_dt - chrono::Duration::seconds(300)).to_rfc3339();
+        let cut_15m = (now_dt - chrono::Duration::seconds(900)).to_rfc3339();
+        let want_by_host = req.by_host.unwrap_or(false);
+
+        let storage = self.storage.clone();
+        let now_clone = now.clone();
+        let cut_1m_q = cut_1m.clone();
+        let cut_5m_q = cut_5m.clone();
+        let cut_15m_q = cut_15m.clone();
+        let result = self
+            .run_db(move |pool| -> anyhow::Result<_> {
+                let buckets = db::ingest_rate(pool, &now_clone, &cut_1m_q, &cut_5m_q, &cut_15m_q)?;
+                let by_host = if want_by_host {
+                    Some(db::ingest_rate_by_host(
+                        pool, &now_clone, &cut_1m_q, &cut_5m_q, &cut_15m_q,
+                    )?)
+                } else {
+                    None
+                };
+                let stats = db::get_stats(pool, &storage)?;
+                Ok((buckets, by_host, stats.write_blocked))
+            })
+            .await?;
+        let (buckets, by_host, write_blocked) = result;
+        Ok(IngestRateResponse {
+            now,
+            buckets,
+            write_blocked,
+            by_host,
+        })
+    }
+
+    pub async fn silent_hosts(
+        &self,
+        req: SilentHostsRequest,
+    ) -> ServiceResult<SilentHostsResponse> {
+        let silent_minutes = req.silent_minutes.unwrap_or(30).min(60 * 24 * 7);
+        let now_dt = chrono::Utc::now();
+        let now = now_dt.to_rfc3339();
+        let cutoff_dt = now_dt - chrono::Duration::minutes(i64::from(silent_minutes));
+        let cutoff = cutoff_dt.to_rfc3339();
+        let now_unix = now_dt.timestamp();
+        let cutoff_q = cutoff.clone();
+        let hosts = self
+            .run_db(move |pool| db::silent_hosts(pool, &cutoff_q, now_unix))
+            .await?;
+        Ok(SilentHostsResponse {
+            silent_minutes,
+            cutoff,
+            now,
+            hosts,
+        })
+    }
+
+    pub async fn clock_skew(&self, req: ClockSkewRequest) -> ServiceResult<ClockSkewResponse> {
+        let since_str = match req.since {
+            Some(s) => parse_optional_timestamp(Some(&s), "since")?
+                .expect("parse_optional_timestamp returns Some when input is Some"),
+            None => (chrono::Utc::now() - chrono::Duration::hours(24)).to_rfc3339(),
+        };
+        let q = since_str.clone();
+        let hosts = self.run_db(move |pool| db::clock_skew(pool, &q)).await?;
+        Ok(ClockSkewResponse {
+            since: since_str,
+            hosts,
+        })
+    }
+
+    pub async fn anomalies(&self, req: AnomaliesRequest) -> ServiceResult<AnomaliesResponse> {
+        let recent_minutes = req.recent_minutes.unwrap_or(15).clamp(1, 60 * 24);
+        let baseline_minutes = req.baseline_minutes.unwrap_or(360).clamp(1, 60 * 24 * 7);
+        let now_dt = chrono::Utc::now();
+        let recent_to = now_dt.to_rfc3339();
+        let recent_from_dt = now_dt - chrono::Duration::minutes(i64::from(recent_minutes));
+        let recent_from = recent_from_dt.to_rfc3339();
+        let baseline_to = recent_from.clone();
+        let baseline_from =
+            (recent_from_dt - chrono::Duration::minutes(i64::from(baseline_minutes))).to_rfc3339();
+
+        let rf = recent_from.clone();
+        let rt = recent_to.clone();
+        let bf = baseline_from.clone();
+        let bt = baseline_to.clone();
+        let hosts = self
+            .run_db(move |pool| {
+                db::anomalies(pool, &rf, &rt, &bf, &bt, recent_minutes, baseline_minutes)
+            })
+            .await?;
+        Ok(AnomaliesResponse {
+            recent_from,
+            recent_to,
+            baseline_from,
+            baseline_to,
+            recent_minutes,
+            baseline_minutes,
+            hosts,
+        })
+    }
+
+    pub async fn compare(&self, req: CompareRequest) -> ServiceResult<CompareResponse> {
+        let a_from =
+            parse_optional_timestamp(Some(&req.a_from), "a_from")?.expect("required field");
+        let a_to = parse_optional_timestamp(Some(&req.a_to), "a_to")?.expect("required field");
+        let b_from =
+            parse_optional_timestamp(Some(&req.b_from), "b_from")?.expect("required field");
+        let b_to = parse_optional_timestamp(Some(&req.b_to), "b_to")?.expect("required field");
+
+        let a_from_q = a_from.clone();
+        let a_to_q = a_to.clone();
+        let b_from_q = b_from.clone();
+        let b_to_q = b_to.clone();
+        let result = self
+            .run_db(move |pool| -> anyhow::Result<_> {
+                let a = db::summarize_range(pool, &a_from_q, &a_to_q)?;
+                let b = db::summarize_range(pool, &b_from_q, &b_to_q)?;
+                Ok((a, b))
+            })
+            .await?;
+        let (a, b) = result;
+        let delta_total_logs = b.total_logs - a.total_logs;
+        let delta_total_errors = b.total_errors - a.total_errors;
+        Ok(CompareResponse {
+            a,
+            b,
+            delta_total_logs,
+            delta_total_errors,
+        })
     }
 }
 

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -296,7 +296,7 @@ impl SyslogService {
         let after = req.after.unwrap_or(10).min(500);
         let resolved = self
             .run_db(move |pool| -> anyhow::Result<_> {
-                let (reference, hostname, timestamp, id): (LogEntry, String, String, i64) =
+                let (reference, hostname, timestamp, id): (LogEntry, String, String, Option<i64>) =
                     if let Some(id) = req.log_id {
                         let row = db::fetch_log_by_id(pool, id)?
                             .ok_or_else(|| anyhow::anyhow!("No log found for id {id}"))?;
@@ -312,7 +312,7 @@ impl SyslogService {
                             received_at: row.received_at.clone(),
                             source_ip: row.source_ip.clone(),
                         };
-                        (entry, row.hostname, row.timestamp, row.id)
+                        (entry, row.hostname, row.timestamp, Some(row.id))
                     } else {
                         let hostname = req.hostname.clone().ok_or_else(|| {
                             anyhow::anyhow!(
@@ -336,7 +336,7 @@ impl SyslogService {
                             received_at: timestamp.clone(),
                             source_ip: String::new(),
                         };
-                        (synthetic, hostname, timestamp, i64::MAX)
+                        (synthetic, hostname, timestamp, None)
                     };
 
                 let (before_rows, after_rows) = db::context_around(

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -210,12 +210,16 @@ impl SyslogService {
         let apps = self
             .run_db(move |pool| db::list_apps(pool, req.hostname.as_deref()))
             .await?;
-        Ok(ListAppsResponse { apps })
+        Ok(ListAppsResponse {
+            apps: apps.into_iter().map(Into::into).collect(),
+        })
     }
 
     pub async fn list_source_ips(&self) -> ServiceResult<ListSourceIpsResponse> {
         let source_ips = self.run_db(db::list_source_ips).await?;
-        Ok(ListSourceIpsResponse { source_ips })
+        Ok(ListSourceIpsResponse {
+            source_ips: source_ips.into_iter().map(Into::into).collect(),
+        })
     }
 
     pub async fn timeline(&self, req: TimelineRequest) -> ServiceResult<TimelineResponse> {
@@ -257,7 +261,7 @@ impl SyslogService {
         Ok(TimelineResponse {
             bucket: bucket_str,
             group_by: group_by_label,
-            points,
+            points: points.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -285,7 +289,7 @@ impl SyslogService {
             })
             .await?;
         Ok(PatternsResponse {
-            patterns,
+            patterns: patterns.into_iter().map(Into::into).collect(),
             scanned,
             truncated,
         })
@@ -381,7 +385,7 @@ impl SyslogService {
             .run_db(move |pool| db::fetch_log_by_id(pool, id))
             .await?
             .ok_or_else(|| ServiceError::InvalidInput(format!("No log found for id {id}")))?;
-        Ok(GetLogResponse { log: row })
+        Ok(GetLogResponse { log: row.into() })
     }
 
     pub async fn ingest_rate(&self, req: IngestRateRequest) -> ServiceResult<IngestRateResponse> {
@@ -414,9 +418,9 @@ impl SyslogService {
         let (buckets, by_host, write_blocked) = result;
         Ok(IngestRateResponse {
             now,
-            buckets,
+            buckets: buckets.into(),
             write_blocked,
-            by_host,
+            by_host: by_host.map(|rows| rows.into_iter().map(Into::into).collect()),
         })
     }
 
@@ -438,7 +442,7 @@ impl SyslogService {
             silent_minutes,
             cutoff,
             now,
-            hosts,
+            hosts: hosts.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -453,7 +457,7 @@ impl SyslogService {
         let hosts = self.run_db(move |pool| db::clock_skew(pool, &q)).await?;
         Ok(ClockSkewResponse {
             since: since_str,
-            hosts,
+            hosts: hosts.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -484,7 +488,7 @@ impl SyslogService {
             baseline_to,
             recent_minutes,
             baseline_minutes,
-            hosts,
+            hosts: hosts.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -509,8 +513,8 @@ impl SyslogService {
         let delta_total_logs = b.total_logs - a.total_logs;
         let delta_total_errors = b.total_errors - a.total_errors;
         Ok(CompareResponse {
-            a,
-            b,
+            a: a.into(),
+            b: b.into(),
             delta_total_logs,
             delta_total_errors,
         })

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -71,8 +71,8 @@ async fn correlate_events_normalizes_window_groups_and_truncates() {
         .await
         .unwrap();
 
-    assert_eq!(response.window_from, "2025-12-31T23:58:00+00:00");
-    assert_eq!(response.window_to, "2026-01-01T00:02:00+00:00");
+    assert_eq!(response.window_from, "2025-12-31T23:58:00.000Z");
+    assert_eq!(response.window_to, "2026-01-01T00:02:00.000Z");
     assert!(response.truncated);
     assert_eq!(response.total_events, 1);
     assert_eq!(response.hosts_count, 1);

--- a/src/app/time.rs
+++ b/src/app/time.rs
@@ -1,12 +1,22 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 
 use super::{ServiceError, ServiceResult};
+
+/// Format a UTC instant in the same `Z`-suffixed shape SQLite stores in
+/// `received_at` (and that OTLP ingest writes for `timestamp`), so
+/// lexicographic TEXT comparisons line up at boundary instants. Plain
+/// `to_rfc3339()` produces the `+00:00` form, which sorts strictly less than
+/// `Z` character-by-character and can silently drop equal-instant rows from
+/// boundary windows.
+pub(crate) fn rfc3339_z(dt: DateTime<Utc>) -> String {
+    dt.to_rfc3339_opts(SecondsFormat::Millis, true)
+}
 
 pub fn parse_optional_timestamp(
     raw: Option<&str>,
     field_name: &str,
 ) -> ServiceResult<Option<String>> {
-    raw.map(|s| parse_required_timestamp(s, field_name).map(|dt| dt.to_rfc3339()))
+    raw.map(|s| parse_required_timestamp(s, field_name).map(rfc3339_z))
         .transpose()
 }
 

--- a/src/app/time_tests.rs
+++ b/src/app/time_tests.rs
@@ -5,7 +5,7 @@ fn parse_optional_timestamp_normalizes_to_utc() {
     let parsed = parse_optional_timestamp(Some("2026-01-01T01:00:00+01:00"), "from")
         .unwrap()
         .unwrap();
-    assert_eq!(parsed, "2026-01-01T00:00:00+00:00");
+    assert_eq!(parsed, "2026-01-01T00:00:00.000Z");
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,6 +90,8 @@ pub(crate) async fn run(service: SyslogService, command: CliCommand) -> Result<(
                     source_ip: args.source_ip,
                     severity: args.severity,
                     app_name: args.app_name,
+                    facility: None,
+                    process_id: None,
                     from: args.from,
                     to: args.to,
                     limit: args.limit,
@@ -104,6 +106,7 @@ pub(crate) async fn run(service: SyslogService, command: CliCommand) -> Result<(
                     hostname: args.hostname,
                     source_ip: args.source_ip,
                     app_name: args.app_name,
+                    severity_min: None,
                     n: args.n,
                 })
                 .await?;
@@ -115,6 +118,7 @@ pub(crate) async fn run(service: SyslogService, command: CliCommand) -> Result<(
                 .get_errors(GetErrorsRequest {
                     from: args.from,
                     to: args.to,
+                    group_by: None,
                 })
                 .await?;
             print_errors_response(&response, json)?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,11 +1,19 @@
 #![allow(unused_imports)]
 
+mod analytics;
 mod ingest;
 mod maintenance;
 mod models;
 mod pool;
 mod queries;
 
+pub use analytics::{
+    anomalies, clock_skew, context_around, fetch_log_by_id, ingest_rate, ingest_rate_by_host,
+    list_apps, list_source_ips, normalize_template, patterns, silent_hosts, summarize_range,
+    timeline, AnomalyEntry, AppEntry, Bucket, ClockSkewEntry, ContextRef, IngestRateBuckets,
+    IngestRatePerHost, LogEntryWithRaw, PatternEntry, RangeSummary, SilentHostEntry, SourceIpEntry,
+    SourceIpHostBreakdown, TimelineGroupBy, TimelinePoint,
+};
 pub use ingest::insert_logs_batch;
 pub use maintenance::{
     enforce_storage_budget, get_storage_metrics, purge_by_tag_window, purge_old_logs,

--- a/src/db.rs
+++ b/src/db.rs
@@ -9,9 +9,9 @@ mod queries;
 
 pub use analytics::{
     anomalies, clock_skew, context_around, fetch_log_by_id, ingest_rate, ingest_rate_by_host,
-    list_apps, list_source_ips, normalize_template, patterns, silent_hosts, summarize_range,
-    timeline, AnomalyEntry, AppEntry, Bucket, ClockSkewEntry, ContextRef, IngestRateBuckets,
-    IngestRatePerHost, LogEntryWithRaw, PatternEntry, RangeSummary, SilentHostEntry, SourceIpEntry,
+    list_apps, list_source_ips, patterns, silent_hosts, summarize_range, timeline, AnomalyEntry,
+    AppEntry, Bucket, ClockSkewEntry, ContextRef, IngestRateBuckets, IngestRatePerHost,
+    LogEntryWithRaw, PatternEntry, RangeSummary, SilentHostEntry, SourceIpEntry,
     SourceIpHostBreakdown, TimelineGroupBy, TimelinePoint,
 };
 pub use ingest::insert_logs_batch;

--- a/src/db/analytics.rs
+++ b/src/db/analytics.rs
@@ -319,7 +319,7 @@ pub struct PatternEntry {
 /// Pattern detection is byte-level (all targets — digits, hex, IPv4, UUIDs —
 /// are ASCII), but non-ASCII bytes are passed through as their proper
 /// codepoint so internationalised log messages stay valid UTF-8.
-pub fn normalize_template(msg: &str) -> String {
+pub(super) fn normalize_template(msg: &str) -> String {
     let bytes = msg.as_bytes();
     let mut out = String::with_capacity(msg.len());
     let mut i = 0;
@@ -990,10 +990,20 @@ pub fn anomalies(
             baseline_errors,
         });
     }
+    // Surface new-but-active hosts (`recent_count > 0` against a zero baseline)
+    // at the top — they have no defined `z_score`, but they are exactly the
+    // signal the docstring promises. Other unscored entries (e.g. recent zero
+    // activity, dormant hosts) sink to the bottom.
+    let sort_key = |e: &AnomalyEntry| -> f64 {
+        if e.baseline_count == 0 && e.recent_count > 0 {
+            f64::INFINITY
+        } else {
+            e.z_score.unwrap_or(f64::NEG_INFINITY)
+        }
+    };
     out.sort_by(|a, b| {
-        b.z_score
-            .unwrap_or(f64::NEG_INFINITY)
-            .partial_cmp(&a.z_score.unwrap_or(f64::NEG_INFINITY))
+        sort_key(b)
+            .partial_cmp(&sort_key(a))
             .unwrap_or(std::cmp::Ordering::Equal)
     });
     Ok(out)

--- a/src/db/analytics.rs
+++ b/src/db/analytics.rs
@@ -1,0 +1,1023 @@
+//! Higher-level analytics queries layered on top of the `logs` table.
+//!
+//! These power MCP actions beyond raw search/tail: distinct-value enumeration
+//! (`apps`, `source_ips`), time-series aggregations (`timeline`,
+//! `ingest_rate`), pattern clustering (`patterns`), drill-down helpers
+//! (`context`, `get`), operational health (`silent_hosts`, `clock_skew`),
+//! and comparison/anomaly detection.
+
+use anyhow::Result;
+use rusqlite::params;
+use std::collections::BTreeMap;
+
+use super::pool::DbPool;
+use super::queries::map_row_with_raw;
+use super::LogEntry;
+
+// -----------------------------------------------------------------------------
+// apps: distinct app_names with stats
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AppEntry {
+    pub app_name: String,
+    pub log_count: i64,
+    pub host_count: i64,
+    pub first_seen: String,
+    pub last_seen: String,
+}
+
+pub fn list_apps(pool: &DbPool, hostname: Option<&str>) -> Result<Vec<AppEntry>> {
+    let conn = pool.get()?;
+    let (sql, want_host) = match hostname {
+        Some(_) => (
+            "SELECT app_name, COUNT(*), COUNT(DISTINCT hostname),
+                    MIN(timestamp), MAX(timestamp)
+             FROM logs
+             WHERE app_name IS NOT NULL AND app_name != '' AND hostname = ?1
+             GROUP BY app_name
+             ORDER BY MAX(timestamp) DESC",
+            true,
+        ),
+        None => (
+            "SELECT app_name, COUNT(*), COUNT(DISTINCT hostname),
+                    MIN(timestamp), MAX(timestamp)
+             FROM logs
+             WHERE app_name IS NOT NULL AND app_name != ''
+             GROUP BY app_name
+             ORDER BY MAX(timestamp) DESC",
+            false,
+        ),
+    };
+
+    let mut stmt = conn.prepare(sql)?;
+    let map = |row: &rusqlite::Row| -> rusqlite::Result<AppEntry> {
+        Ok(AppEntry {
+            app_name: row.get(0)?,
+            log_count: row.get(1)?,
+            host_count: row.get(2)?,
+            first_seen: row.get(3)?,
+            last_seen: row.get(4)?,
+        })
+    };
+    let rows = if want_host {
+        stmt.query_map(params![hostname.unwrap()], map)?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    } else {
+        stmt.query_map([], map)?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    Ok(rows)
+}
+
+// -----------------------------------------------------------------------------
+// source_ips: distinct senders + hostnames seen per sender
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SourceIpHostBreakdown {
+    pub hostname: String,
+    pub log_count: i64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SourceIpEntry {
+    pub source_ip: String,
+    pub log_count: i64,
+    pub host_count: i64,
+    pub first_seen: String,
+    pub last_seen: String,
+    /// Top hostnames associated with this source_ip (capped at 10).
+    pub hostnames: Vec<SourceIpHostBreakdown>,
+}
+
+pub fn list_source_ips(pool: &DbPool) -> Result<Vec<SourceIpEntry>> {
+    let conn = pool.get()?;
+    // Pull (source_ip, hostname) pairs grouped, then aggregate in Rust to
+    // avoid GROUP_CONCAT blowing up for noisy senders.
+    let mut stmt = conn.prepare(
+        "SELECT source_ip, hostname, COUNT(*), MIN(timestamp), MAX(timestamp)
+         FROM logs
+         WHERE source_ip != ''
+         GROUP BY source_ip, hostname
+         ORDER BY source_ip, COUNT(*) DESC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, String>(4)?,
+        ))
+    })?;
+
+    let mut by_ip: BTreeMap<String, SourceIpEntry> = BTreeMap::new();
+    for row in rows {
+        let (ip, host, count, first, last) = row?;
+        let entry = by_ip.entry(ip.clone()).or_insert_with(|| SourceIpEntry {
+            source_ip: ip,
+            log_count: 0,
+            host_count: 0,
+            first_seen: first.clone(),
+            last_seen: last.clone(),
+            hostnames: Vec::new(),
+        });
+        entry.log_count += count;
+        entry.host_count += 1;
+        if first < entry.first_seen {
+            entry.first_seen = first;
+        }
+        if last > entry.last_seen {
+            entry.last_seen = last;
+        }
+        if entry.hostnames.len() < 10 {
+            entry.hostnames.push(SourceIpHostBreakdown {
+                hostname: host,
+                log_count: count,
+            });
+        }
+    }
+
+    let mut out: Vec<SourceIpEntry> = by_ip.into_values().collect();
+    out.sort_by(|a, b| b.log_count.cmp(&a.log_count));
+    Ok(out)
+}
+
+// -----------------------------------------------------------------------------
+// timeline: bucketed counts
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+pub enum Bucket {
+    Minute,
+    Hour,
+    Day,
+}
+
+impl Bucket {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "minute" | "min" | "m" => Some(Self::Minute),
+            "hour" | "h" => Some(Self::Hour),
+            "day" | "d" => Some(Self::Day),
+            _ => None,
+        }
+    }
+
+    fn strftime_format(self) -> &'static str {
+        match self {
+            Self::Minute => "%Y-%m-%dT%H:%M:00Z",
+            Self::Hour => "%Y-%m-%dT%H:00:00Z",
+            Self::Day => "%Y-%m-%dT00:00:00Z",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum TimelineGroupBy {
+    None,
+    Hostname,
+    Severity,
+    AppName,
+}
+
+impl TimelineGroupBy {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "hostname" | "host" => Some(Self::Hostname),
+            "severity" | "sev" => Some(Self::Severity),
+            "app_name" | "app" => Some(Self::AppName),
+            _ => None,
+        }
+    }
+
+    fn column(self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::Hostname => Some("hostname"),
+            Self::Severity => Some("severity"),
+            Self::AppName => Some("app_name"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TimelinePoint {
+    pub bucket: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    pub count: i64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn timeline(
+    pool: &DbPool,
+    bucket: Bucket,
+    group_by: TimelineGroupBy,
+    from: Option<&str>,
+    to: Option<&str>,
+    hostname: Option<&str>,
+    app_name: Option<&str>,
+    severity_in: Option<&[String]>,
+) -> Result<Vec<TimelinePoint>> {
+    let conn = pool.get()?;
+    let mut sql = format!(
+        "SELECT strftime('{fmt}', timestamp) AS bucket",
+        fmt = bucket.strftime_format()
+    );
+    if let Some(col) = group_by.column() {
+        sql.push_str(&format!(", COALESCE({col}, '<none>') AS grp"));
+    }
+    sql.push_str(", COUNT(*) FROM logs WHERE 1=1");
+
+    let mut bindings: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1usize;
+
+    if let Some(f) = from {
+        sql.push_str(&format!(" AND timestamp >= ?{idx}"));
+        bindings.push(Box::new(f.to_string()));
+        idx += 1;
+    }
+    if let Some(t) = to {
+        sql.push_str(&format!(" AND timestamp <= ?{idx}"));
+        bindings.push(Box::new(t.to_string()));
+        idx += 1;
+    }
+    if let Some(h) = hostname {
+        sql.push_str(&format!(" AND hostname = ?{idx}"));
+        bindings.push(Box::new(h.to_string()));
+        idx += 1;
+    }
+    if let Some(a) = app_name {
+        sql.push_str(&format!(" AND app_name = ?{idx}"));
+        bindings.push(Box::new(a.to_string()));
+        idx += 1;
+    }
+    if let Some(levels) = severity_in {
+        if !levels.is_empty() {
+            let placeholders: Vec<String> =
+                (0..levels.len()).map(|i| format!("?{}", idx + i)).collect();
+            sql.push_str(&format!(" AND severity IN ({})", placeholders.join(", ")));
+            for lvl in levels {
+                bindings.push(Box::new(lvl.clone()));
+            }
+        }
+    }
+
+    if group_by.column().is_some() {
+        sql.push_str(" GROUP BY bucket, grp ORDER BY bucket ASC, grp ASC");
+    } else {
+        sql.push_str(" GROUP BY bucket ORDER BY bucket ASC");
+    }
+
+    let mut stmt = conn.prepare(&sql)?;
+    let bind_refs: Vec<&dyn rusqlite::types::ToSql> = bindings.iter().map(|b| b.as_ref()).collect();
+    let has_group = group_by.column().is_some();
+    let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs.iter().copied()), |r| {
+        if has_group {
+            Ok(TimelinePoint {
+                bucket: r.get(0)?,
+                group: Some(r.get::<_, String>(1)?),
+                count: r.get(2)?,
+            })
+        } else {
+            Ok(TimelinePoint {
+                bucket: r.get(0)?,
+                group: None,
+                count: r.get(1)?,
+            })
+        }
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+// -----------------------------------------------------------------------------
+// patterns: cluster near-duplicate messages by template normalization
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PatternEntry {
+    pub template: String,
+    pub count: i64,
+    pub host_count: i64,
+    pub sample: String,
+    pub first_seen: String,
+    pub last_seen: String,
+    /// Up to 5 hostnames where this template was seen.
+    pub hostnames: Vec<String>,
+}
+
+/// Normalise a message into a template by replacing variable runs with
+/// placeholders. Designed to collapse near-duplicates without external regex
+/// dependencies — character-class scan only.
+pub fn normalize_template(msg: &str) -> String {
+    let bytes = msg.as_bytes();
+    let mut out = String::with_capacity(msg.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // UUID: 8-4-4-4-12 hex with dashes
+        if is_hex(b) && looks_like_uuid_at(bytes, i) {
+            out.push_str("<uuid>");
+            i += 36;
+            continue;
+        }
+        // IPv4 / IPv4:port (digits + dots, optionally :digits)
+        if b.is_ascii_digit() {
+            if let Some(end) = ipv4_end(bytes, i) {
+                out.push_str("<ip>");
+                i = end;
+                if i < bytes.len() && bytes[i] == b':' {
+                    let mut j = i + 1;
+                    while j < bytes.len() && bytes[j].is_ascii_digit() {
+                        j += 1;
+                    }
+                    if j > i + 1 {
+                        out.push_str(":<n>");
+                        i = j;
+                    }
+                }
+                continue;
+            }
+        }
+        // Long hex run (>= 8 chars) — typical for hashes
+        if is_hex(b) {
+            let mut j = i;
+            while j < bytes.len() && is_hex(bytes[j]) {
+                j += 1;
+            }
+            if j - i >= 8 {
+                out.push_str("<hex>");
+                i = j;
+                continue;
+            }
+        }
+        // Numeric run
+        if b.is_ascii_digit() {
+            let mut j = i;
+            while j < bytes.len() && bytes[j].is_ascii_digit() {
+                j += 1;
+            }
+            out.push_str("<n>");
+            i = j;
+            continue;
+        }
+        out.push(b as char);
+        i += 1;
+    }
+    out
+}
+
+fn is_hex(b: u8) -> bool {
+    b.is_ascii_digit() || (b'a'..=b'f').contains(&b) || (b'A'..=b'F').contains(&b)
+}
+
+fn looks_like_uuid_at(bytes: &[u8], i: usize) -> bool {
+    if i + 36 > bytes.len() {
+        return false;
+    }
+    let positions = [8, 13, 18, 23];
+    for (k, b) in bytes[i..i + 36].iter().enumerate() {
+        if positions.contains(&k) {
+            if *b != b'-' {
+                return false;
+            }
+        } else if !is_hex(*b) {
+            return false;
+        }
+    }
+    true
+}
+
+fn ipv4_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    let mut octets = 0;
+    while octets < 4 {
+        let octet_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        let len = i - octet_start;
+        if !(1..=3).contains(&len) {
+            return None;
+        }
+        octets += 1;
+        if octets < 4 {
+            if i >= bytes.len() || bytes[i] != b'.' {
+                return None;
+            }
+            i += 1;
+        }
+    }
+    Some(i)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn patterns(
+    pool: &DbPool,
+    from: Option<&str>,
+    to: Option<&str>,
+    hostname: Option<&str>,
+    app_name: Option<&str>,
+    severity_in: Option<&[String]>,
+    scan_limit: u32,
+    top_n: u32,
+) -> Result<(Vec<PatternEntry>, i64, bool)> {
+    let conn = pool.get()?;
+    let scan_limit = scan_limit.clamp(1, 50_000);
+
+    let mut sql = String::from("SELECT timestamp, hostname, message FROM logs WHERE 1=1");
+    let mut bindings: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1usize;
+    if let Some(f) = from {
+        sql.push_str(&format!(" AND timestamp >= ?{idx}"));
+        bindings.push(Box::new(f.to_string()));
+        idx += 1;
+    }
+    if let Some(t) = to {
+        sql.push_str(&format!(" AND timestamp <= ?{idx}"));
+        bindings.push(Box::new(t.to_string()));
+        idx += 1;
+    }
+    if let Some(h) = hostname {
+        sql.push_str(&format!(" AND hostname = ?{idx}"));
+        bindings.push(Box::new(h.to_string()));
+        idx += 1;
+    }
+    if let Some(a) = app_name {
+        sql.push_str(&format!(" AND app_name = ?{idx}"));
+        bindings.push(Box::new(a.to_string()));
+        idx += 1;
+    }
+    if let Some(levels) = severity_in {
+        if !levels.is_empty() {
+            let placeholders: Vec<String> =
+                (0..levels.len()).map(|i| format!("?{}", idx + i)).collect();
+            sql.push_str(&format!(" AND severity IN ({})", placeholders.join(", ")));
+            for lvl in levels {
+                bindings.push(Box::new(lvl.clone()));
+            }
+        }
+    }
+    // Cap rows scanned to bound CPU/memory — we ask for one extra to detect truncation.
+    sql.push_str(&format!(
+        " ORDER BY timestamp DESC LIMIT {}",
+        scan_limit + 1
+    ));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let bind_refs: Vec<&dyn rusqlite::types::ToSql> = bindings.iter().map(|b| b.as_ref()).collect();
+    let rows = stmt.query_map(rusqlite::params_from_iter(bind_refs.iter().copied()), |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+        ))
+    })?;
+
+    struct Acc {
+        count: i64,
+        sample: String,
+        first_seen: String,
+        last_seen: String,
+        hosts: BTreeMap<String, i64>,
+    }
+    let mut by_template: BTreeMap<String, Acc> = BTreeMap::new();
+    let mut scanned = 0i64;
+    let mut overflow = false;
+    for row in rows {
+        let (ts, host, msg) = row?;
+        scanned += 1;
+        if scanned > scan_limit as i64 {
+            overflow = true;
+            break;
+        }
+        let template = normalize_template(&msg);
+        let entry = by_template.entry(template).or_insert_with(|| Acc {
+            count: 0,
+            sample: msg.clone(),
+            first_seen: ts.clone(),
+            last_seen: ts.clone(),
+            hosts: BTreeMap::new(),
+        });
+        entry.count += 1;
+        if ts < entry.first_seen {
+            entry.first_seen = ts.clone();
+        }
+        if ts > entry.last_seen {
+            entry.last_seen = ts;
+        }
+        *entry.hosts.entry(host).or_insert(0) += 1;
+    }
+
+    let total_scanned = scanned.min(scan_limit as i64);
+
+    let mut out: Vec<PatternEntry> = by_template
+        .into_iter()
+        .map(|(template, acc)| {
+            let mut hosts: Vec<(String, i64)> = acc.hosts.into_iter().collect();
+            hosts.sort_by(|a, b| b.1.cmp(&a.1));
+            let host_count = hosts.len() as i64;
+            let hostnames: Vec<String> = hosts.into_iter().take(5).map(|(h, _)| h).collect();
+            PatternEntry {
+                template,
+                count: acc.count,
+                host_count,
+                sample: acc.sample,
+                first_seen: acc.first_seen,
+                last_seen: acc.last_seen,
+                hostnames,
+            }
+        })
+        .collect();
+    out.sort_by(|a, b| b.count.cmp(&a.count));
+    out.truncate(top_n as usize);
+    Ok((out, total_scanned, overflow))
+}
+
+// -----------------------------------------------------------------------------
+// context: surrounding logs for a single point of interest
+// -----------------------------------------------------------------------------
+
+pub struct ContextRef {
+    pub id: i64,
+    pub hostname: String,
+    pub timestamp: String,
+}
+
+pub fn fetch_log_by_id(pool: &DbPool, id: i64) -> Result<Option<LogEntryWithRaw>> {
+    let conn = pool.get()?;
+    let mut stmt = conn.prepare(
+        "SELECT id, timestamp, hostname, facility, severity,
+                app_name, process_id, message, raw, received_at, source_ip
+         FROM logs WHERE id = ?1",
+    )?;
+    let mut rows = stmt.query(params![id])?;
+    if let Some(r) = rows.next()? {
+        Ok(Some(map_row_with_raw(r)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn context_around(
+    pool: &DbPool,
+    reference: &ContextRef,
+    before: u32,
+    after: u32,
+) -> Result<(Vec<LogEntry>, Vec<LogEntry>)> {
+    let conn = pool.get()?;
+    let before = before.min(500);
+    let after = after.min(500);
+
+    // Before: timestamp < ref OR (timestamp = ref AND id < ref.id)
+    let mut before_stmt = conn.prepare(
+        "SELECT id, timestamp, hostname, facility, severity,
+                app_name, process_id, message, received_at, source_ip
+         FROM logs
+         WHERE hostname = ?1
+           AND (timestamp < ?2 OR (timestamp = ?2 AND id < ?3))
+         ORDER BY timestamp DESC, id DESC
+         LIMIT ?4",
+    )?;
+    let mut before_rows = before_stmt
+        .query_map(
+            params![
+                reference.hostname,
+                reference.timestamp,
+                reference.id,
+                before
+            ],
+            super::queries::map_row,
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    // Reverse so the result reads chronologically.
+    before_rows.reverse();
+
+    let mut after_stmt = conn.prepare(
+        "SELECT id, timestamp, hostname, facility, severity,
+                app_name, process_id, message, received_at, source_ip
+         FROM logs
+         WHERE hostname = ?1
+           AND (timestamp > ?2 OR (timestamp = ?2 AND id > ?3))
+         ORDER BY timestamp ASC, id ASC
+         LIMIT ?4",
+    )?;
+    let after_rows = after_stmt
+        .query_map(
+            params![reference.hostname, reference.timestamp, reference.id, after],
+            super::queries::map_row,
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    Ok((before_rows, after_rows))
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LogEntryWithRaw {
+    pub id: i64,
+    pub timestamp: String,
+    pub hostname: String,
+    pub facility: Option<String>,
+    pub severity: String,
+    pub app_name: Option<String>,
+    pub process_id: Option<String>,
+    pub message: String,
+    pub raw: String,
+    pub received_at: String,
+    pub source_ip: String,
+}
+
+// -----------------------------------------------------------------------------
+// ingest_rate: throughput over the last 1m / 5m / 15m windows
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IngestRateBuckets {
+    pub last_1m: i64,
+    pub last_5m: i64,
+    pub last_15m: i64,
+    pub per_sec_1m: f64,
+    pub per_sec_5m: f64,
+    pub per_sec_15m: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IngestRatePerHost {
+    pub hostname: String,
+    pub last_1m: i64,
+    pub last_5m: i64,
+    pub last_15m: i64,
+}
+
+pub fn ingest_rate(
+    pool: &DbPool,
+    now: &str,
+    cut_1m: &str,
+    cut_5m: &str,
+    cut_15m: &str,
+) -> Result<IngestRateBuckets> {
+    let conn = pool.get()?;
+    let row: (i64, i64, i64) = conn.query_row(
+        "SELECT
+            SUM(CASE WHEN received_at >= ?1 THEN 1 ELSE 0 END),
+            SUM(CASE WHEN received_at >= ?2 THEN 1 ELSE 0 END),
+            SUM(CASE WHEN received_at >= ?3 THEN 1 ELSE 0 END)
+         FROM logs
+         WHERE received_at >= ?3 AND received_at <= ?4",
+        params![cut_1m, cut_5m, cut_15m, now],
+        |r| {
+            Ok((
+                r.get::<_, Option<i64>>(0)?.unwrap_or(0),
+                r.get::<_, Option<i64>>(1)?.unwrap_or(0),
+                r.get::<_, Option<i64>>(2)?.unwrap_or(0),
+            ))
+        },
+    )?;
+    Ok(IngestRateBuckets {
+        last_1m: row.0,
+        last_5m: row.1,
+        last_15m: row.2,
+        per_sec_1m: row.0 as f64 / 60.0,
+        per_sec_5m: row.1 as f64 / 300.0,
+        per_sec_15m: row.2 as f64 / 900.0,
+    })
+}
+
+pub fn ingest_rate_by_host(
+    pool: &DbPool,
+    now: &str,
+    cut_1m: &str,
+    cut_5m: &str,
+    cut_15m: &str,
+) -> Result<Vec<IngestRatePerHost>> {
+    let conn = pool.get()?;
+    let mut stmt = conn.prepare(
+        "SELECT hostname,
+                SUM(CASE WHEN received_at >= ?1 THEN 1 ELSE 0 END),
+                SUM(CASE WHEN received_at >= ?2 THEN 1 ELSE 0 END),
+                COUNT(*)
+         FROM logs
+         WHERE received_at >= ?3 AND received_at <= ?4
+         GROUP BY hostname
+         ORDER BY COUNT(*) DESC",
+    )?;
+    let rows = stmt.query_map(params![cut_1m, cut_5m, cut_15m, now], |r| {
+        Ok(IngestRatePerHost {
+            hostname: r.get(0)?,
+            last_1m: r.get::<_, Option<i64>>(1)?.unwrap_or(0),
+            last_5m: r.get::<_, Option<i64>>(2)?.unwrap_or(0),
+            last_15m: r.get(3)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+// -----------------------------------------------------------------------------
+// silent_hosts: hosts whose last_seen is older than a threshold
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SilentHostEntry {
+    pub hostname: String,
+    pub first_seen: String,
+    pub last_seen: String,
+    pub log_count: i64,
+    /// Approx seconds between log arrivals over the host's full history.
+    pub typical_interval_secs: Option<f64>,
+    /// Seconds since last log was received.
+    pub silent_for_secs: i64,
+}
+
+pub fn silent_hosts(pool: &DbPool, cutoff: &str, now_unix: i64) -> Result<Vec<SilentHostEntry>> {
+    let conn = pool.get()?;
+    let mut stmt = conn.prepare(
+        "SELECT hostname, first_seen, last_seen, log_count
+         FROM hosts
+         WHERE last_seen < ?1
+         ORDER BY last_seen ASC",
+    )?;
+    let rows = stmt.query_map(params![cutoff], |r| {
+        let hostname: String = r.get(0)?;
+        let first_seen: String = r.get(1)?;
+        let last_seen: String = r.get(2)?;
+        let log_count: i64 = r.get(3)?;
+        Ok((hostname, first_seen, last_seen, log_count))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (hostname, first_seen, last_seen, log_count) = row?;
+        let typical_interval_secs = compute_interval(&first_seen, &last_seen, log_count);
+        let silent_for_secs = chrono::DateTime::parse_from_rfc3339(&last_seen)
+            .map(|dt| now_unix - dt.timestamp())
+            .unwrap_or(0);
+        out.push(SilentHostEntry {
+            hostname,
+            first_seen,
+            last_seen,
+            log_count,
+            typical_interval_secs,
+            silent_for_secs,
+        });
+    }
+    Ok(out)
+}
+
+fn compute_interval(first: &str, last: &str, count: i64) -> Option<f64> {
+    if count < 2 {
+        return None;
+    }
+    let f = chrono::DateTime::parse_from_rfc3339(first).ok()?;
+    let l = chrono::DateTime::parse_from_rfc3339(last).ok()?;
+    let span = (l - f).num_seconds() as f64;
+    if span <= 0.0 {
+        return None;
+    }
+    Some(span / (count - 1) as f64)
+}
+
+// -----------------------------------------------------------------------------
+// clock_skew: per-host distribution of received_at - timestamp
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ClockSkewEntry {
+    pub hostname: String,
+    pub samples: i64,
+    pub avg_skew_secs: f64,
+    pub min_skew_secs: f64,
+    pub max_skew_secs: f64,
+}
+
+pub fn clock_skew(pool: &DbPool, since: &str) -> Result<Vec<ClockSkewEntry>> {
+    let conn = pool.get()?;
+    let mut stmt = conn.prepare(
+        "SELECT hostname,
+                COUNT(*),
+                AVG((julianday(received_at) - julianday(timestamp)) * 86400),
+                MIN((julianday(received_at) - julianday(timestamp)) * 86400),
+                MAX((julianday(received_at) - julianday(timestamp)) * 86400)
+         FROM logs
+         WHERE received_at >= ?1
+         GROUP BY hostname
+         ORDER BY ABS(AVG((julianday(received_at) - julianday(timestamp)) * 86400)) DESC",
+    )?;
+    let rows = stmt.query_map(params![since], |r| {
+        Ok(ClockSkewEntry {
+            hostname: r.get(0)?,
+            samples: r.get(1)?,
+            avg_skew_secs: r.get::<_, Option<f64>>(2)?.unwrap_or(0.0),
+            min_skew_secs: r.get::<_, Option<f64>>(3)?.unwrap_or(0.0),
+            max_skew_secs: r.get::<_, Option<f64>>(4)?.unwrap_or(0.0),
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+// -----------------------------------------------------------------------------
+// anomalies: per-host volume / error-rate vs baseline
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AnomalyEntry {
+    pub hostname: String,
+    pub recent_count: i64,
+    pub baseline_count: i64,
+    pub recent_per_min: f64,
+    pub baseline_per_min: f64,
+    /// recent_per_min / baseline_per_min (1.0 means unchanged). `None` when
+    /// baseline is zero (host is new — flagged separately).
+    pub ratio: Option<f64>,
+    /// Poisson-style z-score against baseline rate.
+    pub z_score: Option<f64>,
+    pub recent_errors: i64,
+    pub baseline_errors: i64,
+}
+
+pub fn anomalies(
+    pool: &DbPool,
+    recent_from: &str,
+    recent_to: &str,
+    baseline_from: &str,
+    baseline_to: &str,
+    recent_minutes: u32,
+    baseline_minutes: u32,
+) -> Result<Vec<AnomalyEntry>> {
+    let conn = pool.get()?;
+    let error_levels = "('emerg','alert','crit','err','warning')";
+
+    // FULL OUTER JOIN is only available in SQLite ≥ 3.39 — emulate via a
+    // hosts-union CTE so we still pick up hosts that exist in baseline only.
+    let sql = format!(
+        "WITH recent AS (
+             SELECT hostname,
+                    COUNT(*) AS c,
+                    SUM(CASE WHEN severity IN {err} THEN 1 ELSE 0 END) AS e
+             FROM logs
+             WHERE timestamp >= ?1 AND timestamp <= ?2
+             GROUP BY hostname
+         ),
+         baseline AS (
+             SELECT hostname,
+                    COUNT(*) AS c,
+                    SUM(CASE WHEN severity IN {err} THEN 1 ELSE 0 END) AS e
+             FROM logs
+             WHERE timestamp >= ?3 AND timestamp <= ?4
+             GROUP BY hostname
+         ),
+         all_hosts AS (
+             SELECT hostname FROM recent
+             UNION
+             SELECT hostname FROM baseline
+         )
+         SELECT a.hostname,
+                COALESCE(r.c, 0), COALESCE(b.c, 0),
+                COALESCE(r.e, 0), COALESCE(b.e, 0)
+         FROM all_hosts a
+         LEFT JOIN recent r ON r.hostname = a.hostname
+         LEFT JOIN baseline b ON b.hostname = a.hostname
+         ORDER BY a.hostname",
+        err = error_levels
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(
+        params![recent_from, recent_to, baseline_from, baseline_to],
+        |r| {
+            let hostname: String = r.get(0)?;
+            let recent_count: i64 = r.get(1)?;
+            let baseline_count: i64 = r.get(2)?;
+            let recent_errors: i64 = r.get(3)?;
+            let baseline_errors: i64 = r.get(4)?;
+            Ok((
+                hostname,
+                recent_count,
+                baseline_count,
+                recent_errors,
+                baseline_errors,
+            ))
+        },
+    )?;
+
+    let recent_minutes = recent_minutes.max(1) as f64;
+    let baseline_minutes = baseline_minutes.max(1) as f64;
+    let mut out = Vec::new();
+    for row in rows {
+        let (hostname, recent_count, baseline_count, recent_errors, baseline_errors) = row?;
+        let recent_per_min = recent_count as f64 / recent_minutes;
+        let baseline_per_min = baseline_count as f64 / baseline_minutes;
+        let ratio = if baseline_per_min > 0.0 {
+            Some(recent_per_min / baseline_per_min)
+        } else {
+            None
+        };
+        let expected = baseline_per_min * recent_minutes;
+        let z_score = if expected > 0.0 {
+            Some((recent_count as f64 - expected) / expected.sqrt())
+        } else {
+            None
+        };
+        out.push(AnomalyEntry {
+            hostname,
+            recent_count,
+            baseline_count,
+            recent_per_min,
+            baseline_per_min,
+            ratio,
+            z_score,
+            recent_errors,
+            baseline_errors,
+        });
+    }
+    out.sort_by(|a, b| {
+        b.z_score
+            .unwrap_or(f64::NEG_INFINITY)
+            .partial_cmp(&a.z_score.unwrap_or(f64::NEG_INFINITY))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    Ok(out)
+}
+
+// -----------------------------------------------------------------------------
+// compare: side-by-side diff of two time ranges
+// -----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RangeSummary {
+    pub from: String,
+    pub to: String,
+    pub total_logs: i64,
+    pub total_errors: i64,
+    pub by_severity: Vec<(String, i64)>,
+    pub top_hosts: Vec<(String, i64)>,
+    pub top_apps: Vec<(String, i64)>,
+}
+
+pub fn summarize_range(pool: &DbPool, from: &str, to: &str) -> Result<RangeSummary> {
+    let conn = pool.get()?;
+    let total_logs: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM logs WHERE timestamp >= ?1 AND timestamp <= ?2",
+        params![from, to],
+        |r| r.get(0),
+    )?;
+    let total_errors: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM logs
+         WHERE timestamp >= ?1 AND timestamp <= ?2
+           AND severity IN ('emerg','alert','crit','err','warning')",
+        params![from, to],
+        |r| r.get(0),
+    )?;
+    let mut sev_stmt = conn.prepare(
+        "SELECT severity, COUNT(*) FROM logs
+         WHERE timestamp >= ?1 AND timestamp <= ?2
+         GROUP BY severity
+         ORDER BY COUNT(*) DESC",
+    )?;
+    let by_severity = sev_stmt
+        .query_map(params![from, to], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut host_stmt = conn.prepare(
+        "SELECT hostname, COUNT(*) FROM logs
+         WHERE timestamp >= ?1 AND timestamp <= ?2
+         GROUP BY hostname
+         ORDER BY COUNT(*) DESC
+         LIMIT 10",
+    )?;
+    let top_hosts = host_stmt
+        .query_map(params![from, to], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut app_stmt = conn.prepare(
+        "SELECT app_name, COUNT(*) FROM logs
+         WHERE timestamp >= ?1 AND timestamp <= ?2
+           AND app_name IS NOT NULL AND app_name != ''
+         GROUP BY app_name
+         ORDER BY COUNT(*) DESC
+         LIMIT 10",
+    )?;
+    let top_apps = app_stmt
+        .query_map(params![from, to], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    Ok(RangeSummary {
+        from: from.to_string(),
+        to: to.to_string(),
+        total_logs,
+        total_errors,
+        by_severity,
+        top_hosts,
+        top_apps,
+    })
+}
+
+#[cfg(test)]
+#[path = "analytics_tests.rs"]
+mod tests;

--- a/src/db/analytics.rs
+++ b/src/db/analytics.rs
@@ -29,23 +29,25 @@ pub struct AppEntry {
 
 pub fn list_apps(pool: &DbPool, hostname: Option<&str>) -> Result<Vec<AppEntry>> {
     let conn = pool.get()?;
+    // first_seen / last_seen come from `received_at` (server clock) so they match
+    // how the `hosts` table is updated and aren't skewed by a misconfigured device clock.
     let (sql, want_host) = match hostname {
         Some(_) => (
             "SELECT app_name, COUNT(*), COUNT(DISTINCT hostname),
-                    MIN(timestamp), MAX(timestamp)
+                    MIN(received_at), MAX(received_at)
              FROM logs
              WHERE app_name IS NOT NULL AND app_name != '' AND hostname = ?1
              GROUP BY app_name
-             ORDER BY MAX(timestamp) DESC",
+             ORDER BY MAX(received_at) DESC",
             true,
         ),
         None => (
             "SELECT app_name, COUNT(*), COUNT(DISTINCT hostname),
-                    MIN(timestamp), MAX(timestamp)
+                    MIN(received_at), MAX(received_at)
              FROM logs
              WHERE app_name IS NOT NULL AND app_name != ''
              GROUP BY app_name
-             ORDER BY MAX(timestamp) DESC",
+             ORDER BY MAX(received_at) DESC",
             false,
         ),
     };
@@ -93,10 +95,11 @@ pub struct SourceIpEntry {
 
 pub fn list_source_ips(pool: &DbPool) -> Result<Vec<SourceIpEntry>> {
     let conn = pool.get()?;
-    // Pull (source_ip, hostname) pairs grouped, then aggregate in Rust to
-    // avoid GROUP_CONCAT blowing up for noisy senders.
+    // first_seen / last_seen come from `received_at` (server clock): for sender
+    // identity / spoof-detection use cases, the network arrival time is the
+    // verified value, while the message `timestamp` is whatever the sender claimed.
     let mut stmt = conn.prepare(
-        "SELECT source_ip, hostname, COUNT(*), MIN(timestamp), MAX(timestamp)
+        "SELECT source_ip, hostname, COUNT(*), MIN(received_at), MAX(received_at)
          FROM logs
          WHERE source_ip != ''
          GROUP BY source_ip, hostname
@@ -311,12 +314,26 @@ pub struct PatternEntry {
 /// Normalise a message into a template by replacing variable runs with
 /// placeholders. Designed to collapse near-duplicates without external regex
 /// dependencies — character-class scan only.
+///
+/// Pattern detection is byte-level (all targets — digits, hex, IPv4, UUIDs —
+/// are ASCII), but non-ASCII bytes are passed through as their proper
+/// codepoint so internationalised log messages stay valid UTF-8.
 pub fn normalize_template(msg: &str) -> String {
     let bytes = msg.as_bytes();
     let mut out = String::with_capacity(msg.len());
     let mut i = 0;
     while i < bytes.len() {
         let b = bytes[i];
+        if !b.is_ascii() {
+            // Multi-byte UTF-8 sequence — copy the whole codepoint intact rather
+            // than splitting it into mojibake. Indexing `msg[i..]` is safe because
+            // the index lands on a char boundary (we only advance by char widths
+            // or full ASCII pattern matches).
+            let ch = msg[i..].chars().next().expect("char at boundary");
+            out.push(ch);
+            i += ch.len_utf8();
+            continue;
+        }
         // UUID: 8-4-4-4-12 hex with dashes
         if is_hex(b) && looks_like_uuid_at(bytes, i) {
             out.push_str("<uuid>");
@@ -541,7 +558,11 @@ pub fn patterns(
 // -----------------------------------------------------------------------------
 
 pub struct ContextRef {
-    pub id: i64,
+    /// `Some(id)` anchors with stable (timestamp, id) tiebreaking; `None` means
+    /// the caller only has a timestamp (e.g. `context` invoked with
+    /// `hostname` + `timestamp`), in which case the query splits cleanly on
+    /// `< timestamp` / `> timestamp`.
+    pub id: Option<i64>,
     pub hostname: String,
     pub timestamp: String,
 }
@@ -571,45 +592,83 @@ pub fn context_around(
     let before = before.min(500);
     let after = after.min(500);
 
-    // Before: timestamp < ref OR (timestamp = ref AND id < ref.id)
-    let mut before_stmt = conn.prepare(
-        "SELECT id, timestamp, hostname, facility, severity,
-                app_name, process_id, message, received_at, source_ip
-         FROM logs
-         WHERE hostname = ?1
-           AND (timestamp < ?2 OR (timestamp = ?2 AND id < ?3))
-         ORDER BY timestamp DESC, id DESC
-         LIMIT ?4",
-    )?;
-    let mut before_rows = before_stmt
-        .query_map(
-            params![
-                reference.hostname,
-                reference.timestamp,
-                reference.id,
-                before
-            ],
-            super::queries::map_row,
-        )?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    // Reverse so the result reads chronologically.
-    before_rows.reverse();
+    let (mut before_rows, after_rows) = match reference.id {
+        Some(id) => {
+            // ID-anchored: stable (timestamp, id) tiebreaker — symmetrical because
+            // we know exactly which row at `timestamp` is the reference.
+            let mut before_stmt = conn.prepare(
+                "SELECT id, timestamp, hostname, facility, severity,
+                        app_name, process_id, message, received_at, source_ip
+                 FROM logs
+                 WHERE hostname = ?1
+                   AND (timestamp < ?2 OR (timestamp = ?2 AND id < ?3))
+                 ORDER BY timestamp DESC, id DESC
+                 LIMIT ?4",
+            )?;
+            let before_rows = before_stmt
+                .query_map(
+                    params![reference.hostname, reference.timestamp, id, before],
+                    super::queries::map_row,
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
 
-    let mut after_stmt = conn.prepare(
-        "SELECT id, timestamp, hostname, facility, severity,
-                app_name, process_id, message, received_at, source_ip
-         FROM logs
-         WHERE hostname = ?1
-           AND (timestamp > ?2 OR (timestamp = ?2 AND id > ?3))
-         ORDER BY timestamp ASC, id ASC
-         LIMIT ?4",
-    )?;
-    let after_rows = after_stmt
-        .query_map(
-            params![reference.hostname, reference.timestamp, reference.id, after],
-            super::queries::map_row,
-        )?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+            let mut after_stmt = conn.prepare(
+                "SELECT id, timestamp, hostname, facility, severity,
+                        app_name, process_id, message, received_at, source_ip
+                 FROM logs
+                 WHERE hostname = ?1
+                   AND (timestamp > ?2 OR (timestamp = ?2 AND id > ?3))
+                 ORDER BY timestamp ASC, id ASC
+                 LIMIT ?4",
+            )?;
+            let after_rows = after_stmt
+                .query_map(
+                    params![reference.hostname, reference.timestamp, id, after],
+                    super::queries::map_row,
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            (before_rows, after_rows)
+        }
+        None => {
+            // Timestamp-anchored: no row identity, so split strictly on the
+            // timestamp boundary. Rows that share the exact reference timestamp
+            // are excluded from both sides rather than dumped onto one —
+            // symmetry over completeness.
+            let mut before_stmt = conn.prepare(
+                "SELECT id, timestamp, hostname, facility, severity,
+                        app_name, process_id, message, received_at, source_ip
+                 FROM logs
+                 WHERE hostname = ?1 AND timestamp < ?2
+                 ORDER BY timestamp DESC, id DESC
+                 LIMIT ?3",
+            )?;
+            let before_rows = before_stmt
+                .query_map(
+                    params![reference.hostname, reference.timestamp, before],
+                    super::queries::map_row,
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+
+            let mut after_stmt = conn.prepare(
+                "SELECT id, timestamp, hostname, facility, severity,
+                        app_name, process_id, message, received_at, source_ip
+                 FROM logs
+                 WHERE hostname = ?1 AND timestamp > ?2
+                 ORDER BY timestamp ASC, id ASC
+                 LIMIT ?3",
+            )?;
+            let after_rows = after_stmt
+                .query_map(
+                    params![reference.hostname, reference.timestamp, after],
+                    super::queries::map_row,
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            (before_rows, after_rows)
+        }
+    };
+
+    // Reverse the "before" rows so the result reads chronologically.
+    before_rows.reverse();
 
     Ok((before_rows, after_rows))
 }

--- a/src/db/analytics.rs
+++ b/src/db/analytics.rs
@@ -8,6 +8,7 @@
 
 use anyhow::Result;
 use rusqlite::params;
+use std::cmp::Reverse;
 use std::collections::BTreeMap;
 
 use super::pool::DbPool;
@@ -143,7 +144,7 @@ pub fn list_source_ips(pool: &DbPool) -> Result<Vec<SourceIpEntry>> {
     }
 
     let mut out: Vec<SourceIpEntry> = by_ip.into_values().collect();
-    out.sort_by(|a, b| b.log_count.cmp(&a.log_count));
+    out.sort_by_key(|entry| Reverse(entry.log_count));
     Ok(out)
 }
 
@@ -534,7 +535,7 @@ pub fn patterns(
         .into_iter()
         .map(|(template, acc)| {
             let mut hosts: Vec<(String, i64)> = acc.hosts.into_iter().collect();
-            hosts.sort_by(|a, b| b.1.cmp(&a.1));
+            hosts.sort_by_key(|(_, count)| Reverse(*count));
             let host_count = hosts.len() as i64;
             let hostnames: Vec<String> = hosts.into_iter().take(5).map(|(h, _)| h).collect();
             PatternEntry {
@@ -548,7 +549,7 @@ pub fn patterns(
             }
         })
         .collect();
-    out.sort_by(|a, b| b.count.cmp(&a.count));
+    out.sort_by_key(|entry| Reverse(entry.count));
     out.truncate(top_n as usize);
     Ok((out, total_scanned, overflow))
 }

--- a/src/db/analytics_tests.rs
+++ b/src/db/analytics_tests.rs
@@ -172,8 +172,8 @@ fn context_around_returns_neighbours() {
     let (before, after) = context_around(&pool, &r, 3, 3).unwrap();
     assert_eq!(before.len(), 3);
     assert_eq!(after.len(), 3);
-    assert!(before.last().unwrap().timestamp.as_str() <= "2026-01-01T00:00:04Z");
-    assert!(after.first().unwrap().timestamp.as_str() >= "2026-01-01T00:00:04Z");
+    assert!(before.last().unwrap().timestamp.as_str() < "2026-01-01T00:00:04Z");
+    assert!(after.first().unwrap().timestamp.as_str() > "2026-01-01T00:00:04Z");
 }
 
 #[test]

--- a/src/db/analytics_tests.rs
+++ b/src/db/analytics_tests.rs
@@ -34,6 +34,18 @@ fn template_normalises_numbers_ips_uuids() {
 }
 
 #[test]
+fn template_preserves_non_ascii_codepoints() {
+    // Multi-byte UTF-8 sequences must round-trip rather than getting split into
+    // mojibake by `b as char`.
+    let msg = "файл 1234 не найден";
+    let t = normalize_template(msg);
+    assert!(t.contains("файл"));
+    assert!(t.contains("не найден"));
+    assert!(t.contains("<n>"));
+    assert!(t.is_char_boundary(t.len()));
+}
+
+#[test]
 fn list_apps_returns_distinct_apps_with_counts() {
     let (pool, _d) = test_pool();
     insert_logs_batch(
@@ -153,7 +165,7 @@ fn context_around_returns_neighbours() {
     }
     insert_logs_batch(&pool, &entries).unwrap();
     let r = ContextRef {
-        id: 5,
+        id: Some(5),
         hostname: "h1".to_string(),
         timestamp: "2026-01-01T00:00:04Z".to_string(),
     };
@@ -162,6 +174,53 @@ fn context_around_returns_neighbours() {
     assert_eq!(after.len(), 3);
     assert!(before.last().unwrap().timestamp.as_str() <= "2026-01-01T00:00:04Z");
     assert!(after.first().unwrap().timestamp.as_str() >= "2026-01-01T00:00:04Z");
+}
+
+#[test]
+fn context_timestamp_only_anchor_splits_symmetrically() {
+    // Two rows share the exact reference timestamp; with id=None they must not
+    // all land on one side. The before/after split is strict on `< ts` / `> ts`,
+    // so simultaneous rows are excluded from both — consistent regardless of id ordering.
+    let (pool, _d) = test_pool();
+    let mut entries = Vec::new();
+    for i in 0..5 {
+        entries.push(entry(
+            &format!("2026-01-01T00:00:{:02}Z", i),
+            "h1",
+            "info",
+            None,
+            "msg",
+        ));
+    }
+    // Two rows at the exact reference time.
+    entries.push(entry("2026-01-01T00:00:05Z", "h1", "info", None, "ref-a"));
+    entries.push(entry("2026-01-01T00:00:05Z", "h1", "info", None, "ref-b"));
+    for i in 6..10 {
+        entries.push(entry(
+            &format!("2026-01-01T00:00:{:02}Z", i),
+            "h1",
+            "info",
+            None,
+            "msg",
+        ));
+    }
+    insert_logs_batch(&pool, &entries).unwrap();
+
+    let r = ContextRef {
+        id: None,
+        hostname: "h1".to_string(),
+        timestamp: "2026-01-01T00:00:05Z".to_string(),
+    };
+    let (before, after) = context_around(&pool, &r, 10, 10).unwrap();
+    // 5 strictly-less timestamps, 4 strictly-greater. Neither contains a row at 05.
+    assert_eq!(before.len(), 5);
+    assert_eq!(after.len(), 4);
+    assert!(before
+        .iter()
+        .all(|r| r.timestamp.as_str() < "2026-01-01T00:00:05Z"));
+    assert!(after
+        .iter()
+        .all(|r| r.timestamp.as_str() > "2026-01-01T00:00:05Z"));
 }
 
 #[test]

--- a/src/db/analytics_tests.rs
+++ b/src/db/analytics_tests.rs
@@ -10,6 +10,17 @@ fn test_pool() -> (DbPool, tempfile::TempDir) {
 }
 
 fn entry(ts: &str, host: &str, severity: &str, app: Option<&str>, msg: &str) -> LogBatchEntry {
+    entry_with_source_ip(ts, host, severity, app, msg, "127.0.0.1:514")
+}
+
+fn entry_with_source_ip(
+    ts: &str,
+    host: &str,
+    severity: &str,
+    app: Option<&str>,
+    msg: &str,
+    source_ip: &str,
+) -> LogBatchEntry {
     LogBatchEntry {
         timestamp: ts.to_string(),
         hostname: host.to_string(),
@@ -19,7 +30,7 @@ fn entry(ts: &str, host: &str, severity: &str, app: Option<&str>, msg: &str) -> 
         process_id: None,
         message: msg.to_string(),
         raw: format!("<14>{ts} {host} {}: {msg}", app.unwrap_or("test")),
-        source_ip: "127.0.0.1:514".to_string(),
+        source_ip: source_ip.to_string(),
         docker_checkpoint: None,
     }
 }
@@ -244,25 +255,41 @@ fn summarize_range_counts_errors() {
 #[test]
 fn list_source_ips_aggregates_hostnames() {
     let (pool, _d) = test_pool();
-    let make = |ts: &str, host: &str, ip: &str| LogBatchEntry {
-        timestamp: ts.to_string(),
-        hostname: host.to_string(),
-        facility: None,
-        severity: "info".to_string(),
-        app_name: None,
-        process_id: None,
-        message: "x".to_string(),
-        raw: "x".to_string(),
-        source_ip: ip.to_string(),
-        docker_checkpoint: None,
-    };
     insert_logs_batch(
         &pool,
         &[
-            make("2026-01-01T00:00:01Z", "h1", "10.0.0.1:514"),
-            make("2026-01-01T00:00:02Z", "h2", "10.0.0.1:514"),
-            make("2026-01-01T00:00:03Z", "h2", "10.0.0.1:514"),
-            make("2026-01-01T00:00:04Z", "h3", "10.0.0.2:514"),
+            entry_with_source_ip(
+                "2026-01-01T00:00:01Z",
+                "h1",
+                "info",
+                None,
+                "x",
+                "10.0.0.1:514",
+            ),
+            entry_with_source_ip(
+                "2026-01-01T00:00:02Z",
+                "h2",
+                "info",
+                None,
+                "x",
+                "10.0.0.1:514",
+            ),
+            entry_with_source_ip(
+                "2026-01-01T00:00:03Z",
+                "h2",
+                "info",
+                None,
+                "x",
+                "10.0.0.1:514",
+            ),
+            entry_with_source_ip(
+                "2026-01-01T00:00:04Z",
+                "h3",
+                "info",
+                None,
+                "x",
+                "10.0.0.2:514",
+            ),
         ],
     )
     .unwrap();

--- a/src/db/analytics_tests.rs
+++ b/src/db/analytics_tests.rs
@@ -1,0 +1,214 @@
+use super::*;
+use crate::config::StorageConfig;
+use crate::db::{init_pool, insert_logs_batch, DbPool, LogBatchEntry};
+
+fn test_pool() -> (DbPool, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test.db");
+    let pool = init_pool(&StorageConfig::for_test(db_path)).unwrap();
+    (pool, dir)
+}
+
+fn entry(ts: &str, host: &str, severity: &str, app: Option<&str>, msg: &str) -> LogBatchEntry {
+    LogBatchEntry {
+        timestamp: ts.to_string(),
+        hostname: host.to_string(),
+        facility: None,
+        severity: severity.to_string(),
+        app_name: app.map(String::from),
+        process_id: None,
+        message: msg.to_string(),
+        raw: format!("<14>{ts} {host} {}: {msg}", app.unwrap_or("test")),
+        source_ip: "127.0.0.1:514".to_string(),
+        docker_checkpoint: None,
+    }
+}
+
+#[test]
+fn template_normalises_numbers_ips_uuids() {
+    let t = normalize_template(
+        "connection refused from 10.0.0.5:42 (id b3a1c0de-1234-5678-9abc-def012345678)",
+    );
+    assert!(t.contains("<ip>:<n>"));
+    assert!(t.contains("<uuid>"));
+}
+
+#[test]
+fn list_apps_returns_distinct_apps_with_counts() {
+    let (pool, _d) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            entry("2026-01-01T00:00:01Z", "h1", "info", Some("nginx"), "hello"),
+            entry("2026-01-01T00:00:02Z", "h1", "info", Some("nginx"), "again"),
+            entry(
+                "2026-01-01T00:00:03Z",
+                "h2",
+                "info",
+                Some("sshd"),
+                "auth ok",
+            ),
+        ],
+    )
+    .unwrap();
+
+    let apps = list_apps(&pool, None).unwrap();
+    let nginx = apps.iter().find(|a| a.app_name == "nginx").unwrap();
+    assert_eq!(nginx.log_count, 2);
+    assert_eq!(nginx.host_count, 1);
+
+    // Filter by hostname
+    let only_h2 = list_apps(&pool, Some("h2")).unwrap();
+    assert_eq!(only_h2.len(), 1);
+    assert_eq!(only_h2[0].app_name, "sshd");
+}
+
+#[test]
+fn timeline_buckets_by_hour() {
+    let (pool, _d) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            entry("2026-01-01T00:10:00Z", "h1", "info", None, "a"),
+            entry("2026-01-01T00:50:00Z", "h1", "info", None, "b"),
+            entry("2026-01-01T01:05:00Z", "h1", "info", None, "c"),
+        ],
+    )
+    .unwrap();
+    let pts = timeline(
+        &pool,
+        Bucket::Hour,
+        TimelineGroupBy::None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+    assert_eq!(pts.len(), 2);
+    assert_eq!(pts[0].count, 2);
+    assert_eq!(pts[1].count, 1);
+}
+
+#[test]
+fn patterns_clusters_by_template() {
+    let (pool, _d) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            entry(
+                "2026-01-01T00:00:01Z",
+                "h1",
+                "err",
+                None,
+                "disk 1234 failed",
+            ),
+            entry(
+                "2026-01-01T00:00:02Z",
+                "h1",
+                "err",
+                None,
+                "disk 9999 failed",
+            ),
+            entry("2026-01-01T00:00:03Z", "h2", "err", None, "disk 5 failed"),
+            entry("2026-01-01T00:00:04Z", "h1", "info", None, "all good"),
+        ],
+    )
+    .unwrap();
+    let (pats, scanned, truncated) =
+        patterns(&pool, None, None, None, None, None, 100, 10).unwrap();
+    assert!(!truncated);
+    assert_eq!(scanned, 4);
+    let top = &pats[0];
+    assert_eq!(top.count, 3);
+    assert_eq!(top.host_count, 2);
+}
+
+#[test]
+fn fetch_log_by_id_returns_raw() {
+    let (pool, _d) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[entry("2026-01-01T00:00:01Z", "h1", "info", None, "hello")],
+    )
+    .unwrap();
+    let row = fetch_log_by_id(&pool, 1).unwrap().unwrap();
+    assert_eq!(row.message, "hello");
+    assert!(row.raw.contains("hello"));
+}
+
+#[test]
+fn context_around_returns_neighbours() {
+    let (pool, _d) = test_pool();
+    let mut entries = Vec::new();
+    for i in 0..10 {
+        entries.push(entry(
+            &format!("2026-01-01T00:00:{:02}Z", i),
+            "h1",
+            "info",
+            None,
+            &format!("msg {i}"),
+        ));
+    }
+    insert_logs_batch(&pool, &entries).unwrap();
+    let r = ContextRef {
+        id: 5,
+        hostname: "h1".to_string(),
+        timestamp: "2026-01-01T00:00:04Z".to_string(),
+    };
+    let (before, after) = context_around(&pool, &r, 3, 3).unwrap();
+    assert_eq!(before.len(), 3);
+    assert_eq!(after.len(), 3);
+    assert!(before.last().unwrap().timestamp.as_str() <= "2026-01-01T00:00:04Z");
+    assert!(after.first().unwrap().timestamp.as_str() >= "2026-01-01T00:00:04Z");
+}
+
+#[test]
+fn summarize_range_counts_errors() {
+    let (pool, _d) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            entry("2026-01-01T00:00:01Z", "h1", "err", Some("a"), "x"),
+            entry("2026-01-01T00:00:02Z", "h1", "info", Some("a"), "y"),
+            entry("2026-01-01T00:00:03Z", "h2", "warning", Some("b"), "z"),
+        ],
+    )
+    .unwrap();
+    let summary = summarize_range(&pool, "2026-01-01T00:00:00Z", "2026-01-01T00:00:10Z").unwrap();
+    assert_eq!(summary.total_logs, 3);
+    assert_eq!(summary.total_errors, 2);
+    assert_eq!(summary.top_apps.len(), 2);
+}
+
+#[test]
+fn list_source_ips_aggregates_hostnames() {
+    let (pool, _d) = test_pool();
+    let make = |ts: &str, host: &str, ip: &str| LogBatchEntry {
+        timestamp: ts.to_string(),
+        hostname: host.to_string(),
+        facility: None,
+        severity: "info".to_string(),
+        app_name: None,
+        process_id: None,
+        message: "x".to_string(),
+        raw: "x".to_string(),
+        source_ip: ip.to_string(),
+        docker_checkpoint: None,
+    };
+    insert_logs_batch(
+        &pool,
+        &[
+            make("2026-01-01T00:00:01Z", "h1", "10.0.0.1:514"),
+            make("2026-01-01T00:00:02Z", "h2", "10.0.0.1:514"),
+            make("2026-01-01T00:00:03Z", "h2", "10.0.0.1:514"),
+            make("2026-01-01T00:00:04Z", "h3", "10.0.0.2:514"),
+        ],
+    )
+    .unwrap();
+    let ips = list_source_ips(&pool).unwrap();
+    let first = ips.iter().find(|e| e.source_ip == "10.0.0.1:514").unwrap();
+    assert_eq!(first.host_count, 2);
+    assert_eq!(first.log_count, 3);
+}

--- a/src/db/ingest_tests.rs
+++ b/src/db/ingest_tests.rs
@@ -41,7 +41,7 @@ fn test_insert_and_tail() {
     let n = insert_logs_batch(&pool, &entries).unwrap();
     assert_eq!(n, 3);
 
-    let rows = tail_logs(&pool, None, None, None, 10).unwrap();
+    let rows = tail_logs(&pool, None, None, None, None, 10).unwrap();
     assert_eq!(rows.len(), 3);
 }
 
@@ -85,7 +85,7 @@ fn test_batch_empty() {
     assert!(result.is_ok(), "empty batch should not error");
     assert_eq!(result.unwrap(), 0);
 
-    let rows = tail_logs(&pool, None, None, None, 10).unwrap();
+    let rows = tail_logs(&pool, None, None, None, None, 10).unwrap();
     assert_eq!(rows.len(), 0, "no rows should exist after empty batch");
 
     let hosts = list_hosts(&pool).unwrap();

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -86,7 +86,7 @@ fn test_purge_old_logs_removes_old() {
     let deleted = purge_old_logs(&pool, 90, 0).unwrap();
     assert_eq!(deleted, 1, "should have deleted exactly the old entry");
 
-    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    let remaining = tail_logs(&pool, None, None, None, None, 10).unwrap();
     assert_eq!(remaining.len(), 1);
     assert_eq!(remaining[0].message, "future message");
 }
@@ -122,7 +122,7 @@ fn test_enforce_storage_budget_deletes_by_received_at_until_recovery_target() {
     assert!(outcome.deleted_rows > 0);
     assert!(outcome.metrics.logical_db_size_bytes <= outcome.recovery.logical_db_size_bytes);
 
-    let rows = tail_logs(&pool, None, None, None, 10).unwrap();
+    let rows = tail_logs(&pool, None, None, None, None, 10).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].message, large_new);
 }

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -264,7 +264,7 @@ fn test_purge_by_tag_window_zero_days_is_noop() {
     let deleted = super::purge_by_tag_window(&pool, "adguard-allowed", 0, 0).unwrap();
     assert_eq!(deleted, 0, "max_days=0 must be a no-op");
 
-    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    let remaining = tail_logs(&pool, None, None, None, None, 10).unwrap();
     assert_eq!(remaining.len(), 1, "row must still be present");
 }
 
@@ -294,7 +294,7 @@ fn test_purge_by_tag_window_only_targets_named_tag() {
     let deleted = super::purge_by_tag_window(&pool, "adguard-allowed", 7, 0).unwrap();
     assert_eq!(deleted, 1, "only the adguard-allowed row must be deleted");
 
-    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    let remaining = tail_logs(&pool, None, None, None, None, 10).unwrap();
     let messages: Vec<&str> = remaining.iter().map(|r| r.message.as_str()).collect();
     assert!(messages.contains(&"old-nginx"), "nginx must survive");
     assert!(messages.contains(&"old-kernel"), "kernel must survive");
@@ -341,7 +341,7 @@ fn test_purge_by_tag_window_excludes_high_severity_rows() {
     let deleted = super::purge_by_tag_window(&pool, "adguard-allowed", 7, 0).unwrap();
     assert_eq!(deleted, 1, "only the info row should be purged");
 
-    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    let remaining = tail_logs(&pool, None, None, None, None, 10).unwrap();
     let messages: Vec<&str> = remaining.iter().map(|r| r.message.as_str()).collect();
     assert!(
         messages.contains(&"err-old"),
@@ -387,7 +387,7 @@ fn test_purge_by_tag_window_respects_cutoff_boundary() {
     let deleted = super::purge_by_tag_window(&pool, "adguard-allowed", 7, 0).unwrap();
     assert_eq!(deleted, 1, "only the old row should be deleted");
 
-    let remaining = tail_logs(&pool, None, None, None, 10).unwrap();
+    let remaining = tail_logs(&pool, None, None, None, None, 10).unwrap();
     let messages: Vec<&str> = remaining.iter().map(|r| r.message.as_str()).collect();
     assert!(messages.contains(&"fresh"), "fresh row must survive");
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -31,10 +31,12 @@ pub struct DockerCheckpoint {
     pub timestamp: String,
 }
 
-/// Error/warning summary entry (one row per hostname+severity)
+/// Error/warning summary entry (one row per hostname+severity, plus optional app_name)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorSummaryEntry {
     pub hostname: String,
+    /// Populated when the summary was requested with `group_by=app_name`.
+    pub app_name: Option<String>,
     pub severity: String,
     pub count: i64,
 }
@@ -116,7 +118,7 @@ pub struct LogEntry {
 }
 
 /// Parameters for searching logs
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct SearchParams {
     /// Full-text search query (FTS5 syntax)
     pub query: Option<String>,
@@ -131,6 +133,10 @@ pub struct SearchParams {
     pub severity_in: Option<Vec<String>>,
     /// Filter by app name
     pub app_name: Option<String>,
+    /// Filter by syslog facility name (e.g. `kern`, `auth`, `daemon`)
+    pub facility: Option<String>,
+    /// Filter by process_id (exact match)
+    pub process_id: Option<String>,
     /// Start of time range (ISO 8601)
     pub from: Option<String>,
     /// End of time range (ISO 8601)

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -127,6 +127,8 @@ pub fn tail_logs(
                     idx += 1;
                 }
             }
+            idx += levels.len();
+            debug_assert_eq!(bindings.len() + 1, idx);
         }
     }
 

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -122,6 +122,10 @@ pub fn tail_logs(
             sql.push_str(&format!(" AND severity IN ({})", placeholders.join(", ")));
             for lvl in levels {
                 bindings.push(Box::new(lvl.clone()));
+                #[allow(unused_assignments)]
+                {
+                    idx += 1;
+                }
             }
         }
     }

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -86,6 +86,7 @@ pub fn tail_logs(
     hostname: Option<&str>,
     source_ip: Option<&str>,
     app_name: Option<&str>,
+    severity_in: Option<&[String]>,
     n: u32,
 ) -> Result<Vec<LogEntry>> {
     let conn = pool.get()?;
@@ -112,6 +113,17 @@ pub fn tail_logs(
     if let Some(a) = app_name {
         sql.push_str(&format!(" AND app_name = ?{idx}"));
         bindings.push(Box::new(a.to_string()));
+        idx += 1;
+    }
+    if let Some(levels) = severity_in {
+        if !levels.is_empty() {
+            let placeholders: Vec<String> =
+                (0..levels.len()).map(|i| format!("?{}", idx + i)).collect();
+            sql.push_str(&format!(" AND severity IN ({})", placeholders.join(", ")));
+            for lvl in levels {
+                bindings.push(Box::new(lvl.clone()));
+            }
+        }
     }
 
     sql.push_str(&format!(" ORDER BY timestamp DESC LIMIT {n}"));
@@ -124,11 +136,13 @@ pub fn tail_logs(
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
-/// Get error/warning summary per host in a time window
+/// Get error/warning summary per host in a time window. When `group_by_app` is
+/// true, results also include `app_name` as a secondary grouping key.
 pub fn get_error_summary(
     pool: &DbPool,
     from: Option<&str>,
     to: Option<&str>,
+    group_by_app: bool,
 ) -> Result<Vec<ErrorSummaryEntry>> {
     let conn = pool.get()?;
 
@@ -136,24 +150,43 @@ pub fn get_error_summary(
     // Upper sentinel: any valid RFC 3339 timestamp will sort before this.
     let to = to.unwrap_or("9999-12-31T23:59:59Z");
 
-    let mut stmt = conn.prepare(
-        "SELECT hostname, severity, COUNT(*) as count
-         FROM logs
-         WHERE severity IN ('emerg', 'alert', 'crit', 'err', 'warning')
-           AND timestamp BETWEEN ?1 AND ?2
-         GROUP BY hostname, severity
-         ORDER BY hostname, count DESC",
-    )?;
-
-    let rows = stmt.query_map(params![from, to], |row| {
-        Ok(ErrorSummaryEntry {
-            hostname: row.get(0)?,
-            severity: row.get(1)?,
-            count: row.get(2)?,
-        })
-    })?;
-
-    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    if group_by_app {
+        let mut stmt = conn.prepare(
+            "SELECT hostname, app_name, severity, COUNT(*) as count
+             FROM logs
+             WHERE severity IN ('emerg', 'alert', 'crit', 'err', 'warning')
+               AND timestamp BETWEEN ?1 AND ?2
+             GROUP BY hostname, app_name, severity
+             ORDER BY hostname, app_name, count DESC",
+        )?;
+        let rows = stmt.query_map(params![from, to], |row| {
+            Ok(ErrorSummaryEntry {
+                hostname: row.get(0)?,
+                app_name: row.get::<_, Option<String>>(1)?,
+                severity: row.get(2)?,
+                count: row.get(3)?,
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    } else {
+        let mut stmt = conn.prepare(
+            "SELECT hostname, severity, COUNT(*) as count
+             FROM logs
+             WHERE severity IN ('emerg', 'alert', 'crit', 'err', 'warning')
+               AND timestamp BETWEEN ?1 AND ?2
+             GROUP BY hostname, severity
+             ORDER BY hostname, count DESC",
+        )?;
+        let rows = stmt.query_map(params![from, to], |row| {
+            Ok(ErrorSummaryEntry {
+                hostname: row.get(0)?,
+                app_name: None,
+                severity: row.get(1)?,
+                count: row.get(2)?,
+            })
+        })?;
+        Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    }
 }
 
 /// List all known hosts with stats
@@ -271,6 +304,16 @@ fn append_filters(
         bindings.push(rusqlite::types::Value::Text(a.clone()));
         *idx += 1;
     }
+    if let Some(ref f) = params.facility {
+        sql.push_str(&format!(" AND l.facility = ?{}", *idx));
+        bindings.push(rusqlite::types::Value::Text(f.clone()));
+        *idx += 1;
+    }
+    if let Some(ref pid) = params.process_id {
+        sql.push_str(&format!(" AND l.process_id = ?{}", *idx));
+        bindings.push(rusqlite::types::Value::Text(pid.clone()));
+        *idx += 1;
+    }
     if let Some(ref from) = params.from {
         sql.push_str(&format!(" AND l.timestamp >= ?{}", *idx));
         bindings.push(rusqlite::types::Value::Text(from.clone()));
@@ -283,7 +326,7 @@ fn append_filters(
     }
 }
 
-fn map_row(row: &rusqlite::Row) -> rusqlite::Result<LogEntry> {
+pub(super) fn map_row(row: &rusqlite::Row) -> rusqlite::Result<LogEntry> {
     Ok(LogEntry {
         id: row.get(0)?,
         timestamp: row.get(1)?,
@@ -295,6 +338,25 @@ fn map_row(row: &rusqlite::Row) -> rusqlite::Result<LogEntry> {
         message: row.get(7)?,
         received_at: row.get(8)?,
         source_ip: row.get(9)?,
+    })
+}
+
+/// Map a row that includes the unparsed `raw` syslog frame (column index 8).
+pub(super) fn map_row_with_raw(
+    row: &rusqlite::Row,
+) -> rusqlite::Result<super::analytics::LogEntryWithRaw> {
+    Ok(super::analytics::LogEntryWithRaw {
+        id: row.get(0)?,
+        timestamp: row.get(1)?,
+        hostname: row.get(2)?,
+        facility: row.get(3)?,
+        severity: row.get(4)?,
+        app_name: row.get(5)?,
+        process_id: row.get(6)?,
+        message: row.get(7)?,
+        raw: row.get(8)?,
+        received_at: row.get(9)?,
+        source_ip: row.get(10)?,
     })
 }
 

--- a/src/db/queries_tests.rs
+++ b/src/db/queries_tests.rs
@@ -56,6 +56,8 @@ fn test_search_fts() {
         severity: None,
         severity_in: None,
         app_name: None,
+        facility: None,
+        process_id: None,
         from: None,
         to: None,
         limit: None,
@@ -76,6 +78,8 @@ fn test_search_invalid_fts_returns_error() {
         severity: None,
         severity_in: None,
         app_name: None,
+        facility: None,
+        process_id: None,
         from: None,
         to: None,
         limit: None,
@@ -148,7 +152,7 @@ fn test_tail_filter_by_host() {
     ];
     insert_logs_batch(&pool, &entries).unwrap();
 
-    let rows = tail_logs(&pool, Some("host-a"), None, None, 10).unwrap();
+    let rows = tail_logs(&pool, Some("host-a"), None, None, None, 10).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].hostname, "host-a");
 }
@@ -171,6 +175,8 @@ fn test_search_timestamp_range_filtering() {
         severity: None,
         severity_in: None,
         app_name: None,
+        facility: None,
+        process_id: None,
         from: Some("2026-06-01T00:00:00Z".into()),
         to: None,
         limit: None,
@@ -186,6 +192,8 @@ fn test_search_timestamp_range_filtering() {
         severity: None,
         severity_in: None,
         app_name: None,
+        facility: None,
+        process_id: None,
         from: None,
         to: Some("2026-06-30T00:00:00Z".into()),
         limit: None,
@@ -201,6 +209,8 @@ fn test_search_timestamp_range_filtering() {
         severity: None,
         severity_in: None,
         app_name: None,
+        facility: None,
+        process_id: None,
         from: Some("2026-06-01T00:00:00Z".into()),
         to: Some("2026-06-30T00:00:00Z".into()),
         limit: None,
@@ -242,7 +252,7 @@ fn test_error_summary_severity_filter() {
     ];
     insert_logs_batch(&pool, &entries).unwrap();
 
-    let summary = get_error_summary(&pool, None, None).unwrap();
+    let summary = get_error_summary(&pool, None, None, false).unwrap();
     // Only err and warning should appear (not info, debug)
     assert_eq!(summary.len(), 2);
     let severities: Vec<&str> = summary.iter().map(|e| e.severity.as_str()).collect();
@@ -269,6 +279,8 @@ fn test_search_severity_in_filter() {
         severity: None,
         severity_in: Some(vec!["emerg".into(), "err".into(), "warning".into()]),
         app_name: None,
+        facility: None,
+        process_id: None,
         from: None,
         to: None,
         limit: None,
@@ -313,6 +325,8 @@ fn search_logs_ignores_deleted_fts_phantom_rows() {
         severity: None,
         severity_in: None,
         app_name: None,
+        facility: None,
+        process_id: None,
         from: None,
         to: None,
         limit: None,

--- a/src/docker_ingest/parser.rs
+++ b/src/docker_ingest/parser.rs
@@ -48,7 +48,10 @@ fn split_docker_timestamp(raw: &str) -> (String, String) {
         Some((ts, rest)) if chrono::DateTime::parse_from_rfc3339(ts).is_ok() => {
             (ts.to_string(), rest.to_string())
         }
-        _ => (chrono::Utc::now().to_rfc3339(), raw.to_string()),
+        _ => (
+            chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            raw.to_string(),
+        ),
     }
 }
 

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -9,6 +9,17 @@ pub(super) const SYSLOG_ACTIONS: &[&str] = &[
     "correlate",
     "stats",
     "status",
+    "apps",
+    "source_ips",
+    "timeline",
+    "patterns",
+    "context",
+    "get",
+    "ingest_rate",
+    "silent_hosts",
+    "clock_skew",
+    "anomalies",
+    "compare",
     "help",
 ];
 
@@ -16,14 +27,14 @@ pub(super) const SYSLOG_ACTIONS: &[&str] = &[
 pub(super) fn tool_definitions() -> Vec<Value> {
     vec![json!({
         "name": "syslog",
-        "description": "Query syslog-mcp logs with action-based subcommands: syslog search, syslog tail, syslog errors, syslog hosts, syslog correlate, syslog stats, syslog status, and syslog help.",
+        "description": "Query syslog-mcp logs with action-based subcommands: syslog search, syslog tail, syslog errors, syslog hosts, syslog correlate, syslog stats, syslog status, syslog apps, syslog source_ips, syslog timeline, syslog patterns, syslog context, syslog get, syslog ingest_rate, syslog silent_hosts, syslog clock_skew, syslog anomalies, syslog compare, and syslog help.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
                     "enum": SYSLOG_ACTIONS,
-                    "description": "Action to run: search, tail, errors, hosts, correlate, stats, status, or help."
+                    "description": "Action to run. Supported actions are listed in the enum."
                 },
                 "query": {
                     "type": "string",
@@ -31,7 +42,7 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 },
                 "hostname": {
                     "type": "string",
-                    "description": "For action=search, tail, or correlate: exact hostname filter. Use action=hosts to enumerate."
+                    "description": "For action=search, tail, correlate, apps, timeline, patterns, or context: exact hostname filter. Use action=hosts to enumerate."
                 },
                 "source_ip": {
                     "type": "string",
@@ -45,19 +56,27 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 "severity_min": {
                     "type": "string",
                     "enum": SEVERITY_LEVELS,
-                    "description": "For action=correlate: minimum severity to include. Defaults to warning."
+                    "description": "For action=tail, correlate, timeline, or patterns: minimum severity to include."
                 },
                 "app_name": {
                     "type": "string",
-                    "description": "For action=search or action=tail: application name filter, e.g. sshd, dockerd, kernel."
+                    "description": "For action=search, tail, timeline, or patterns: application name filter, e.g. sshd, dockerd, kernel."
+                },
+                "facility": {
+                    "type": "string",
+                    "description": "For action=search: syslog facility filter, e.g. kern, auth, daemon."
+                },
+                "process_id": {
+                    "type": "string",
+                    "description": "For action=search: exact process_id filter."
                 },
                 "from": {
                     "type": "string",
-                    "description": "For action=search or action=errors: start of time range as ISO 8601/RFC3339."
+                    "description": "For action=search, errors, timeline, or patterns: start of time range as ISO 8601/RFC3339."
                 },
                 "to": {
                     "type": "string",
-                    "description": "For action=search or action=errors: end of time range as ISO 8601/RFC3339."
+                    "description": "For action=search, errors, timeline, or patterns: end of time range as ISO 8601/RFC3339."
                 },
                 "limit": {
                     "type": "integer",
@@ -74,6 +93,80 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 "window_minutes": {
                     "type": "integer",
                     "description": "For action=correlate: minutes before and after reference_time to search, default 5, max 60."
+                },
+                "group_by": {
+                    "type": "string",
+                    "enum": ["app_name", "hostname", "host", "severity", "sev", "app"],
+                    "description": "For action=errors: app_name. For action=timeline: hostname, severity, or app_name."
+                },
+                "bucket": {
+                    "type": "string",
+                    "enum": ["minute", "min", "m", "hour", "h", "day", "d"],
+                    "description": "For action=timeline: time bucket size."
+                },
+                "scan_limit": {
+                    "type": "integer",
+                    "description": "For action=patterns: max messages to scan, default 10000, max 50000."
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": "For action=patterns: max templates to return, default 20, max 200."
+                },
+                "log_id": {
+                    "type": "integer",
+                    "description": "For action=context: existing log id to anchor surrounding logs."
+                },
+                "timestamp": {
+                    "type": "string",
+                    "description": "For action=context: anchor timestamp when log_id is not provided."
+                },
+                "before": {
+                    "type": "integer",
+                    "description": "For action=context: entries before the reference, default 10, max 500."
+                },
+                "after": {
+                    "type": "integer",
+                    "description": "For action=context: entries after the reference, default 10, max 500."
+                },
+                "id": {
+                    "type": "integer",
+                    "description": "For action=get: log id to fetch."
+                },
+                "by_host": {
+                    "type": "boolean",
+                    "description": "For action=ingest_rate: include per-host buckets."
+                },
+                "silent_minutes": {
+                    "type": "integer",
+                    "description": "For action=silent_hosts: staleness threshold, default 30, max 10080."
+                },
+                "since": {
+                    "type": "string",
+                    "description": "For action=clock_skew: sample entries with received_at >= since."
+                },
+                "recent_minutes": {
+                    "type": "integer",
+                    "description": "For action=anomalies: recent window, default 15, max 1440."
+                },
+                "baseline_minutes": {
+                    "type": "integer",
+                    "description": "For action=anomalies: baseline window before recent window, default 360, max 10080."
+                },
+                "a_from": {
+                    "type": "string",
+                    "description": "For action=compare: first range start as ISO 8601/RFC3339."
+                },
+                "a_to": {
+                    "type": "string",
+                    "description": "For action=compare: first range end as ISO 8601/RFC3339."
+                },
+                "b_from": {
+                    "type": "string",
+                    "description": "For action=compare: second range start as ISO 8601/RFC3339."
+                },
+                "b_to": {
+                    "type": "string",
+                    "description": "For action=compare: second range end as ISO 8601/RFC3339."
                 }
             },
             "required": ["action"]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,10 @@
 use serde_json::{json, Value};
 
-use crate::app::{CorrelateEventsRequest, GetErrorsRequest, SearchLogsRequest, TailLogsRequest};
+use crate::app::{
+    AnomaliesRequest, ClockSkewRequest, CompareRequest, ContextRequest, CorrelateEventsRequest,
+    GetErrorsRequest, GetLogRequest, IngestRateRequest, ListAppsRequest, PatternsRequest,
+    SearchLogsRequest, SilentHostsRequest, TailLogsRequest, TimelineRequest,
+};
 
 use super::schemas::SYSLOG_ACTIONS;
 use super::AppState;
@@ -28,6 +32,17 @@ async fn tool_syslog(state: &AppState, args: Value) -> anyhow::Result<Value> {
         "correlate" => tool_correlate_events(state, args).await,
         "stats" => tool_get_stats(state, args).await,
         "status" => tool_get_status(state, args).await,
+        "apps" => tool_list_apps(state, args).await,
+        "source_ips" => tool_list_source_ips(state).await,
+        "timeline" => tool_timeline(state, args).await,
+        "patterns" => tool_patterns(state, args).await,
+        "context" => tool_context(state, args).await,
+        "get" => tool_get_log(state, args).await,
+        "ingest_rate" => tool_ingest_rate(state, args).await,
+        "silent_hosts" => tool_silent_hosts(state, args).await,
+        "clock_skew" => tool_clock_skew(state, args).await,
+        "anomalies" => tool_anomalies(state, args).await,
+        "compare" => tool_compare(state, args).await,
         "help" => tool_syslog_help().await,
         _ => Err(anyhow::anyhow!(
             "unknown syslog action: {action}; expected one of {}",
@@ -45,6 +60,8 @@ async fn tool_search_logs(state: &AppState, args: Value) -> anyhow::Result<Value
             source_ip: string_arg(&args, "source_ip"),
             severity: string_arg(&args, "severity"),
             app_name: string_arg(&args, "app_name"),
+            facility: string_arg(&args, "facility"),
+            process_id: string_arg(&args, "process_id"),
             from: string_arg(&args, "from"),
             to: string_arg(&args, "to"),
             limit: u32_arg(&args, "limit")?,
@@ -61,6 +78,7 @@ async fn tool_tail_logs(state: &AppState, args: Value) -> anyhow::Result<Value> 
             hostname: string_arg(&args, "hostname"),
             source_ip: string_arg(&args, "source_ip"),
             app_name: string_arg(&args, "app_name"),
+            severity_min: string_arg(&args, "severity_min"),
             n: u32_arg(&args, "n")?,
         })
         .await?;
@@ -74,12 +92,152 @@ async fn tool_get_errors(state: &AppState, args: Value) -> anyhow::Result<Value>
         .get_errors(GetErrorsRequest {
             from: string_arg(&args, "from"),
             to: string_arg(&args, "to"),
+            group_by: string_arg(&args, "group_by"),
         })
         .await?;
     tracing::debug!(
         summary_rows = response.summary.len(),
         "get_errors completed"
     );
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_list_apps(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let response = state
+        .service
+        .list_apps(ListAppsRequest {
+            hostname: string_arg(&args, "hostname"),
+        })
+        .await?;
+    tracing::debug!(app_count = response.apps.len(), "list_apps completed");
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_list_source_ips(state: &AppState) -> anyhow::Result<Value> {
+    let response = state.service.list_source_ips().await?;
+    tracing::debug!(
+        source_ip_count = response.source_ips.len(),
+        "list_source_ips completed"
+    );
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_timeline(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let response = state
+        .service
+        .timeline(TimelineRequest {
+            bucket: string_arg(&args, "bucket"),
+            group_by: string_arg(&args, "group_by"),
+            from: string_arg(&args, "from"),
+            to: string_arg(&args, "to"),
+            hostname: string_arg(&args, "hostname"),
+            app_name: string_arg(&args, "app_name"),
+            severity_min: string_arg(&args, "severity_min"),
+        })
+        .await?;
+    tracing::debug!(point_count = response.points.len(), "timeline completed");
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_patterns(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let response = state
+        .service
+        .patterns(PatternsRequest {
+            from: string_arg(&args, "from"),
+            to: string_arg(&args, "to"),
+            hostname: string_arg(&args, "hostname"),
+            app_name: string_arg(&args, "app_name"),
+            severity_min: string_arg(&args, "severity_min"),
+            scan_limit: u32_arg(&args, "scan_limit")?,
+            top_n: u32_arg(&args, "top_n")?,
+        })
+        .await?;
+    tracing::debug!(
+        pattern_count = response.patterns.len(),
+        scanned = response.scanned,
+        truncated = response.truncated,
+        "patterns completed"
+    );
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_context(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let response = state
+        .service
+        .context(ContextRequest {
+            log_id: i64_arg(&args, "log_id")?,
+            hostname: string_arg(&args, "hostname"),
+            timestamp: string_arg(&args, "timestamp"),
+            before: u32_arg(&args, "before")?,
+            after: u32_arg(&args, "after")?,
+        })
+        .await?;
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_get_log(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let id = i64_arg(&args, "id")?.ok_or_else(|| anyhow::anyhow!("`id` is required"))?;
+    let response = state.service.get_log(GetLogRequest { id }).await?;
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_ingest_rate(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let response = state
+        .service
+        .ingest_rate(IngestRateRequest {
+            by_host: bool_arg(&args, "by_host"),
+        })
+        .await?;
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_silent_hosts(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let response = state
+        .service
+        .silent_hosts(SilentHostsRequest {
+            silent_minutes: u32_arg(&args, "silent_minutes")?,
+        })
+        .await?;
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_clock_skew(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let response = state
+        .service
+        .clock_skew(ClockSkewRequest {
+            since: string_arg(&args, "since"),
+        })
+        .await?;
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_anomalies(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let response = state
+        .service
+        .anomalies(AnomaliesRequest {
+            recent_minutes: u32_arg(&args, "recent_minutes")?,
+            baseline_minutes: u32_arg(&args, "baseline_minutes")?,
+        })
+        .await?;
+    Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_compare(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let a_from =
+        string_arg(&args, "a_from").ok_or_else(|| anyhow::anyhow!("`a_from` is required"))?;
+    let a_to = string_arg(&args, "a_to").ok_or_else(|| anyhow::anyhow!("`a_to` is required"))?;
+    let b_from =
+        string_arg(&args, "b_from").ok_or_else(|| anyhow::anyhow!("`b_from` is required"))?;
+    let b_to = string_arg(&args, "b_to").ok_or_else(|| anyhow::anyhow!("`b_to` is required"))?;
+    let response = state
+        .service
+        .compare(CompareRequest {
+            a_from,
+            a_to,
+            b_from,
+            b_to,
+        })
+        .await?;
     Ok(serde_json::to_value(response)?)
 }
 
@@ -164,6 +322,25 @@ fn u32_arg(args: &Value, name: &str) -> anyhow::Result<Option<u32>> {
         .map_err(|_| anyhow::anyhow!("{name} must be <= {}", u32::MAX))
 }
 
+fn i64_arg(args: &Value, name: &str) -> anyhow::Result<Option<i64>> {
+    let Some(value) = args.get(name) else {
+        return Ok(None);
+    };
+    if let Some(n) = value.as_i64() {
+        return Ok(Some(n));
+    }
+    if let Some(n) = value.as_u64() {
+        return i64::try_from(n)
+            .map(Some)
+            .map_err(|_| anyhow::anyhow!("{name} must fit in i64"));
+    }
+    Err(anyhow::anyhow!("{name} must be an integer"))
+}
+
+fn bool_arg(args: &Value, name: &str) -> Option<bool> {
+    args.get(name).and_then(|v| v.as_bool())
+}
+
 async fn tool_syslog_help() -> anyhow::Result<Value> {
     let help = r#"# syslog-mcp Tool Reference
 
@@ -181,6 +358,8 @@ phrase matching with quotes, prefix matching with *.
 - `source_ip` (string, optional) — filter by exact source identifier. Syslog uses verified `IP:port`; Docker ingest uses `docker://host/container/stream`.
 - `severity` (string, optional) — one of: `emerg`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug`
 - `app_name` (string, optional) — filter by application name, e.g. `sshd`, `dockerd`, `kernel`
+- `facility` (string, optional) — filter by syslog facility name (e.g. `kern`, `auth`, `daemon`)
+- `process_id` (string, optional) — filter by process_id (exact match)
 - `from` (string, optional) — start of time range (ISO 8601 / RFC3339, e.g. `2025-01-15T00:00:00Z`)
 - `to` (string, optional) — end of time range (ISO 8601)
 - `limit` (integer, optional) — max results (default 100, max 1000)
@@ -188,29 +367,51 @@ phrase matching with quotes, prefix matching with *.
 ---
 
 ## syslog tail
-Get the N most recent log entries, optionally filtered by host and/or application.
+Get the N most recent log entries, optionally filtered by host, application, and/or severity floor.
 Equivalent to `tail -f` across all hosts.
 
 **Parameters:**
 - `hostname` (string, optional) — filter to a specific host
 - `source_ip` (string, optional) — filter by exact source identifier. Syslog uses verified `IP:port`; Docker ingest uses `docker://host/container/stream`.
 - `app_name` (string, optional) — filter to a specific application
+- `severity_min` (string, optional) — only return entries at or above this severity (e.g. `warning` returns warning + worse)
 - `n` (integer, optional) — number of recent entries (default 50, max 500)
 
 ---
 
 ## syslog errors
 Get a summary of errors and warnings across all hosts in a time window.
-Groups by hostname and severity level, showing counts. Useful for quick health assessments.
+Groups by hostname and severity level (and optionally app_name), showing counts.
 
 **Parameters:**
 - `from` (string, optional) — start of time range (ISO 8601); defaults to all time
 - `to` (string, optional) — end of time range (ISO 8601); defaults to now
+- `group_by` (string, optional) — secondary grouping key. Currently `app_name` is supported; default groups only by hostname+severity.
 
 ---
 
 ## syslog hosts
 List all hosts that have sent syslog messages, with first/last seen timestamps and total log counts.
+
+**Parameters:** none
+
+---
+
+## syslog apps
+List distinct application names with log counts, host counts, and first/last seen timestamps.
+Mirror of `syslog hosts` for the `app_name` dimension.
+
+**Parameters:**
+- `hostname` (string, optional) — restrict to apps seen on this host
+
+---
+
+## syslog source_ips
+List distinct source identifiers (network sender IP:port for syslog input,
+`docker://host/container/stream` for Docker ingest) with log counts, the number
+of distinct hostnames each sender claims, and up to 10 top hostnames per sender.
+`source_ip` is the only network-verified identity — useful for spoof detection
+on hostname-spoofable formats (e.g. UniFi CEF).
 
 **Parameters:** none
 
@@ -229,6 +430,107 @@ of a reference timestamp. Results are grouped by host and ordered by time.
 - `source_ip` (string, optional) — limit correlation to an exact source identifier. Syslog uses verified `IP:port`; Docker ingest uses `docker://host/container/stream`.
 - `query` (string, optional) — optional FTS query to narrow results
 - `limit` (integer, optional) — max total events to return (default 500, max 999)
+
+---
+
+## syslog timeline
+Bucketed log counts over a time range. Use to answer "when did errors start"
+or "is the incident still active". Each point reports `{bucket, group?, count}`.
+
+**Parameters:**
+- `bucket` (string, optional) — `minute`, `hour` (default), or `day`
+- `group_by` (string, optional) — split each bucket by `hostname`, `severity`, or `app_name`
+- `from` (string, optional) — start of time range (ISO 8601)
+- `to` (string, optional) — end of time range (ISO 8601)
+- `hostname` (string, optional) — restrict to one host
+- `app_name` (string, optional) — restrict to one app
+- `severity_min` (string, optional) — only count entries at or above this severity
+
+---
+
+## syslog patterns
+Cluster near-duplicate messages by template. Variable runs (numbers, IPv4
+addresses, UUIDs, long hex strings) are normalised to placeholders so similar
+messages aggregate. Returns top templates with counts, sample message, and
+host distribution.
+
+**Parameters:**
+- `from` / `to` (string, optional) — time range (ISO 8601)
+- `hostname`, `app_name` (string, optional) — narrow the population
+- `severity_min` (string, optional) — only cluster entries at or above this severity
+- `scan_limit` (integer, optional) — max messages to read (default 10000, max 50000)
+- `top_n` (integer, optional) — max templates to return (default 20, max 200)
+
+---
+
+## syslog context
+Surrounding logs around a single point of interest, on the same host. Pass
+either `log_id` (preferred — uses (timestamp, id) for stable ordering) or both
+`hostname` + `timestamp` to anchor on a synthetic reference.
+
+**Parameters:**
+- `log_id` (integer, optional) — id of an existing log entry (e.g. from `search`)
+- `hostname` (string, optional) — required when `log_id` is not given
+- `timestamp` (string, optional) — required when `log_id` is not given (ISO 8601)
+- `before` (integer, optional) — entries before the reference (default 10, max 500)
+- `after` (integer, optional) — entries after the reference (default 10, max 500)
+
+---
+
+## syslog get
+Fetch one log entry by `id`, including the unparsed `raw` syslog frame.
+
+**Parameters:**
+- `id` (integer, **required**) — primary key from any other action
+
+---
+
+## syslog ingest_rate
+Recent ingest throughput: counts and per-second rates over the last 1m / 5m /
+15m windows (using `received_at`, not message timestamp). Includes the current
+write-block flag for live ingest health.
+
+**Parameters:**
+- `by_host` (boolean, optional) — also include per-host buckets
+
+---
+
+## syslog silent_hosts
+Hosts whose `last_seen` is older than `silent_minutes` ago. Reports their
+typical inter-arrival interval so you can spot devices that should be chatty.
+
+**Parameters:**
+- `silent_minutes` (integer, optional) — staleness threshold (default 30, max 10080)
+
+---
+
+## syslog clock_skew
+Per-host distribution of `received_at - timestamp` (seconds), sorted by
+absolute mean. Surfaces devices with a broken or drifting clock.
+
+**Parameters:**
+- `since` (string, optional) — only sample entries with `received_at >= since` (default last 24h)
+
+---
+
+## syslog anomalies
+Per-host comparison of recent volume against a baseline window. Reports
+`recent_per_min`, `baseline_per_min`, ratio, and a Poisson-style z-score so an
+agent can rank hosts whose log rate or error count is unusual.
+
+**Parameters:**
+- `recent_minutes` (integer, optional) — recent window (default 15, max 1440)
+- `baseline_minutes` (integer, optional) — baseline window before the recent one (default 360, max 10080)
+
+---
+
+## syslog compare
+Side-by-side summary of two time ranges (volume, error count, severity mix,
+top hosts, top apps) plus deltas. Answers "what changed since yesterday".
+
+**Parameters:**
+- `a_from`, `a_to` (string, **required**) — first range (ISO 8601)
+- `b_from`, `b_to` (string, **required**) — second range (ISO 8601)
 
 ---
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -33,7 +33,7 @@ async fn tool_syslog(state: &AppState, args: Value) -> anyhow::Result<Value> {
         "stats" => tool_get_stats(state, args).await,
         "status" => tool_get_status(state, args).await,
         "apps" => tool_list_apps(state, args).await,
-        "source_ips" => tool_list_source_ips(state).await,
+        "source_ips" => tool_list_source_ips(state, args).await,
         "timeline" => tool_timeline(state, args).await,
         "patterns" => tool_patterns(state, args).await,
         "context" => tool_context(state, args).await,
@@ -113,7 +113,7 @@ async fn tool_list_apps(state: &AppState, args: Value) -> anyhow::Result<Value> 
     Ok(serde_json::to_value(response)?)
 }
 
-async fn tool_list_source_ips(state: &AppState) -> anyhow::Result<Value> {
+async fn tool_list_source_ips(state: &AppState, _args: Value) -> anyhow::Result<Value> {
     let response = state.service.list_source_ips().await?;
     tracing::debug!(
         source_ip_count = response.source_ips.len(),

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -6,13 +6,13 @@ use crate::mcp::AppState;
 use serde_json::json;
 use std::sync::Arc;
 
-fn test_state_with_token(token: Option<String>) -> (AppState, tempfile::TempDir) {
+fn test_state_with_token(token: Option<String>) -> (AppState, Arc<db::DbPool>, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let storage = StorageConfig::for_test(dir.path().join("mcp-test.db"));
     let pool = Arc::new(db::init_pool(&storage).unwrap());
     (
         AppState {
-            service: SyslogService::new(pool, storage.clone()),
+            service: SyslogService::new(Arc::clone(&pool), storage.clone()),
             config: McpConfig {
                 host: "127.0.0.1".into(),
                 port: 3100,
@@ -24,19 +24,25 @@ fn test_state_with_token(token: Option<String>) -> (AppState, tempfile::TempDir)
             otlp_counters: Arc::new(crate::otlp::OtlpCounters::default()),
             observability: Arc::new(crate::observability::RuntimeObservability::default()),
         },
+        pool,
         dir,
     )
 }
 
 struct TestHarness {
     state: AppState,
+    pool: Arc<db::DbPool>,
     _dir: tempfile::TempDir,
 }
 
 impl TestHarness {
     fn new() -> Self {
-        let (state, dir) = test_state_with_token(None);
-        TestHarness { state, _dir: dir }
+        let (state, pool, dir) = test_state_with_token(None);
+        TestHarness {
+            state,
+            pool,
+            _dir: dir,
+        }
     }
 }
 
@@ -93,10 +99,33 @@ async fn numeric_args_reject_wrong_type_values() {
 #[tokio::test]
 async fn schema_actions_are_dispatchable() {
     let h = TestHarness::new();
+    db::insert_logs_batch(
+        &h.pool,
+        &[db::LogBatchEntry {
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+            hostname: "schema-test-host".to_string(),
+            facility: Some("auth".to_string()),
+            severity: "err".to_string(),
+            app_name: Some("schema-test".to_string()),
+            process_id: Some("42".to_string()),
+            message: "schema dispatch test".to_string(),
+            raw: "<11>schema dispatch test".to_string(),
+            source_ip: "127.0.0.1:514".to_string(),
+            docker_checkpoint: None,
+        }],
+    )
+    .unwrap();
     for action in SYSLOG_ACTIONS {
         let args = match *action {
             "correlate" => {
                 json!({"action": action, "reference_time": "2026-01-01T00:00:00Z"})
+            }
+            "context" => {
+                json!({"action": action, "hostname": "schema-test-host", "timestamp": "2026-01-01T00:00:00Z"})
+            }
+            "get" => json!({"action": action, "id": 1}),
+            "compare" => {
+                json!({"action": action, "a_from": "2026-01-01T00:00:00Z", "a_to": "2026-01-01T00:01:00Z", "b_from": "2026-01-01T00:01:00Z", "b_to": "2026-01-01T00:02:00Z"})
             }
             _ => json!({"action": action}),
         };

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -207,7 +207,7 @@ fn parse_optional_timestamp_normalizes_offsets_to_utc() {
     let parsed = crate::app::parse_optional_timestamp(Some("2026-01-01T01:00:00+01:00"), "from")
         .unwrap()
         .unwrap();
-    assert_eq!(parsed, "2026-01-01T00:00:00+00:00");
+    assert_eq!(parsed, "2026-01-01T00:00:00.000Z");
 }
 
 #[test]

--- a/src/syslog/parser.rs
+++ b/src/syslog/parser.rs
@@ -169,8 +169,11 @@ pub(super) fn parse_syslog(raw: &str, source_ip: String) -> db::LogBatchEntry {
 
     let timestamp = msg
         .timestamp
-        .map(|dt| dt.with_timezone(&Utc).to_rfc3339())
-        .unwrap_or_else(|| Utc::now().to_rfc3339());
+        .map(|dt| {
+            dt.with_timezone(&Utc)
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        })
+        .unwrap_or_else(|| Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
 
     let raw_hostname = msg.hostname.map(|h| h.to_string()).unwrap_or_default();
     let raw_app_name = msg.appname.map(|a| a.to_string());

--- a/src/syslog/writer_tests.rs
+++ b/src/syslog/writer_tests.rs
@@ -96,7 +96,7 @@ async fn flush_batch_resumes_after_storage_recovers() {
     assert!(batch.is_empty());
     assert!(!storage_blocked);
     assert_eq!(observability.snapshot().writer_logs_written, 1);
-    let rows = db::tail_logs(&pool, None, None, None, 10).unwrap();
+    let rows = db::tail_logs(&pool, None, None, None, None, 10).unwrap();
     assert_eq!(rows.len(), 1);
 }
 

--- a/src/syslog/writer_tests.rs
+++ b/src/syslog/writer_tests.rs
@@ -138,7 +138,7 @@ async fn flush_batch_isolates_bad_rows_and_writes_remaining_entries() {
     assert!(batch.is_empty());
     assert_eq!(observability.snapshot().writer_logs_written, 2);
     assert_eq!(observability.snapshot().writer_logs_discarded, 1);
-    let rows = db::tail_logs(&pool, None, None, None, 10).unwrap();
+    let rows = db::tail_logs(&pool, None, None, None, None, 10).unwrap();
     assert_eq!(rows.len(), 2);
 }
 

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -4,7 +4,10 @@
 #
 # Exercises broad non-destructive coverage of the action-based syslog MCP tool:
 #   syslog search, syslog tail, syslog errors, syslog hosts, syslog correlate,
-#   syslog stats, syslog status, syslog help
+#   syslog stats, syslog status, syslog apps, syslog source_ips,
+#   syslog timeline, syslog patterns, syslog context, syslog get,
+#   syslog ingest_rate, syslog silent_hosts, syslog clock_skew,
+#   syslog anomalies, syslog compare, syslog help
 #
 # The server runs as a Docker container over HTTP. No stdio launch needed.
 # Credentials are sourced from ~/.claude-homelab/.env:

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -2,7 +2,8 @@
 # =============================================================================
 # test-tools.sh — Integration smoke-test for syslog-mcp MCP server tools
 #
-# Exercises broad non-destructive coverage of the action-based syslog MCP tool:
+# Exercises broad non-destructive checks for the action-based syslog MCP tool.
+# Action inventory reference (not every action is exercised below):
 #   syslog search, syslog tail, syslog errors, syslog hosts, syslog correlate,
 #   syslog stats, syslog status, syslog apps, syslog source_ips,
 #   syslog timeline, syslog patterns, syslog context, syslog get,

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -17,6 +17,13 @@
 #   SYSLOG_MCP_TOKEN       Bearer token for auth (optional — server may run without it)
 #   PORT                   Override server port (default: 3100)
 #
+# Action coverage reference:
+#   syslog search, syslog tail, syslog errors, syslog hosts, syslog correlate,
+#   syslog stats, syslog status, syslog apps, syslog source_ips,
+#   syslog timeline, syslog patterns, syslog context, syslog get,
+#   syslog ingest_rate, syslog silent_hosts, syslog clock_skew,
+#   syslog anomalies, syslog compare, syslog help
+#
 # Exit codes:
 #   0 — all tests passed (SKIPs do not count as failures)
 #   1 — one or more tests failed

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -17,7 +17,7 @@
 #   SYSLOG_MCP_TOKEN       Bearer token for auth (optional — server may run without it)
 #   PORT                   Override server port (default: 3100)
 #
-# Action coverage reference:
+# Action inventory reference (not every action is exercised by this live test):
 #   syslog search, syslog tail, syslog errors, syslog hosts, syslog correlate,
 #   syslog stats, syslog status, syslog apps, syslog source_ips,
 #   syslog timeline, syslog patterns, syslog context, syslog get,


### PR DESCRIPTION
## Summary

Adds 11 new actions to the `syslog` MCP tool plus filter extensions to existing actions. The action surface grows from 7 to 18.

### New actions

- **`apps`** — distinct app_names with log/host counts and first/last seen (mirror of `hosts` for the `app_name` dimension).
- **`source_ips`** — distinct senders with hostname breakdown; supports spoof detection on hostname-spoofable formats (UniFi CEF).
- **`timeline`** — bucketed counts (`minute`/`hour`/`day`) over a time range, optionally split by `hostname` / `severity` / `app_name`.
- **`patterns`** — cluster near-duplicate messages by template; numbers, IPv4 addresses, UUIDs, and long hex strings are normalised to placeholders so similar messages aggregate.
- **`context`** — surrounding logs around a single point of interest by `log_id` or `hostname`+`timestamp`.
- **`get`** — fetch one log by `id`, including the previously unreachable `raw` syslog frame.
- **`ingest_rate`** — last 1m / 5m / 15m throughput (using `received_at`) plus current `write_blocked` flag and optional per-host buckets.
- **`silent_hosts`** — hosts whose `last_seen` is older than the threshold, with their typical inter-arrival interval.
- **`clock_skew`** — per-host distribution of `received_at − timestamp` (seconds), sorted by absolute mean.
- **`anomalies`** — per-host comparison of recent volume/error count against a baseline window; returns ratio and Poisson-style z-score.
- **`compare`** — side-by-side summary of two time ranges (volume, error count, severity mix, top hosts/apps) with deltas.

### Filter extensions

- `search` accepts `facility` and `process_id`.
- `tail` accepts `severity_min` (returns entries at or above the threshold).
- `errors` accepts `group_by=app_name` for hostname × app_name × severity grouping.

### Implementation

- New `src/db/analytics.rs` module holds the query layer for the new actions; existing `queries.rs` was kept lean.
- `tail_logs` and `get_error_summary` gained additional parameters (`severity_in`, `group_by_app`); internal callers updated.
- Help text (`syslog help`) expanded to document all 18 actions and updated parameters.
- Version bumped 0.10.1 → 0.11.0; CHANGELOG entry added.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 163 unit tests + integration tests pass
- [x] `scripts/check-version-sync.sh` — OK at v0.11.0
- [ ] Manual smoke against a running server (recommended pre-merge): `bash scripts/smoke-test.sh` and spot-check `mcporter call ... action=timeline bucket=hour`, `action=patterns`, `action=context log_id=…`, `action=ingest_rate by_host=true`.

https://claude.ai/code/session_018JFJQ6HiRtdnwVN2t22VEi

---
_Generated by [Claude Code](https://claude.ai/code/session_018JFJQ6HiRtdnwVN2t22VEi)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 11 new `syslog` MCP actions (surface 7 → 18) for analytics, drill‑down, and ops health, plus new filters and updated docs/tests/help. Normalizes timestamps to RFC3339 Z across ingest and queries to fix boundary sorting and improve consistency.

- **New Features**
  - Actions: `apps`, `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`, `silent_hosts`, `clock_skew`, `anomalies`, `compare`.
  - Filters: `search` adds `facility`/`process_id`; `tail` adds `severity_min`; `errors` adds `group_by=app_name`.

- **Bug Fixes**
  - Timestamp normalization: store/compare in RFC3339 Z; fixes boundary rows for `ingest_rate`/`silent_hosts`/`clock_skew` and windowed queries (`correlate`, `context`, `compare`, `anomalies`); syslog and Docker parsers now emit Z-form.
  - `compare`: invalid timestamps now return `InvalidInput` instead of panicking.
  - `anomalies`: rank new‑but‑active hosts first as documented.
  - `apps`/`source_ips`: first/last seen use `received_at` to avoid device clock skew.
  - `context`: correct before/after split for `hostname`+`timestamp`; strict `<`/`>` when id‑anchored.
  - `patterns`: preserve multi‑byte UTF‑8 during template normalization.
  - `tail`: advance placeholder index for `severity_in` to avoid future `?N` collisions.
  - CI: Docker builds use `config/Dockerfile`; clippy clean on stable.

<sup>Written for commit bee15d2319457f57d75253ad12400a8d297138aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.15.0

* **New Features**
  * Added 11 new syslog analytics actions: apps, source_ips, timeline, patterns, context, get, ingest_rate, silent_hosts, clock_skew, anomalies, and compare.
  * Enhanced existing actions with new filters: search (facility, process_id), tail (severity_min), errors (group_by).
  * Exposed raw syslog data via new get action.

* **Documentation**
  * Updated tool references and help documentation to reflect new actions and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->