### PR TITLE
fix: harden syslog ingestion reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] - 2026-05-07
+
+### Added
+
+- Added bounded TCP syslog frame handling with oversized-frame regression coverage.
+- Added fail-fast validation for zero-valued syslog ingest settings.
+- Added Docker ingest supervisor policy/backoff tests, sidecar supervisor tests,
+  and Docker ingest producer observability in status/stats.
+- Added TCP ingest smoke coverage and a tracked ingestion full-review artifact.
+
+### Changed
+
+- Hardened Docker ingest reconnect backoff with deterministic jitter and durable
+  stream-duration reset semantics.
+- Improved failed batch handling so retryable storage failures retain bounded
+  rows, while permanent failures retry chunks and isolate bad rows.
+- Capped ingest summary cardinality with overflow buckets while preserving total
+  log counts.
+- Documented Docker ingest trust boundaries and heavy SQLite migration runbooks.
+
 ## [0.14.1] - 2026-05-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/README.md
+++ b/README.md
@@ -411,7 +411,9 @@ The plain JSON API is disabled by default. When enabled, it is mounted under `/a
 |----------|----------|---------|-------------|
 | `SYSLOG_HOST` | no | `0.0.0.0` | Bind host for UDP + TCP syslog listeners |
 | `SYSLOG_PORT` | no | `1514` | Bind port for UDP + TCP syslog listeners |
-| `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | Max message size in bytes (oversized messages are dropped) |
+| `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | Max bytes per UDP datagram or newline-delimited TCP frame. Oversized newline-delimited TCP frames are dropped and the connection stays open; oversized unterminated frames are dropped and the connection is closed. |
+| `SYSLOG_MAX_TCP_CONNECTIONS` | no | `1024` | Maximum simultaneous TCP syslog connections |
+| `SYSLOG_TCP_IDLE_TIMEOUT_SECS` | no | `300` | Idle timeout per TCP read before closing inactive connections |
 | `SYSLOG_BATCH_SIZE` | no | `100` | Number of messages per batch write |
 | `SYSLOG_FLUSH_INTERVAL` | no | `500` | Batch flush interval in milliseconds |
 
@@ -442,6 +444,8 @@ allow_insecure_http = true
 ```
 
 The docker-socket-proxy side only needs read access to containers, events, ping, and version endpoints: `CONTAINERS=1`, `EVENTS=1`, `PING=1`, `VERSION=1`, `POST=0`. `CONTAINERS=1` exposes the broader read-only Docker container API to anything that can reach the proxy, so bind it only on a trusted private network, firewall it to syslog-mcp, or put it behind authenticated TLS. Plain `http://` endpoints require `allow_insecure_http = true` in the hosts file so that this trust decision is explicit.
+
+Docker ingest is intentionally not part of the default smoke test because it needs a live docker-socket-proxy-compatible endpoint and container log stream. For integration testing, run syslog-mcp with `SYSLOG_DOCKER_INGEST_ENABLED=true` against a disposable docker-socket-proxy or mocked Docker HTTP fixture, emit a unique line from a short-lived container, then verify it with `syslog search` or `mcporter call ... action=search`. The expected stored `source_ip` shape is `docker://<host>/<container>/<stream>`.
 
 #### Storage
 
@@ -681,6 +685,19 @@ If enforcement cannot free enough space (e.g. the DB is empty but storage is sti
 
 Disable either guard by setting its trigger to `0` (also set the recovery target to `0`).
 
+### Heavy SQLite migrations
+
+Most schema setup runs automatically during startup. Heavy migrations, such as creating a new index on a populated multi-million-row `logs` table, can hold SQLite's write lock for several minutes before syslog listeners and `/health` are available. During that window TCP senders may back up and UDP packets may be dropped by kernel buffers.
+
+Before upgrading a populated database:
+
+1. Take a WAL-safe backup with `scripts/backup.sh` or `sqlite3 /data/syslog.db ".backup /data/syslog-pre-upgrade.db"`.
+2. Schedule a short ingest maintenance window for large databases.
+3. Start the new version and monitor logs for `Migration N: starting ...` and `Migration N: ... created`.
+4. Keep the previous image or binary available until `/health` returns `ok` and `syslog stats` reports sane counts.
+
+See [docs/runbooks/deploy.md](docs/runbooks/deploy.md) for the deploy checklist.
+
 ---
 
 ## Batch Writer
@@ -821,6 +838,14 @@ just check
 just lint
 just test
 ```
+
+Run the live smoke test against a running server:
+
+```bash
+bash scripts/smoke-test.sh
+```
+
+The smoke test seeds UDP and TCP syslog messages and verifies MCP search/tail results. Docker ingest coverage is handled by the explicit integration path described in the Docker socket-proxy ingest section because it requires an external Docker-compatible log endpoint.
 
 ---
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -66,9 +66,13 @@ such as `https://syslog.example.com`.
 | --- | --- | --- | --- | --- |
 | `SYSLOG_HOST` | no | `0.0.0.0` | no | Listen host for UDP+TCP syslog (no port -- use separate setting) |
 | `SYSLOG_PORT` | no | `1514` | no | Listen port shared by UDP and TCP syslog listeners |
-| `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | no | Max message size in bytes per syslog frame |
+| `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | no | Max bytes per UDP datagram or newline-delimited TCP frame. Oversized frames are dropped. |
+| `SYSLOG_MAX_TCP_CONNECTIONS` | no | `1024` | no | Maximum simultaneous TCP syslog connections |
+| `SYSLOG_TCP_IDLE_TIMEOUT_SECS` | no | `300` | no | Idle timeout per TCP read before closing inactive connections |
 | `SYSLOG_BATCH_SIZE` | no | `100` | no | Entries per batch flush to SQLite |
 | `SYSLOG_FLUSH_INTERVAL` | no | `500` | no | Batch flush interval in milliseconds |
+
+TCP forwarders can keep a connection open and send multiple newline-delimited syslog frames. The size limit applies to each frame, not to the full TCP connection lifetime. An oversized newline-delimited frame is dropped and later bounded frames on the same connection can still be ingested. An oversized unterminated frame is dropped and the connection is closed because the listener cannot safely find the next frame boundary.
 
 ### Docker socket-proxy ingest (`SYSLOG_DOCKER_*`)
 
@@ -100,6 +104,8 @@ POST=0
 ```
 
 `CONTAINERS=1` exposes the broader read-only Docker container API to every client that can reach docker-socket-proxy. Bind the proxy on a trusted private network, firewall it so only syslog-mcp can connect, or put it behind authenticated TLS. Hosts using plain `http://` must set `allow_insecure_http = true` in the hosts file; otherwise config validation rejects them.
+
+Docker ingest is not included in the default smoke test because it requires a live docker-socket-proxy-compatible endpoint. For integration coverage, run a disposable docker-socket-proxy or mocked Docker HTTP fixture, set `SYSLOG_DOCKER_INGEST_ENABLED=true`, emit a unique container stdout/stderr line, and verify it with `search` or `tail`. Docker-ingested rows identify their source as `docker://<host>/<container>/<stream>`.
 
 ### MCP server (`SYSLOG_MCP_*`)
 
@@ -167,6 +173,20 @@ The storage budget is a two-threshold system with hysteresis to prevent oscillat
 4. **Enforcement interval**: Checked every `cleanup_interval_secs` seconds (default 60).
 
 Set both `max_db_size_mb` and `min_free_disk_mb` to 0 to disable all storage enforcement.
+
+## SQLite migration upgrades
+
+Startup creates missing schema objects automatically. Small migrations are expected to complete quickly, but heavyweight migrations on a populated database can hold SQLite's write lock before syslog listeners and `/health` are ready. The server logs an operator-visible `Migration N: starting ...` message before such work and a completion message with elapsed time.
+
+For populated databases, treat heavy migrations as a planned upgrade step:
+
+1. Stop or quiet high-volume senders if packet loss is unacceptable.
+2. Take a WAL-safe backup with `scripts/backup.sh` or `sqlite3 /data/syslog.db ".backup /data/syslog-pre-upgrade.db"`.
+3. Start the upgraded container or binary and watch `docker compose logs -f syslog-mcp` or the relevant service log for migration start/completion lines.
+4. Wait for `curl -sf http://localhost:3100/health` to succeed.
+5. Run `syslog stats --json` or `mcporter call ... action=stats` and confirm `total_logs`, storage metrics, and `write_blocked` match expectations.
+
+If a migration must be abandoned, stop the new process before changing files, restore the WAL-safe backup, and restart the previous image or binary. See [runbooks/deploy.md](runbooks/deploy.md) for the full deploy checklist.
 
 ## Validation rules
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -180,6 +180,8 @@ The ingest loop follows existing containers, listens for container start events,
 
 Plain `http://` docker-socket-proxy URLs require `allow_insecure_http = true`. Use that only on trusted private networks, firewall the proxy so only syslog-mcp can connect, or put the proxy behind authenticated TLS. `CONTAINERS=1` exposes Docker's broader read-only container API to anything that can reach the proxy, not just the log endpoints syslog-mcp calls.
 
+For Docker ingest integration testing, keep the default smoke test focused on UDP/TCP syslog and run Docker ingest as a separate fixture-backed check. Start syslog-mcp with `SYSLOG_DOCKER_INGEST_ENABLED=true` against a disposable docker-socket-proxy or mocked Docker HTTP endpoint, emit a unique marker from a short-lived container, then verify it with `search` or `tail`. Docker-ingested rows should report `source_ip` as `docker://<host>/<container>/<stream>`.
+
 ## Troubleshooting
 
 ### "Connection refused" on health check

--- a/docs/reviews/ingestion-full-review.md
+++ b/docs/reviews/ingestion-full-review.md
@@ -1,0 +1,51 @@
+# Ingestion Full-Review Report
+
+Date: 2026-05-07
+
+Scope: syslog UDP/TCP receive path, syslog parsing/enrichment handoff, batch writer, SQLite insert/checkpoint path, Docker log ingestion, and runtime/maintenance behavior that can block or drop ingest.
+
+Tracker epic: `syslog-mcp-vzg8`
+
+## Artifact Policy
+
+`.full-review/` is an ignored scratch workspace for live review notes. Final review reports that need to survive branch handoff must be copied to a tracked `docs/reviews/` path. This file is the tracked ingestion report and should be treated as the durable source for the ingestion remediation epic.
+
+## Findings
+
+### Fixed or Covered in Current Remediation
+
+1. TCP live smoke coverage was incomplete.
+   - Evidence: `scripts/smoke-test.sh` seeded UDP messages only.
+   - Remediation: default smoke now seeds one TCP syslog frame with a unique marker and validates the frame through both `tail` and `search`.
+   - Bead: `syslog-mcp-vzg8.10`
+
+2. Docker ingest did not have a practical smoke-test boundary.
+   - Evidence: Docker ingest requires a docker-socket-proxy-compatible endpoint and a real or mocked container log stream.
+   - Remediation: default smoke remains practical; Docker ingest is documented as a separate integration path using a disposable proxy or mocked Docker HTTP fixture.
+   - Bead: `syslog-mcp-vzg8.10`
+
+3. TCP message-size documentation could overstate protection.
+   - Evidence: config docs described a generic max message size without TCP frame behavior.
+   - Current code state: TCP receive uses bounded newline-delimited frames and drops oversized frames without treating one persistent TCP connection as one unbounded message.
+   - Remediation: README and config docs now state the limit is per UDP datagram or per TCP frame.
+   - Bead: `syslog-mcp-vzg8.11`
+
+4. Heavy SQLite migrations were operator-visible in code but not in runbooks.
+   - Evidence: `src/db/pool.rs` documents migration 3 startup cost and logs start/completion.
+   - Remediation: deployment and config docs now include backup, downtime, monitoring, health-check, stats, and rollback steps for populated databases.
+   - Beads: `syslog-mcp-vzg8.9`, `syslog-mcp-vzg8.15`
+
+5. Review artifact drift made the ingestion report non-durable.
+   - Evidence: the original final report was under ignored `.full-review/`, which can be overwritten by later review scopes.
+   - Remediation: this tracked `docs/reviews/ingestion-full-review.md` report records the ingestion scope and remediation state.
+   - Bead: `syslog-mcp-vzg8.17`
+
+## Remaining Follow-Up
+
+- A full Docker ingest integration fixture can still be automated later. The current branch documents the required fixture path and keeps the default smoke test local and fast.
+- Future heavyweight migrations should add an explicit release-note callout and keep the startup log wording operator-visible.
+
+## Verification
+
+- Run `bash -n scripts/smoke-test.sh` after smoke script edits.
+- Run the full live smoke test only against a running syslog-mcp daemon with `mcporter`, `nc`, `curl`, and `python3` available.

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -55,6 +55,7 @@ docker inspect --format='{{.State.Health.Status}}' syslog-mcp
 - [ ] `cargo clippy` has no warnings
 - [ ] No uncommitted changes (`git status` clean)
 - [ ] Database backup taken (see backup section below)
+- [ ] For populated databases, review [Heavy SQLite Migration Upgrade](#heavy-sqlite-migration-upgrade) before restarting
 
 ## Database Backup Before Deploy
 
@@ -62,3 +63,50 @@ docker inspect --format='{{.State.Health.Status}}' syslog-mcp
 # WAL-safe online backup (no downtime)
 docker compose exec syslog-mcp sqlite3 /data/syslog.db ".backup /data/syslog-pre-deploy.db"
 ```
+
+The repo also includes `scripts/backup.sh`, which performs a WAL-safe checkpoint and SQLite backup from the host when the database path is reachable.
+
+## Heavy SQLite Migration Upgrade
+
+Most schema migrations run automatically at startup and are safe for normal rolling updates. Some migrations are intentionally heavier, such as creating an index on a populated `logs` table. Those can hold SQLite's write lock for several minutes before `/health` responds or syslog listeners start, so treat them as a planned ingest maintenance window on large databases.
+
+Use this path when release notes, startup logs, or `docs/CONFIG.md` indicate a heavy migration:
+
+```bash
+# 1. Confirm current database size and baseline counts.
+docker compose exec syslog-mcp sqlite3 /data/syslog.db \
+  "SELECT COUNT(*) FROM logs; PRAGMA page_count; PRAGMA page_size;"
+
+# 2. Take a WAL-safe backup.
+docker compose exec syslog-mcp sqlite3 /data/syslog.db ".backup /data/syslog-pre-heavy-migration.db"
+
+# 3. Build or pull the new version, then start it.
+docker compose build
+docker compose up -d
+
+# 4. Watch for migration start/completion lines.
+docker compose logs -f syslog-mcp
+
+# 5. Verify health and storage state after completion.
+curl -sf http://localhost:3100/health
+mcporter call --config config/mcporter.json syslog.syslog action=stats
+```
+
+Expected operator signals:
+
+- Startup logs include `Migration N: starting ...` before a heavyweight operation.
+- Completion logs include the migration name and elapsed time.
+- `/health` may fail until the migration commits.
+- UDP senders can lose packets while the listener is unavailable; TCP senders may reconnect or buffer depending on their own config.
+
+Rollback while a migration is running is a restore operation, not a partial schema edit. Stop the new process, restore the WAL-safe backup to `/data/syslog.db`, then start the previous image or binary.
+
+## Docker Ingest Integration Check
+
+The default `scripts/smoke-test.sh` covers live UDP and TCP ingest plus MCP actions. Docker ingest is heavier because it requires a docker-socket-proxy-compatible endpoint and a container log stream, so run it explicitly during Docker ingest changes:
+
+1. Start a disposable docker-socket-proxy or mocked Docker HTTP fixture with `CONTAINERS=1`, `EVENTS=1`, `PING=1`, `VERSION=1`, and `POST=0`.
+2. Start syslog-mcp with `SYSLOG_DOCKER_INGEST_ENABLED=true` and `SYSLOG_DOCKER_HOSTS=<fixture-host>`.
+3. Run a short-lived container that writes a unique marker to stdout and stderr.
+4. Verify `search` or `tail` returns the marker and that `source_ip` is `docker://<host>/<container>/<stream>`.
+5. Stop the fixture and confirm syslog-mcp logs reconnect/backoff without crashing.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -21,6 +21,8 @@ MCPORTER_CONFIG="config/mcporter.json"
 _MCPORTER_CONFIG_TMPFILE=""
 SEED_HOST="smoke-test-host"
 GHOST_HOST="nonexistent-host-xyz-404"
+RUN_ID="${SYSLOG_SMOKE_RUN_ID:-$(date -u +%Y%m%d%H%M%S)}"
+TCP_MARKER="smoketcp${RUN_ID}"
 
 trap '[[ -n "$_MCPORTER_CONFIG_TMPFILE" ]] && rm -f "$_MCPORTER_CONFIG_TMPFILE"' EXIT
 
@@ -123,6 +125,14 @@ except Exception:
     fi
 }
 
+send_tcp_seed() {
+    local message="$1"
+    if printf '%s\n' "$message" | nc -w2 -N "$SYSLOG_HOST" "$SYSLOG_PORT" >/dev/null 2>&1; then
+        return 0
+    fi
+    printf '%s\n' "$message" | nc -w2 "$SYSLOG_HOST" "$SYSLOG_PORT" >/dev/null
+}
+
 # ─── Phase 1: Pre-flight ─────────────────────────────────────────────────────
 echo ""
 echo -e "${COLOR_BOLD}=== syslog-mcp smoke test ===${COLOR_RESET}"
@@ -148,8 +158,9 @@ if [[ "$SKIP_SEED" -eq 0 ]]; then
     printf '<11>%s %s sshd[42]: smoke-test: error authentication failure\n' "$(date '+%b %e %H:%M:%S')" "$SEED_HOST" | nc -u -w1 "$SYSLOG_HOST" "$SYSLOG_PORT"
     printf '<2>%s %s kernel: smoke-test: crit memory allocation failed\n'    "$(date '+%b %e %H:%M:%S')" "$SEED_HOST" | nc -u -w1 "$SYSLOG_HOST" "$SYSLOG_PORT"
     printf '<12>%s %s dockerd[99]: smoke-test: warning container restart\n'  "$(date '+%b %e %H:%M:%S')" "$SEED_HOST" | nc -u -w1 "$SYSLOG_HOST" "$SYSLOG_PORT"
+    send_tcp_seed "<14>$(date '+%b %e %H:%M:%S') ${SEED_HOST} tcpsmoke[77]: smoke-test tcp seed ${TCP_MARKER} bounded frame ok"
     sleep 2
-    echo "Seeded 4 messages (info, err, crit, warning) from $SEED_HOST"
+    echo "Seeded 5 messages (4 UDP, 1 TCP) from $SEED_HOST; TCP marker=$TCP_MARKER"
 else
     echo "Skipping seed (--skip-seed)"
 fi
@@ -282,6 +293,15 @@ assert not wrong, f'hostname filter leaked other hosts: {wrong}'
 print('ok')
 " 2>/dev/null || echo "error")
     assert_eq "tail(hostname filter): only returns logs for '$SEED_HOST'" "$TAIL_FILTER_VALID" "ok"
+
+    TAIL_TCP_MARKER=$(echo "$TAIL_FILTERED" | python3 -c "
+import sys, json
+logs = json.load(sys.stdin)['logs']
+matches = [l for l in logs if '${TCP_MARKER}' in (l.get('message') or '')]
+assert matches, 'TCP seed marker not present in tail(hostname filter)'
+print('ok')
+" 2>/dev/null || echo "error")
+    assert_eq "tail(hostname filter): TCP seed marker appears" "$TAIL_TCP_MARKER" "ok"
 fi
 
 # ── search ────────────────────────────────────────────────────────────────────
@@ -342,6 +362,19 @@ assert not wrong, f'severity filter leaked wrong levels: {set(wrong)}'
 print('ok')
 " 2>/dev/null || echo "error")
     assert_eq "search(severity filter): only returns warning-level logs" "$SEARCH_SEV_VALID" "ok"
+
+    SEARCH_TCP=$(mcp_call search "query=${TCP_MARKER}" "hostname=${SEED_HOST}" "limit=10" 2>&1)
+    assert_no_error "search(TCP seed marker): no error" "$SEARCH_TCP"
+    SEARCH_TCP_VALID=$(echo "$SEARCH_TCP" | python3 -c "
+import sys, json
+logs = json.load(sys.stdin)['logs']
+assert logs, 'TCP seed marker search returned no logs'
+for l in logs:
+    assert l['hostname'] == '${SEED_HOST}', f'wrong hostname: {l[\"hostname\"]}'
+    assert '${TCP_MARKER}' in (l.get('message') or ''), 'marker missing from result'
+print('ok')
+" 2>/dev/null || echo "error")
+    assert_eq "search(TCP seed marker): returns TCP-ingested message" "$SEARCH_TCP_VALID" "ok"
 fi
 
 # Nonexistent hostname must return 0 results (filter is not ignored)

--- a/src/config.rs
+++ b/src/config.rs
@@ -336,6 +336,14 @@ impl Config {
             "SYSLOG_MAX_MESSAGE_SIZE",
             &mut config.syslog.max_message_size,
         )?;
+        env_override_parse(
+            "SYSLOG_MAX_TCP_CONNECTIONS",
+            &mut config.syslog.max_tcp_connections,
+        )?;
+        env_override_parse(
+            "SYSLOG_TCP_IDLE_TIMEOUT_SECS",
+            &mut config.syslog.tcp_idle_timeout_secs,
+        )?;
         env_override_parse("SYSLOG_BATCH_SIZE", &mut config.syslog.batch_size)?;
         env_override_parse("SYSLOG_FLUSH_INTERVAL", &mut config.syslog.flush_interval)?;
 
@@ -441,6 +449,13 @@ impl Config {
                             allow_insecure_http: true,
                         })
                         .collect();
+                    for host in &config.docker_ingest.hosts {
+                        tracing::warn!(
+                            host = %host.name,
+                            base_url = %host.base_url,
+                            "SYSLOG_DOCKER_HOSTS expands to insecure HTTP docker-socket-proxy endpoints; use only on trusted private networks or SYSLOG_DOCKER_HOSTS_FILE with TLS/custom base_url"
+                        );
+                    }
                 }
             } else if let Ok(path) = std::env::var("SYSLOG_DOCKER_HOSTS_FILE") {
                 if !path.is_empty() {
@@ -475,6 +490,7 @@ impl Config {
         if config.storage.pool_size == 0 {
             return Err(anyhow::anyhow!("SYSLOG_MCP_POOL_SIZE must be > 0"));
         }
+        validate_syslog_config(&config.syslog)?;
         validate_storage_config(&config.storage)?;
         validate_host(&config.syslog.host)?;
         validate_host(&config.mcp.host)?;
@@ -606,6 +622,25 @@ pub(crate) fn validate_docker_ingest_config(config: &DockerIngestConfig) -> anyh
                 host.name
             ));
         }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_syslog_config(config: &SyslogConfig) -> anyhow::Result<()> {
+    if config.max_message_size == 0 {
+        return Err(anyhow::anyhow!("syslog.max_message_size must be > 0"));
+    }
+    if config.max_tcp_connections == 0 {
+        return Err(anyhow::anyhow!("syslog.max_tcp_connections must be > 0"));
+    }
+    if config.tcp_idle_timeout_secs == 0 {
+        return Err(anyhow::anyhow!("syslog.tcp_idle_timeout_secs must be > 0"));
+    }
+    if config.batch_size == 0 {
+        return Err(anyhow::anyhow!("syslog.batch_size must be > 0"));
+    }
+    if config.flush_interval == 0 {
+        return Err(anyhow::anyhow!("syslog.flush_interval must be > 0"));
     }
     Ok(())
 }

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -68,6 +68,11 @@ fn defaults_are_applied_without_env_vars() {
     for key in [
         "SYSLOG_HOST",
         "SYSLOG_PORT",
+        "SYSLOG_MAX_MESSAGE_SIZE",
+        "SYSLOG_MAX_TCP_CONNECTIONS",
+        "SYSLOG_TCP_IDLE_TIMEOUT_SECS",
+        "SYSLOG_BATCH_SIZE",
+        "SYSLOG_FLUSH_INTERVAL",
         "SYSLOG_MCP_HOST",
         "SYSLOG_MCP_PORT",
         "SYSLOG_MCP_ALLOWED_HOSTS",
@@ -118,6 +123,53 @@ fn defaults_are_applied_without_env_vars() {
     assert!(cfg.docker_ingest.hosts.is_empty());
     assert_eq!(cfg.docker_ingest.reconnect_initial_ms, 1_000);
     assert_eq!(cfg.docker_ingest.reconnect_max_ms, 30_000);
+}
+
+#[test]
+#[serial]
+fn rejects_invalid_syslog_ingest_env_settings() {
+    for (key, expected) in [
+        ("SYSLOG_MAX_MESSAGE_SIZE", "max_message_size"),
+        ("SYSLOG_MAX_TCP_CONNECTIONS", "max_tcp_connections"),
+        ("SYSLOG_TCP_IDLE_TIMEOUT_SECS", "tcp_idle_timeout_secs"),
+        ("SYSLOG_BATCH_SIZE", "batch_size"),
+        ("SYSLOG_FLUSH_INTERVAL", "flush_interval"),
+    ] {
+        std::env::set_var(key, "0");
+        let result = Config::load();
+        std::env::remove_var(key);
+
+        let err = result.expect_err(&format!("Config::load should reject {key}=0"));
+        assert!(
+            err.to_string().contains(expected),
+            "expected {key}=0 error to mention {expected}, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn rejects_invalid_syslog_ingest_toml_settings() {
+    for (toml, expected) in [
+        ("[syslog]\nmax_message_size = 0\n", "max_message_size"),
+        ("[syslog]\nmax_tcp_connections = 0\n", "max_tcp_connections"),
+        (
+            "[syslog]\ntcp_idle_timeout_secs = 0\n",
+            "tcp_idle_timeout_secs",
+        ),
+        ("[syslog]\nbatch_size = 0\n", "batch_size"),
+        ("[syslog]\nflush_interval = 0\n", "flush_interval"),
+    ] {
+        let mut config: Config = toml::from_str(toml).unwrap();
+        let err = validate_syslog_config(&config.syslog)
+            .expect_err(&format!("validate_syslog_config should reject {toml}"));
+        assert!(
+            err.to_string().contains(expected),
+            "expected TOML error to mention {expected}, got: {err}"
+        );
+
+        config.syslog = SyslogConfig::default();
+        validate_syslog_config(&config.syslog).unwrap();
+    }
 }
 
 #[test]

--- a/src/docker_ingest/supervisor.rs
+++ b/src/docker_ingest/supervisor.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use futures_util::StreamExt;
@@ -8,11 +9,16 @@ use tokio::task::JoinHandle;
 use crate::config::{DockerHostConfig, DockerIngestConfig};
 use crate::db::DbPool;
 use crate::ingest::IngestTx;
+use crate::observability::RuntimeObservability;
 
 use super::checkpoint::load_checkpoint;
 use super::client::DockerHostClient;
 use super::models::ContainerMeta;
 use super::parser::log_output_to_entry;
+
+const MIN_STREAM_DURATION_FOR_BACKOFF_RESET: Duration = Duration::from_secs(30);
+const RECONNECT_JITTER_MIN_PCT: u64 = 80;
+const RECONNECT_JITTER_SPREAD_PCT: u64 = 41;
 
 pub(crate) fn spawn_all(
     config: DockerIngestConfig,
@@ -31,8 +37,9 @@ pub(crate) fn spawn_all(
             let config = config.clone();
             let pool = Arc::clone(&pool);
             let ingest = ingest.clone();
+            let observability = ingest.observability();
             tokio::spawn(async move {
-                run_host_forever(config, host, pool, ingest).await;
+                run_host_forever(config, host, pool, ingest, observability).await;
             })
         })
         .collect()
@@ -43,32 +50,85 @@ async fn run_host_forever(
     host: DockerHostConfig,
     pool: Arc<DbPool>,
     ingest: IngestTx,
+    observability: Arc<RuntimeObservability>,
 ) {
     let mut delay_ms = config.reconnect_initial_ms;
     loop {
-        let reset_backoff = match run_host_once(&config, &host, Arc::clone(&pool), ingest.clone())
+        let stream_started = Instant::now();
+        let outcome = {
+            let _active = ActiveDockerHostStream::new(Arc::clone(&observability));
+            match run_host_once(
+                &config,
+                &host,
+                Arc::clone(&pool),
+                ingest.clone(),
+                Arc::clone(&observability),
+            )
             .await
-        {
-            Ok(()) => {
-                tracing::warn!(host = %host.name, "Docker ingest host stream ended; reconnecting");
-                true
-            }
-            Err(e) => {
-                tracing::warn!(
-                    host = %host.name,
-                    error = %e,
-                    delay_ms,
-                    "Docker ingest host failed; retrying"
-                );
-                false
+            {
+                Ok(()) => {
+                    tracing::warn!(host = %host.name, "Docker ingest host stream ended; reconnecting");
+                    StreamEnd::Clean
+                }
+                Err(e) => {
+                    observability.record_docker_ingest_stream_failure();
+                    tracing::warn!(
+                        host = %host.name,
+                        error = %e,
+                        delay_ms,
+                        "Docker ingest host failed; retrying"
+                    );
+                    StreamEnd::Failed
+                }
             }
         };
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-        delay_ms = if reset_backoff {
-            config.reconnect_initial_ms
-        } else {
-            (delay_ms * 2).min(config.reconnect_max_ms)
-        };
+        let reset_backoff = should_reset_reconnect_backoff(outcome, stream_started.elapsed());
+        observability.record_docker_ingest_stream_reconnect();
+        tokio::time::sleep(Duration::from_millis(jittered_reconnect_delay_ms(
+            delay_ms, &host.name,
+        )))
+        .await;
+        delay_ms = next_reconnect_backoff_ms(
+            delay_ms,
+            config.reconnect_initial_ms,
+            config.reconnect_max_ms,
+            reset_backoff,
+        );
+    }
+}
+
+struct ActiveDockerHostStream {
+    observability: Arc<RuntimeObservability>,
+}
+
+impl ActiveDockerHostStream {
+    fn new(observability: Arc<RuntimeObservability>) -> Self {
+        observability.record_docker_ingest_host_stream_started();
+        Self { observability }
+    }
+}
+
+impl Drop for ActiveDockerHostStream {
+    fn drop(&mut self) {
+        self.observability.record_docker_ingest_host_stream_ended();
+    }
+}
+
+struct ActiveDockerContainerStream {
+    observability: Arc<RuntimeObservability>,
+}
+
+impl ActiveDockerContainerStream {
+    fn new(observability: Arc<RuntimeObservability>) -> Self {
+        observability.record_docker_ingest_container_stream_started();
+        Self { observability }
+    }
+}
+
+impl Drop for ActiveDockerContainerStream {
+    fn drop(&mut self) {
+        self.observability
+            .record_docker_ingest_container_stream_ended();
     }
 }
 
@@ -77,6 +137,7 @@ async fn run_host_once(
     host: &DockerHostConfig,
     pool: Arc<DbPool>,
     ingest: IngestTx,
+    observability: Arc<RuntimeObservability>,
 ) -> Result<()> {
     let event_since_unix = chrono::Utc::now().timestamp().saturating_sub(60);
     let client = DockerHostClient::connect(&host.base_url)?;
@@ -88,49 +149,46 @@ async fn run_host_once(
     );
 
     let mut log_tasks: HashMap<String, JoinHandle<()>> = HashMap::new();
-    for container in containers {
-        spawn_log_task_if_absent(
-            config,
-            host,
-            &client,
-            Arc::clone(&pool),
-            ingest.clone(),
-            &mut log_tasks,
-            container,
-        );
-    }
-
-    let result = follow_container_events(
+    let runtime = HostRuntime {
         config,
         host,
-        &client,
+        client: &client,
         pool,
         ingest,
-        &mut log_tasks,
-        event_since_unix,
-    )
-    .await;
+        observability,
+    };
+    for container in containers {
+        spawn_log_task_if_absent(&runtime, &mut log_tasks, container);
+    }
+
+    let result = follow_container_events(&runtime, &mut log_tasks, event_since_unix).await;
     for handle in log_tasks.into_values() {
         handle.abort();
     }
     result
 }
 
-async fn follow_container_events(
-    config: &DockerIngestConfig,
-    host: &DockerHostConfig,
-    client: &DockerHostClient,
+struct HostRuntime<'a> {
+    config: &'a DockerIngestConfig,
+    host: &'a DockerHostConfig,
+    client: &'a DockerHostClient,
     pool: Arc<DbPool>,
     ingest: IngestTx,
+    observability: Arc<RuntimeObservability>,
+}
+
+async fn follow_container_events(
+    runtime: &HostRuntime<'_>,
     log_tasks: &mut HashMap<String, JoinHandle<()>>,
     event_since_unix: i64,
 ) -> Result<()> {
-    let docker = client.docker();
+    let docker = runtime.client.docker();
     let mut events = docker.events(Some(DockerHostClient::container_events_options(
         event_since_unix,
     )));
     while let Some(event) = events.next().await {
         let event = event?;
+        runtime.observability.record_docker_ingest_event();
         let action = event.action.unwrap_or_default();
         let Some(actor) = event.actor else {
             continue;
@@ -139,33 +197,26 @@ async fn follow_container_events(
             continue;
         };
 
-        match action.as_str() {
-            "start" | "restart" | "rename" => {
+        let policy = event_task_policy(&action);
+        match policy {
+            DockerEventTaskPolicy::EnsureLogTask | DockerEventTaskPolicy::ReplaceLogTask => {
                 prune_finished_tasks(log_tasks);
-                if action == "rename" {
+                if policy == DockerEventTaskPolicy::ReplaceLogTask {
                     if let Some(handle) = log_tasks.remove(&id) {
                         handle.abort();
                     }
                 }
-                let containers = client.list_containers().await?;
+                let containers = runtime.client.list_containers().await?;
                 for container in containers.into_iter().filter(|c| c.id == id) {
-                    spawn_log_task_if_absent(
-                        config,
-                        host,
-                        client,
-                        Arc::clone(&pool),
-                        ingest.clone(),
-                        log_tasks,
-                        container,
-                    );
+                    spawn_log_task_if_absent(runtime, log_tasks, container);
                 }
             }
-            "die" | "destroy" | "stop" => {
+            DockerEventTaskPolicy::StopLogTask => {
                 if let Some(handle) = log_tasks.remove(&id) {
                     handle.abort();
                 }
             }
-            _ => {}
+            DockerEventTaskPolicy::Ignore => {}
         }
     }
     Ok(())
@@ -182,70 +233,130 @@ fn is_expected_disconnect(e: &anyhow::Error) -> bool {
         || msg.contains("broken pipe")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DockerEventTaskPolicy {
+    EnsureLogTask,
+    ReplaceLogTask,
+    StopLogTask,
+    Ignore,
+}
+
+fn event_task_policy(action: &str) -> DockerEventTaskPolicy {
+    match action {
+        "start" | "restart" => DockerEventTaskPolicy::EnsureLogTask,
+        "rename" => DockerEventTaskPolicy::ReplaceLogTask,
+        "die" | "destroy" | "stop" => DockerEventTaskPolicy::StopLogTask,
+        _ => DockerEventTaskPolicy::Ignore,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamEnd {
+    Clean,
+    ExpectedDisconnect,
+    Failed,
+}
+
+fn should_reset_reconnect_backoff(outcome: StreamEnd, stream_duration: Duration) -> bool {
+    matches!(outcome, StreamEnd::Clean | StreamEnd::ExpectedDisconnect)
+        && stream_duration >= MIN_STREAM_DURATION_FOR_BACKOFF_RESET
+}
+
+fn next_reconnect_backoff_ms(current_ms: u64, initial_ms: u64, max_ms: u64, reset: bool) -> u64 {
+    if reset {
+        initial_ms
+    } else {
+        current_ms.saturating_mul(2).min(max_ms)
+    }
+}
+
+fn jittered_reconnect_delay_ms(base_ms: u64, key: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in key.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    let pct = RECONNECT_JITTER_MIN_PCT + (hash % RECONNECT_JITTER_SPREAD_PCT);
+    ((u128::from(base_ms) * u128::from(pct)) / 100).max(1) as u64
+}
+
 fn spawn_log_task_if_absent(
-    config: &DockerIngestConfig,
-    host: &DockerHostConfig,
-    client: &DockerHostClient,
-    pool: Arc<DbPool>,
-    ingest: IngestTx,
+    runtime: &HostRuntime<'_>,
     tasks: &mut HashMap<String, JoinHandle<()>>,
     container: ContainerMeta,
 ) {
     if tasks.contains_key(&container.id) {
         return;
     }
-    let docker = client.docker();
-    let host_name = host.name.clone();
-    let reconnect_initial_ms = config.reconnect_initial_ms;
-    let reconnect_max_ms = config.reconnect_max_ms;
+    let docker = runtime.client.docker();
+    let host_name = runtime.host.name.clone();
+    let reconnect_initial_ms = runtime.config.reconnect_initial_ms;
+    let reconnect_max_ms = runtime.config.reconnect_max_ms;
+    let pool = Arc::clone(&runtime.pool);
+    let ingest = runtime.ingest.clone();
+    let observability = Arc::clone(&runtime.observability);
     let container_id = container.id.clone();
     let task_container_id = container_id.clone();
+    observability.record_docker_ingest_task_spawned();
     let handle = tokio::spawn(async move {
         let mut delay_ms = reconnect_initial_ms;
         loop {
-            let reset_backoff = match follow_container_logs_once(
-                &docker,
-                &pool,
-                &ingest,
-                &host_name,
+            let stream_started = Instant::now();
+            let outcome = {
+                let _active = ActiveDockerContainerStream::new(Arc::clone(&observability));
+                match follow_container_logs_once(
+                    &docker,
+                    &pool,
+                    &ingest,
+                    &observability,
+                    &host_name,
+                    &task_container_id,
+                    &container,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        tracing::debug!(
+                            host = %host_name,
+                            container_id = %task_container_id,
+                            "Docker log stream ended; reconnecting"
+                        );
+                        StreamEnd::Clean
+                    }
+                    Err(ref e) if is_expected_disconnect(e) => {
+                        tracing::debug!(
+                            host = %host_name,
+                            container_id = %task_container_id,
+                            "Docker log stream closed by daemon; reconnecting"
+                        );
+                        StreamEnd::ExpectedDisconnect
+                    }
+                    Err(e) => {
+                        observability.record_docker_ingest_stream_failure();
+                        tracing::warn!(
+                            host = %host_name,
+                            container_id = %task_container_id,
+                            error = %e,
+                            delay_ms,
+                            "Docker log stream failed; retrying"
+                        );
+                        StreamEnd::Failed
+                    }
+                }
+            };
+            let reset_backoff = should_reset_reconnect_backoff(outcome, stream_started.elapsed());
+            observability.record_docker_ingest_stream_reconnect();
+            tokio::time::sleep(Duration::from_millis(jittered_reconnect_delay_ms(
+                delay_ms,
                 &task_container_id,
-                &container,
-            )
-            .await
-            {
-                Ok(()) => {
-                    tracing::debug!(
-                        host = %host_name,
-                        container_id = %task_container_id,
-                        "Docker log stream ended; reconnecting"
-                    );
-                    true
-                }
-                Err(ref e) if is_expected_disconnect(e) => {
-                    tracing::debug!(
-                        host = %host_name,
-                        container_id = %task_container_id,
-                        "Docker log stream closed by daemon; reconnecting"
-                    );
-                    true
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        host = %host_name,
-                        container_id = %task_container_id,
-                        error = %e,
-                        delay_ms,
-                        "Docker log stream failed; retrying"
-                    );
-                    false
-                }
-            };
-            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-            delay_ms = if reset_backoff {
-                reconnect_initial_ms
-            } else {
-                (delay_ms * 2).min(reconnect_max_ms)
-            };
+            )))
+            .await;
+            delay_ms = next_reconnect_backoff_ms(
+                delay_ms,
+                reconnect_initial_ms,
+                reconnect_max_ms,
+                reset_backoff,
+            );
         }
     });
     tasks.insert(container_id, handle);
@@ -255,6 +366,7 @@ async fn follow_container_logs_once(
     docker: &bollard::Docker,
     pool: &Arc<DbPool>,
     ingest: &IngestTx,
+    observability: &RuntimeObservability,
     host_name: &str,
     container_id: &str,
     container: &ContainerMeta,
@@ -270,6 +382,7 @@ async fn follow_container_logs_once(
     while let Some(output) = logs.next().await {
         match log_output_to_entry(host_name, container, output?) {
             Ok(Some(entry)) => {
+                observability.record_docker_ingest_log_entry();
                 if checkpoint
                     .as_ref()
                     .is_some_and(|checkpoint| entry_is_at_or_before_checkpoint(&entry, checkpoint))
@@ -281,12 +394,15 @@ async fn follow_container_logs_once(
                 }
             }
             Ok(None) => {}
-            Err(e) => tracing::warn!(
-                host = %host_name,
-                container_id = %container_id,
-                error = %e,
-                "Failed to parse Docker log frame"
-            ),
+            Err(e) => {
+                observability.record_docker_ingest_parse_error();
+                tracing::warn!(
+                    host = %host_name,
+                    container_id = %container_id,
+                    error = %e,
+                    "Failed to parse Docker log frame"
+                );
+            }
         }
     }
     Ok(())
@@ -304,48 +420,6 @@ fn entry_is_at_or_before_checkpoint(
         })
         .is_some_and(|entry_ts| entry_ts <= *checkpoint)
 }
-
 #[cfg(test)]
-mod tests {
-    use crate::db::{DockerCheckpoint, LogBatchEntry};
-
-    use super::entry_is_at_or_before_checkpoint;
-
-    fn docker_entry(timestamp: &str) -> LogBatchEntry {
-        LogBatchEntry {
-            timestamp: timestamp.into(),
-            hostname: "edge-host-a".into(),
-            facility: Some("local0".into()),
-            severity: "info".into(),
-            app_name: Some("nginx".into()),
-            process_id: Some("abcdef123456".into()),
-            message: "line".into(),
-            raw: format!("{timestamp} line"),
-            source_ip: "docker://edge-host-a/abcdef123456/stdout".into(),
-            docker_checkpoint: Some(DockerCheckpoint {
-                host_name: "edge-host-a".into(),
-                container_id: "abcdef123456".into(),
-                timestamp: timestamp.into(),
-            }),
-        }
-    }
-
-    #[test]
-    fn checkpoint_filter_skips_only_entries_at_or_before_precise_checkpoint() {
-        let checkpoint =
-            chrono::DateTime::parse_from_rfc3339("2026-05-05T01:02:03.500000000Z").unwrap();
-
-        assert!(entry_is_at_or_before_checkpoint(
-            &docker_entry("2026-05-05T01:02:03.123456789Z"),
-            &checkpoint
-        ));
-        assert!(entry_is_at_or_before_checkpoint(
-            &docker_entry("2026-05-05T01:02:03.500000000Z"),
-            &checkpoint
-        ));
-        assert!(!entry_is_at_or_before_checkpoint(
-            &docker_entry("2026-05-05T01:02:03.500000001Z"),
-            &checkpoint
-        ));
-    }
-}
+#[path = "supervisor_tests.rs"]
+mod tests;

--- a/src/docker_ingest/supervisor_tests.rs
+++ b/src/docker_ingest/supervisor_tests.rs
@@ -1,0 +1,125 @@
+use std::time::Duration;
+
+use crate::db::{DockerCheckpoint, LogBatchEntry};
+
+use super::{
+    entry_is_at_or_before_checkpoint, event_task_policy, jittered_reconnect_delay_ms,
+    next_reconnect_backoff_ms, should_reset_reconnect_backoff, DockerEventTaskPolicy, StreamEnd,
+    MIN_STREAM_DURATION_FOR_BACKOFF_RESET,
+};
+
+fn docker_entry(timestamp: &str) -> LogBatchEntry {
+    LogBatchEntry {
+        timestamp: timestamp.into(),
+        hostname: "edge-host-a".into(),
+        facility: Some("local0".into()),
+        severity: "info".into(),
+        app_name: Some("nginx".into()),
+        process_id: Some("abcdef123456".into()),
+        message: "line".into(),
+        raw: format!("{timestamp} line"),
+        source_ip: "docker://edge-host-a/abcdef123456/stdout".into(),
+        docker_checkpoint: Some(DockerCheckpoint {
+            host_name: "edge-host-a".into(),
+            container_id: "abcdef123456".into(),
+            timestamp: timestamp.into(),
+        }),
+    }
+}
+
+#[test]
+fn checkpoint_filter_skips_only_entries_at_or_before_precise_checkpoint() {
+    let checkpoint =
+        chrono::DateTime::parse_from_rfc3339("2026-05-05T01:02:03.500000000Z").unwrap();
+
+    assert!(entry_is_at_or_before_checkpoint(
+        &docker_entry("2026-05-05T01:02:03.123456789Z"),
+        &checkpoint
+    ));
+    assert!(entry_is_at_or_before_checkpoint(
+        &docker_entry("2026-05-05T01:02:03.500000000Z"),
+        &checkpoint
+    ));
+    assert!(!entry_is_at_or_before_checkpoint(
+        &docker_entry("2026-05-05T01:02:03.500000001Z"),
+        &checkpoint
+    ));
+}
+
+#[test]
+fn docker_event_policy_maps_lifecycle_actions_to_task_work() {
+    assert_eq!(
+        event_task_policy("start"),
+        DockerEventTaskPolicy::EnsureLogTask
+    );
+    assert_eq!(
+        event_task_policy("restart"),
+        DockerEventTaskPolicy::EnsureLogTask
+    );
+    assert_eq!(
+        event_task_policy("rename"),
+        DockerEventTaskPolicy::ReplaceLogTask
+    );
+    assert_eq!(event_task_policy("die"), DockerEventTaskPolicy::StopLogTask);
+    assert_eq!(
+        event_task_policy("stop"),
+        DockerEventTaskPolicy::StopLogTask
+    );
+    assert_eq!(
+        event_task_policy("destroy"),
+        DockerEventTaskPolicy::StopLogTask
+    );
+    assert_eq!(
+        event_task_policy("exec_start"),
+        DockerEventTaskPolicy::Ignore
+    );
+}
+
+#[test]
+fn reconnect_backoff_resets_only_after_durable_clean_streams() {
+    assert!(!should_reset_reconnect_backoff(
+        StreamEnd::Clean,
+        MIN_STREAM_DURATION_FOR_BACKOFF_RESET - Duration::from_millis(1)
+    ));
+    assert!(should_reset_reconnect_backoff(
+        StreamEnd::Clean,
+        MIN_STREAM_DURATION_FOR_BACKOFF_RESET
+    ));
+    assert!(should_reset_reconnect_backoff(
+        StreamEnd::ExpectedDisconnect,
+        MIN_STREAM_DURATION_FOR_BACKOFF_RESET + Duration::from_secs(1)
+    ));
+    assert!(!should_reset_reconnect_backoff(
+        StreamEnd::Failed,
+        MIN_STREAM_DURATION_FOR_BACKOFF_RESET + Duration::from_secs(1)
+    ));
+}
+
+#[test]
+fn reconnect_backoff_doubles_to_cap_unless_reset() {
+    assert_eq!(
+        next_reconnect_backoff_ms(1_000, 1_000, 30_000, false),
+        2_000
+    );
+    assert_eq!(
+        next_reconnect_backoff_ms(20_000, 1_000, 30_000, false),
+        30_000
+    );
+    assert_eq!(
+        next_reconnect_backoff_ms(u64::MAX, 1_000, 30_000, false),
+        30_000
+    );
+    assert_eq!(next_reconnect_backoff_ms(8_000, 1_000, 30_000, true), 1_000);
+}
+
+#[test]
+fn reconnect_delay_jitter_is_deterministic_and_bounded() {
+    let first = jittered_reconnect_delay_ms(10_000, "edge-host-a");
+    let second = jittered_reconnect_delay_ms(10_000, "edge-host-a");
+    let other = jittered_reconnect_delay_ms(10_000, "edge-host-b");
+
+    assert_eq!(first, second);
+    assert_ne!(first, other);
+    assert!((8_000..=12_000).contains(&first));
+    assert!((8_000..=12_000).contains(&other));
+}

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -15,6 +15,14 @@ pub struct RuntimeObservability {
     syslog_tcp_lines_received: AtomicU64,
     syslog_tcp_bytes_received: AtomicU64,
     syslog_tcp_lines_dropped_oversize: AtomicU64,
+    docker_ingest_events_received: AtomicU64,
+    docker_ingest_log_entries_received: AtomicU64,
+    docker_ingest_parse_errors: AtomicU64,
+    docker_ingest_stream_reconnects: AtomicU64,
+    docker_ingest_stream_failures: AtomicU64,
+    docker_ingest_tasks_spawned: AtomicU64,
+    docker_ingest_host_streams_active: AtomicU64,
+    docker_ingest_container_streams_active: AtomicU64,
     ingest_entries_enqueued: AtomicU64,
     ingest_enqueue_errors: AtomicU64,
     ingest_queue_depth: AtomicUsize,
@@ -28,6 +36,9 @@ pub struct RuntimeObservability {
     last_ingest_at: Mutex<Option<String>>,
     last_write_at: Mutex<Option<String>>,
     last_error_at: Mutex<Option<String>>,
+    last_docker_ingest_event_at: Mutex<Option<String>>,
+    last_docker_ingest_log_at: Mutex<Option<String>>,
+    last_docker_ingest_error_at: Mutex<Option<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -41,6 +52,14 @@ pub struct RuntimeObservabilitySnapshot {
     pub syslog_tcp_lines_received: u64,
     pub syslog_tcp_bytes_received: u64,
     pub syslog_tcp_lines_dropped_oversize: u64,
+    pub docker_ingest_events_received: u64,
+    pub docker_ingest_log_entries_received: u64,
+    pub docker_ingest_parse_errors: u64,
+    pub docker_ingest_stream_reconnects: u64,
+    pub docker_ingest_stream_failures: u64,
+    pub docker_ingest_tasks_spawned: u64,
+    pub docker_ingest_host_streams_active: u64,
+    pub docker_ingest_container_streams_active: u64,
     pub ingest_entries_enqueued: u64,
     pub ingest_enqueue_errors: u64,
     pub ingest_queue_depth: usize,
@@ -55,6 +74,9 @@ pub struct RuntimeObservabilitySnapshot {
     pub last_ingest_at: Option<String>,
     pub last_write_at: Option<String>,
     pub last_error_at: Option<String>,
+    pub last_docker_ingest_event_at: Option<String>,
+    pub last_docker_ingest_log_at: Option<String>,
+    pub last_docker_ingest_error_at: Option<String>,
 }
 
 impl RuntimeObservability {
@@ -110,6 +132,73 @@ impl RuntimeObservability {
         self.syslog_tcp_lines_dropped_oversize
             .fetch_add(1, Ordering::Relaxed);
         self.touch_error();
+    }
+
+    pub fn record_docker_ingest_event(&self) {
+        self.docker_ingest_events_received
+            .fetch_add(1, Ordering::Relaxed);
+        *self
+            .last_docker_ingest_event_at
+            .lock()
+            .expect("last_docker_ingest_event_at mutex poisoned") = Some(now_iso());
+    }
+
+    pub fn record_docker_ingest_log_entry(&self) {
+        self.docker_ingest_log_entries_received
+            .fetch_add(1, Ordering::Relaxed);
+        *self
+            .last_docker_ingest_log_at
+            .lock()
+            .expect("last_docker_ingest_log_at mutex poisoned") = Some(now_iso());
+        self.touch_ingest();
+    }
+
+    pub fn record_docker_ingest_parse_error(&self) {
+        self.docker_ingest_parse_errors
+            .fetch_add(1, Ordering::Relaxed);
+        self.touch_docker_ingest_error();
+    }
+
+    pub fn record_docker_ingest_stream_reconnect(&self) {
+        self.docker_ingest_stream_reconnects
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_docker_ingest_stream_failure(&self) {
+        self.docker_ingest_stream_failures
+            .fetch_add(1, Ordering::Relaxed);
+        self.touch_docker_ingest_error();
+    }
+
+    pub fn record_docker_ingest_task_spawned(&self) {
+        self.docker_ingest_tasks_spawned
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_docker_ingest_host_stream_started(&self) {
+        self.docker_ingest_host_streams_active
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_docker_ingest_host_stream_ended(&self) {
+        self.docker_ingest_host_streams_active
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                Some(n.saturating_sub(1))
+            })
+            .ok();
+    }
+
+    pub fn record_docker_ingest_container_stream_started(&self) {
+        self.docker_ingest_container_streams_active
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_docker_ingest_container_stream_ended(&self) {
+        self.docker_ingest_container_streams_active
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                Some(n.saturating_sub(1))
+            })
+            .ok();
     }
 
     pub fn record_enqueue_ok(&self, queue_depth: usize) {
@@ -178,6 +267,26 @@ impl RuntimeObservability {
             syslog_tcp_lines_dropped_oversize: self
                 .syslog_tcp_lines_dropped_oversize
                 .load(Ordering::Relaxed),
+            docker_ingest_events_received: self
+                .docker_ingest_events_received
+                .load(Ordering::Relaxed),
+            docker_ingest_log_entries_received: self
+                .docker_ingest_log_entries_received
+                .load(Ordering::Relaxed),
+            docker_ingest_parse_errors: self.docker_ingest_parse_errors.load(Ordering::Relaxed),
+            docker_ingest_stream_reconnects: self
+                .docker_ingest_stream_reconnects
+                .load(Ordering::Relaxed),
+            docker_ingest_stream_failures: self
+                .docker_ingest_stream_failures
+                .load(Ordering::Relaxed),
+            docker_ingest_tasks_spawned: self.docker_ingest_tasks_spawned.load(Ordering::Relaxed),
+            docker_ingest_host_streams_active: self
+                .docker_ingest_host_streams_active
+                .load(Ordering::Relaxed),
+            docker_ingest_container_streams_active: self
+                .docker_ingest_container_streams_active
+                .load(Ordering::Relaxed),
             ingest_entries_enqueued: self.ingest_entries_enqueued.load(Ordering::Relaxed),
             ingest_enqueue_errors: self.ingest_enqueue_errors.load(Ordering::Relaxed),
             ingest_queue_depth: queue_depth,
@@ -204,6 +313,21 @@ impl RuntimeObservability {
                 .lock()
                 .expect("last_error_at mutex poisoned")
                 .clone(),
+            last_docker_ingest_event_at: self
+                .last_docker_ingest_event_at
+                .lock()
+                .expect("last_docker_ingest_event_at mutex poisoned")
+                .clone(),
+            last_docker_ingest_log_at: self
+                .last_docker_ingest_log_at
+                .lock()
+                .expect("last_docker_ingest_log_at mutex poisoned")
+                .clone(),
+            last_docker_ingest_error_at: self
+                .last_docker_ingest_error_at
+                .lock()
+                .expect("last_docker_ingest_error_at mutex poisoned")
+                .clone(),
         }
     }
 
@@ -219,6 +343,14 @@ impl RuntimeObservability {
             .last_error_at
             .lock()
             .expect("last_error_at mutex poisoned") = Some(now_iso());
+    }
+
+    fn touch_docker_ingest_error(&self) {
+        *self
+            .last_docker_ingest_error_at
+            .lock()
+            .expect("last_docker_ingest_error_at mutex poisoned") = Some(now_iso());
+        self.touch_error();
     }
 }
 
@@ -252,5 +384,43 @@ mod tests {
         obs.record_tcp_connection_accepted();
         obs.record_tcp_connection_closed();
         assert_eq!(obs.snapshot().syslog_tcp_connections_active, 0);
+    }
+
+    #[test]
+    fn snapshot_reports_docker_ingest_counters() {
+        let obs = RuntimeObservability::default();
+        obs.record_docker_ingest_event();
+        obs.record_docker_ingest_log_entry();
+        obs.record_docker_ingest_parse_error();
+        obs.record_docker_ingest_stream_reconnect();
+        obs.record_docker_ingest_stream_failure();
+        obs.record_docker_ingest_task_spawned();
+        obs.record_docker_ingest_host_stream_started();
+        obs.record_docker_ingest_container_stream_started();
+
+        let snapshot = obs.snapshot();
+
+        assert_eq!(snapshot.docker_ingest_events_received, 1);
+        assert_eq!(snapshot.docker_ingest_log_entries_received, 1);
+        assert_eq!(snapshot.docker_ingest_parse_errors, 1);
+        assert_eq!(snapshot.docker_ingest_stream_reconnects, 1);
+        assert_eq!(snapshot.docker_ingest_stream_failures, 1);
+        assert_eq!(snapshot.docker_ingest_tasks_spawned, 1);
+        assert_eq!(snapshot.docker_ingest_host_streams_active, 1);
+        assert_eq!(snapshot.docker_ingest_container_streams_active, 1);
+        assert!(snapshot.last_ingest_at.is_some());
+        assert!(snapshot.last_error_at.is_some());
+        assert!(snapshot.last_docker_ingest_event_at.is_some());
+        assert!(snapshot.last_docker_ingest_log_at.is_some());
+        assert!(snapshot.last_docker_ingest_error_at.is_some());
+
+        obs.record_docker_ingest_host_stream_ended();
+        obs.record_docker_ingest_host_stream_ended();
+        obs.record_docker_ingest_container_stream_ended();
+        obs.record_docker_ingest_container_stream_ended();
+
+        let snapshot = obs.snapshot();
+        assert_eq!(snapshot.docker_ingest_host_streams_active, 0);
+        assert_eq!(snapshot.docker_ingest_container_streams_active, 0);
     }
 }

--- a/src/syslog/listener.rs
+++ b/src/syslog/listener.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
 use tokio::net::{TcpListener, UdpSocket};
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn};
@@ -11,6 +11,13 @@ use crate::ingest::IngestTx;
 use super::parser::parse_syslog;
 use super::writer::source_addr_ip;
 use super::WRITE_CHANNEL_CAPACITY;
+
+#[derive(Debug)]
+enum TcpFrame {
+    Line(String),
+    Oversize { line_bytes: usize, terminated: bool },
+    Eof,
+}
 
 /// UDP syslog receiver.
 pub(super) async fn udp_listener(bind: &str, max_size: usize, ingest: IngestTx) -> Result<()> {
@@ -34,23 +41,24 @@ pub(super) async fn udp_listener(bind: &str, max_size: usize, ingest: IngestTx) 
                     "UDP syslog packet received"
                 );
 
-                let at_capacity = ingest.capacity() == 0;
-                if at_capacity && !backpressure {
-                    warn!(
-                        src = %addr,
-                        queue_depth = ingest.queue_depth(),
-                        channel_capacity = WRITE_CHANNEL_CAPACITY,
-                        "syslog write channel full — backpressure applied"
-                    );
-                    backpressure = true;
-                } else if !at_capacity && backpressure {
-                    info!(
-                        src = %addr,
-                        queue_depth = ingest.queue_depth(),
-                        channel_capacity = WRITE_CHANNEL_CAPACITY,
-                        "syslog write channel cleared — backpressure lifted"
-                    );
-                    backpressure = false;
+                match update_backpressure(&mut backpressure, ingest.capacity() == 0) {
+                    Some(BackpressureTransition::Applied) => {
+                        warn!(
+                            src = %addr,
+                            queue_depth = ingest.queue_depth(),
+                            channel_capacity = WRITE_CHANNEL_CAPACITY,
+                            "syslog write channel full — backpressure applied"
+                        );
+                    }
+                    Some(BackpressureTransition::Cleared) => {
+                        info!(
+                            src = %addr,
+                            queue_depth = ingest.queue_depth(),
+                            channel_capacity = WRITE_CHANNEL_CAPACITY,
+                            "syslog write channel cleared — backpressure lifted"
+                        );
+                    }
+                    None => {}
                 }
 
                 if ingest
@@ -84,8 +92,7 @@ pub(super) async fn handle_tcp_connection(
     // Persistent forwarders like rsyslog reuse a single TCP session for many
     // syslog frames, so max_size must apply per message line, not to the whole
     // connection lifetime.
-    let reader = BufReader::new(stream);
-    let mut lines = reader.lines();
+    let mut reader = BufReader::new(stream);
     let mut backpressure = false;
     let mut line_count: u64 = 0;
     let mut total_bytes: usize = 0;
@@ -95,47 +102,37 @@ pub(super) async fn handle_tcp_connection(
         // Idle timeout is per read, not wall-clock lifetime.
         let next = tokio::time::timeout(
             tokio::time::Duration::from_secs(idle_timeout_secs),
-            lines.next_line(),
+            read_bounded_line(&mut reader, max_size),
         );
         match next.await {
-            Ok(Ok(Some(line))) => {
+            Ok(Ok(TcpFrame::Line(line))) => {
                 if line.is_empty() {
-                    continue;
-                }
-                if line.len() > max_size {
-                    observability.record_tcp_line_dropped_oversize();
-                    warn!(
-                        peer = %addr,
-                        line_count,
-                        line_bytes = line.len(),
-                        max_message_size = max_size,
-                        "Dropping oversized TCP syslog line"
-                    );
                     continue;
                 }
                 line_count += 1;
                 total_bytes += line.len();
                 observability.record_tcp_line(line.len());
 
-                let at_capacity = ingest.capacity() == 0;
-                if at_capacity && !backpressure {
-                    warn!(
-                        peer = %addr,
-                        queue_depth = ingest.queue_depth(),
-                        channel_capacity = WRITE_CHANNEL_CAPACITY,
-                        line_count,
-                        "syslog write channel full — backpressure applied"
-                    );
-                    backpressure = true;
-                } else if !at_capacity && backpressure {
-                    info!(
-                        peer = %addr,
-                        queue_depth = ingest.queue_depth(),
-                        channel_capacity = WRITE_CHANNEL_CAPACITY,
-                        line_count,
-                        "syslog write channel cleared — backpressure lifted"
-                    );
-                    backpressure = false;
+                match update_backpressure(&mut backpressure, ingest.capacity() == 0) {
+                    Some(BackpressureTransition::Applied) => {
+                        warn!(
+                            peer = %addr,
+                            queue_depth = ingest.queue_depth(),
+                            channel_capacity = WRITE_CHANNEL_CAPACITY,
+                            line_count,
+                            "syslog write channel full — backpressure applied"
+                        );
+                    }
+                    Some(BackpressureTransition::Cleared) => {
+                        info!(
+                            peer = %addr,
+                            queue_depth = ingest.queue_depth(),
+                            channel_capacity = WRITE_CHANNEL_CAPACITY,
+                            line_count,
+                            "syslog write channel cleared — backpressure lifted"
+                        );
+                    }
+                    None => {}
                 }
                 debug!(
                     peer = %addr,
@@ -158,7 +155,25 @@ pub(super) async fn handle_tcp_connection(
                     break "write_channel_closed";
                 }
             }
-            Ok(Ok(None)) => break "eof",
+            Ok(Ok(TcpFrame::Oversize {
+                line_bytes,
+                terminated,
+            })) => {
+                observability.record_tcp_line_dropped_oversize();
+                warn!(
+                    peer = %addr,
+                    line_count,
+                    line_bytes,
+                    max_message_size = max_size,
+                    terminated,
+                    "Dropping oversized TCP syslog line"
+                );
+                if terminated {
+                    continue;
+                }
+                break "oversized_unterminated_line";
+            }
+            Ok(Ok(TcpFrame::Eof)) => break "eof",
             Ok(Err(e)) => {
                 error!(peer = %addr, error = %e, "TCP syslog read error");
                 break "read_error";
@@ -179,6 +194,68 @@ pub(super) async fn handle_tcp_connection(
         "TCP syslog connection closed"
     );
     observability.record_tcp_connection_closed();
+}
+
+async fn read_bounded_line<R>(reader: &mut R, max_size: usize) -> std::io::Result<TcpFrame>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut line = Vec::with_capacity(max_size.min(8192));
+
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return if line.is_empty() {
+                Ok(TcpFrame::Eof)
+            } else {
+                Ok(TcpFrame::Line(decode_tcp_line(&line)))
+            };
+        }
+
+        if let Some(pos) = available.iter().position(|byte| *byte == b'\n') {
+            let take = pos + 1;
+            let total = line.len().saturating_add(take);
+            let payload_bytes = line
+                .len()
+                .saturating_add(pos)
+                .saturating_sub(usize::from(pos > 0 && available[pos - 1] == b'\r'));
+            if payload_bytes > max_size {
+                reader.consume(take);
+                return Ok(TcpFrame::Oversize {
+                    line_bytes: total,
+                    terminated: true,
+                });
+            }
+            line.extend_from_slice(&available[..take]);
+            reader.consume(take);
+            return Ok(TcpFrame::Line(decode_tcp_line(&line)));
+        }
+
+        let available_len = available.len();
+        let total = line.len().saturating_add(available_len);
+        if total > max_size {
+            let remaining = max_size.saturating_sub(line.len());
+            if remaining > 0 {
+                line.extend_from_slice(&available[..remaining]);
+            }
+            reader.consume(available_len);
+            return Ok(TcpFrame::Oversize {
+                line_bytes: total,
+                terminated: false,
+            });
+        }
+
+        line.extend_from_slice(available);
+        reader.consume(available_len);
+    }
+}
+
+fn decode_tcp_line(raw: &[u8]) -> String {
+    let mut end = raw.len();
+    while end > 0 && matches!(raw[end - 1], b'\n' | b'\r') {
+        end -= 1;
+    }
+    String::from_utf8_lossy(&raw[..end]).to_string()
 }
 
 /// TCP syslog receiver (newline-delimited).
@@ -260,6 +337,29 @@ pub(super) async fn tcp_listener(
         }
     }
     Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum BackpressureTransition {
+    Applied,
+    Cleared,
+}
+
+pub(super) fn update_backpressure(
+    backpressure: &mut bool,
+    at_capacity: bool,
+) -> Option<BackpressureTransition> {
+    match (at_capacity, *backpressure) {
+        (true, false) => {
+            *backpressure = true;
+            Some(BackpressureTransition::Applied)
+        }
+        (false, true) => {
+            *backpressure = false;
+            Some(BackpressureTransition::Cleared)
+        }
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/src/syslog/listener_tests.rs
+++ b/src/syslog/listener_tests.rs
@@ -1,5 +1,23 @@
 use super::*;
 
+#[test]
+fn update_backpressure_only_reports_state_transitions() {
+    let mut backpressure = false;
+
+    assert_eq!(
+        update_backpressure(&mut backpressure, true),
+        Some(BackpressureTransition::Applied)
+    );
+    assert!(backpressure);
+    assert_eq!(update_backpressure(&mut backpressure, true), None);
+    assert_eq!(
+        update_backpressure(&mut backpressure, false),
+        Some(BackpressureTransition::Cleared)
+    );
+    assert!(!backpressure);
+    assert_eq!(update_backpressure(&mut backpressure, false), None);
+}
+
 #[tokio::test]
 async fn tcp_connection_allows_multiple_lines_beyond_connection_total_size() {
     let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::db::LogBatchEntry>(16);
@@ -35,4 +53,81 @@ async fn tcp_connection_allows_multiple_lines_beyond_connection_total_size() {
     assert!(second.message.contains("second message"));
 
     accept_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn tcp_connection_closes_oversized_unterminated_line_without_enqueueing() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::db::LogBatchEntry>(16);
+    let ingest = crate::ingest::IngestTx::from_sender_for_test(tx);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let accept_task = tokio::spawn(async move {
+        let (server_stream, peer) = listener.accept().await.unwrap();
+        handle_tcp_connection(server_stream, peer, ingest, 32, 5).await;
+    });
+
+    let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    client.write_all(&vec![b'x'; 128]).await.unwrap();
+
+    let mut buf = [0u8; 1];
+    let read = tokio::time::timeout(std::time::Duration::from_secs(1), client.read(&mut buf))
+        .await
+        .expect("server should close oversized TCP connection")
+        .unwrap();
+    assert_eq!(read, 0);
+
+    match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await {
+        Ok(Some(entry)) => panic!(
+            "oversized unterminated line must not enqueue an entry, got: {:?}",
+            entry
+        ),
+        Ok(None) | Err(_) => {}
+    }
+
+    accept_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn tcp_connection_drops_oversized_delimited_line_and_keeps_later_frames() {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::db::LogBatchEntry>(16);
+    let ingest = crate::ingest::IngestTx::from_sender_for_test(tx);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let accept_task = tokio::spawn(async move {
+        let (server_stream, peer) = listener.accept().await.unwrap();
+        handle_tcp_connection(server_stream, peer, ingest, 32, 5).await;
+    });
+
+    let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    use tokio::io::AsyncWriteExt;
+    client.write_all(&vec![b'x'; 64]).await.unwrap();
+    client.write_all(b"\nvalid\n").await.unwrap();
+    client.shutdown().await.unwrap();
+
+    let entry = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(entry.raw.contains("valid"));
+
+    accept_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn bounded_reader_allows_crlf_frame_at_payload_limit() {
+    let input = format!("{}\r\nnext\n", "x".repeat(32));
+    let mut reader = BufReader::new(input.as_bytes());
+
+    match read_bounded_line(&mut reader, 32).await.unwrap() {
+        TcpFrame::Line(line) => assert_eq!(line, "x".repeat(32)),
+        other => panic!("expected bounded CRLF line, got unexpected frame: {other:?}"),
+    }
+
+    match read_bounded_line(&mut reader, 32).await.unwrap() {
+        TcpFrame::Line(line) => assert_eq!(line, "next"),
+        other => panic!("expected next line after CRLF frame, got unexpected frame: {other:?}"),
+    }
 }

--- a/src/syslog/writer.rs
+++ b/src/syslog/writer.rs
@@ -1,3 +1,4 @@
+use rusqlite::{Error as SqliteError, ErrorCode};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -10,6 +11,10 @@ use crate::db::{self, DbPool};
 use crate::observability::RuntimeObservability;
 
 const INGEST_SUMMARY_INTERVAL_SECS: u64 = 60;
+const FAILED_BATCH_RETAIN_LIMIT: usize = 1000;
+const FAILED_BATCH_RETRY_CHUNK_SIZE: usize = 100;
+const INGEST_SUMMARY_CARDINALITY_LIMIT: usize = 256;
+const OTHER_SUMMARY_LABEL: &str = "__other__";
 
 /// Batch writer — collects messages and writes in batches for throughput.
 pub(crate) struct WriterContext {
@@ -160,7 +165,10 @@ pub(super) async fn flush_batch(
     match tokio::task::spawn_blocking(
         move || match db::insert_logs_batch(&pool, &batch_to_write) {
             Ok(n) => Ok((n, batch_to_write)),
-            Err(e) => Err((e, batch_to_write, false)),
+            Err(e) => {
+                let outcome = handle_failed_batch(&pool, batch_to_write, &e);
+                Err((e, outcome))
+            }
         },
     )
     .await
@@ -182,43 +190,50 @@ pub(super) async fn flush_batch(
                 "Flushed log batch"
             );
         }
-        Ok(Err((e, failed_batch, blocked_by_storage))) => {
-            if failed_batch.len() < 1000 {
+        Ok(Err((e, outcome))) => {
+            if !outcome.inserted_entries.is_empty() {
+                let inserted_count = outcome.inserted_count.min(outcome.inserted_entries.len());
+                summary.record_batch(&outcome.inserted_entries[..inserted_count]);
+                context.observability.record_writer_flushed(inserted_count);
+                debug!(
+                    inserted_count,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    "Flushed recovered log chunks after batch failure"
+                );
+            }
+
+            if !outcome.retained_entries.is_empty() {
                 context
                     .observability
-                    .record_writer_retained(failed_batch.len(), blocked_by_storage);
-                if blocked_by_storage {
-                    if !*storage_blocked {
-                        error!(
-                            error = %e,
-                            count,
-                            retained_batch = failed_batch.len(),
-                            elapsed_ms = started.elapsed().as_millis(),
-                            "Storage budget exceeded — retaining batch until space recovers"
-                        );
-                        *storage_blocked = true;
-                    }
-                } else {
-                    error!(
-                        error = %e,
-                        count,
-                        retained_batch = failed_batch.len(),
-                        elapsed_ms = started.elapsed().as_millis(),
-                        "Failed to flush log batch — retaining for next flush"
-                    );
-                }
-                *batch = failed_batch;
-                tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
-            } else {
-                context
-                    .observability
-                    .record_writer_discarded(failed_batch.len());
+                    .record_writer_retained(outcome.retained_entries.len(), false);
                 error!(
                     error = %e,
                     count,
-                    retained_batch = failed_batch.len(),
+                    inserted_rows = outcome.inserted_count,
+                    retained_rows = outcome.retained_entries.len(),
+                    retained_chunks = outcome.retained_chunks,
+                    discarded_rows = outcome.discarded_count,
+                    discarded_chunks = outcome.discarded_chunks,
                     elapsed_ms = started.elapsed().as_millis(),
-                    "Failed to flush log batch — batch too large to retain, discarding"
+                    "Failed to flush full log batch — retained retryable chunks and discarded unrecoverable rows"
+                );
+                *batch = outcome.retained_entries;
+                tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+            }
+
+            if outcome.discarded_count > 0 {
+                context
+                    .observability
+                    .record_writer_discarded(outcome.discarded_count);
+                error!(
+                    error = %e,
+                    count,
+                    inserted_rows = outcome.inserted_count,
+                    retained_rows = batch.len(),
+                    discarded_rows = outcome.discarded_count,
+                    discarded_chunks = outcome.discarded_chunks,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    "Discarded unrecoverable log rows after failed batch retry"
                 );
             }
         }
@@ -235,24 +250,117 @@ pub(super) async fn flush_batch(
 }
 
 #[derive(Default)]
+struct FailedBatchOutcome {
+    inserted_count: usize,
+    inserted_entries: Vec<db::LogBatchEntry>,
+    retained_entries: Vec<db::LogBatchEntry>,
+    retained_chunks: usize,
+    discarded_count: usize,
+    discarded_chunks: usize,
+}
+
+fn handle_failed_batch(
+    pool: &DbPool,
+    failed_batch: Vec<db::LogBatchEntry>,
+    error: &anyhow::Error,
+) -> FailedBatchOutcome {
+    let mut outcome = FailedBatchOutcome::default();
+    if is_retryable_sqlite_error(error) {
+        retain_or_discard_entries(&mut outcome, failed_batch);
+        return outcome;
+    }
+
+    for chunk in failed_batch.chunks(FAILED_BATCH_RETRY_CHUNK_SIZE) {
+        retry_failed_chunk(pool, chunk.to_vec(), &mut outcome);
+    }
+    outcome
+}
+
+fn retry_failed_chunk(
+    pool: &DbPool,
+    chunk: Vec<db::LogBatchEntry>,
+    outcome: &mut FailedBatchOutcome,
+) {
+    match db::insert_logs_batch(pool, &chunk) {
+        Ok(inserted) => {
+            outcome.inserted_count += inserted;
+            outcome.inserted_entries.extend(chunk);
+        }
+        Err(e) if is_retryable_sqlite_error(&e) => {
+            retain_or_discard_entries(outcome, chunk);
+        }
+        Err(_) if chunk.len() > 1 => {
+            let mid = chunk.len() / 2;
+            let mut right = chunk;
+            let left = right.split_off(mid);
+            retry_failed_chunk(pool, right, outcome);
+            retry_failed_chunk(pool, left, outcome);
+        }
+        Err(_) => {
+            outcome.discarded_count += chunk.len();
+            outcome.discarded_chunks += 1;
+        }
+    }
+}
+
+fn retain_or_discard_entries(outcome: &mut FailedBatchOutcome, entries: Vec<db::LogBatchEntry>) {
+    let retain_remaining = FAILED_BATCH_RETAIN_LIMIT.saturating_sub(outcome.retained_entries.len());
+    if retain_remaining == 0 {
+        outcome.discarded_count += entries.len();
+        outcome.discarded_chunks += 1;
+        return;
+    }
+
+    if entries.len() <= retain_remaining {
+        outcome.retained_entries.extend(entries);
+        outcome.retained_chunks += 1;
+        return;
+    }
+
+    let discarded = entries.len() - retain_remaining;
+    outcome
+        .retained_entries
+        .extend(entries.into_iter().take(retain_remaining));
+    outcome.retained_chunks += 1;
+    outcome.discarded_count += discarded;
+    outcome.discarded_chunks += 1;
+}
+
+fn is_retryable_sqlite_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<SqliteError>(),
+            Some(SqliteError::SqliteFailure(sql_err, _))
+                if matches!(
+                    sql_err.code,
+                    ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked | ErrorCode::DiskFull
+                )
+        )
+    })
+}
+
+#[derive(Default)]
 pub(super) struct IngestSummary {
     total_logs: usize,
     host_counts: HashMap<String, usize>,
     source_ip_counts: HashMap<String, usize>,
     sender_counts: HashMap<(String, String), usize>,
+    host_overflow_count: usize,
+    source_ip_overflow_count: usize,
+    sender_overflow_count: usize,
 }
 
 impl IngestSummary {
     fn record_batch(&mut self, entries: &[db::LogBatchEntry]) {
         self.total_logs += entries.len();
         for entry in entries {
-            *self.host_counts.entry(entry.hostname.clone()).or_insert(0) += 1;
+            self.host_overflow_count +=
+                record_bounded_count(&mut self.host_counts, entry.hostname.clone());
             let source_ip = source_addr_ip(&entry.source_ip);
-            *self.source_ip_counts.entry(source_ip.clone()).or_insert(0) += 1;
-            *self
-                .sender_counts
-                .entry((entry.hostname.clone(), source_ip))
-                .or_insert(0) += 1;
+            self.source_ip_overflow_count +=
+                record_bounded_count(&mut self.source_ip_counts, source_ip.clone());
+            self.sender_overflow_count +=
+                record_bounded_count(&mut self.sender_counts, (entry.hostname.clone(), source_ip));
         }
     }
 
@@ -261,7 +369,25 @@ impl IngestSummary {
         self.host_counts.clear();
         self.source_ip_counts.clear();
         self.sender_counts.clear();
+        self.host_overflow_count = 0;
+        self.source_ip_overflow_count = 0;
+        self.sender_overflow_count = 0;
     }
+}
+
+fn record_bounded_count<K>(counts: &mut HashMap<K, usize>, key: K) -> usize
+where
+    K: Eq + std::hash::Hash,
+{
+    if let Some(count) = counts.get_mut(&key) {
+        *count += 1;
+        return 0;
+    }
+    if counts.len() < INGEST_SUMMARY_CARDINALITY_LIMIT {
+        counts.insert(key, 1);
+        return 0;
+    }
+    1
 }
 
 fn emit_ingest_summary(summary: &mut IngestSummary) {
@@ -269,12 +395,16 @@ fn emit_ingest_summary(summary: &mut IngestSummary) {
         return;
     }
 
-    let top_senders = summarize_top_senders(&summary.sender_counts, 5);
+    let top_senders =
+        summarize_top_senders(&summary.sender_counts, summary.sender_overflow_count, 5);
     info!(
         interval_secs = INGEST_SUMMARY_INTERVAL_SECS,
         total_logs = summary.total_logs,
         unique_hosts = summary.host_counts.len(),
         unique_source_ips = summary.source_ip_counts.len(),
+        host_overflow_count = summary.host_overflow_count,
+        source_ip_overflow_count = summary.source_ip_overflow_count,
+        sender_overflow_count = summary.sender_overflow_count,
         top_senders = %top_senders,
         "Syslog ingest summary"
     );
@@ -283,9 +413,20 @@ fn emit_ingest_summary(summary: &mut IngestSummary) {
 
 pub(super) fn summarize_top_senders(
     counts: &HashMap<(String, String), usize>,
+    overflow_count: usize,
     limit: usize,
 ) -> String {
+    let overflow = (
+        (
+            OTHER_SUMMARY_LABEL.to_string(),
+            OTHER_SUMMARY_LABEL.to_string(),
+        ),
+        overflow_count,
+    );
     let mut entries: Vec<_> = counts.iter().collect();
+    if overflow_count > 0 {
+        entries.push((&overflow.0, &overflow.1));
+    }
     entries.sort_by(|a, b| {
         b.1.cmp(a.1)
             .then_with(|| a.0 .0.cmp(&b.0 .0))

--- a/src/syslog/writer_tests.rs
+++ b/src/syslog/writer_tests.rs
@@ -30,6 +30,14 @@ fn make_entry(message: &str) -> db::LogBatchEntry {
     }
 }
 
+fn make_entry_for_sender(hostname: &str, source_ip: &str, message: &str) -> db::LogBatchEntry {
+    db::LogBatchEntry {
+        hostname: hostname.to_string(),
+        source_ip: source_ip.to_string(),
+        ..make_entry(message)
+    }
+}
+
 #[tokio::test]
 async fn flush_batch_retains_entries_while_storage_is_write_blocked() {
     let (pool, mut storage, _dir) = test_pool();
@@ -91,6 +99,122 @@ async fn flush_batch_resumes_after_storage_recovers() {
     let rows = db::tail_logs(&pool, None, None, None, 10).unwrap();
     assert_eq!(rows.len(), 1);
 }
+
+#[tokio::test]
+async fn flush_batch_isolates_bad_rows_and_writes_remaining_entries() {
+    let (pool, storage, _dir) = test_pool();
+    pool.get()
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER fail_bad_message BEFORE INSERT ON logs
+             WHEN new.message = 'bad row'
+             BEGIN
+                 SELECT RAISE(FAIL, 'bad row rejected');
+             END;",
+        )
+        .unwrap();
+    let storage_state = Arc::new(Mutex::new(Some(db::StorageBudgetState {
+        metrics: db::get_storage_metrics(&pool, &storage).unwrap(),
+        write_blocked: false,
+    })));
+    let mut batch = vec![
+        make_entry("good row one"),
+        make_entry("bad row"),
+        make_entry("good row two"),
+    ];
+    let mut storage_blocked = false;
+    let mut summary = IngestSummary::default();
+    let observability = Arc::new(crate::observability::RuntimeObservability::default());
+    let context = WriterContext::new(
+        Arc::clone(&pool),
+        storage.clone(),
+        Arc::clone(&storage_state),
+        crate::syslog::enrichment::EnrichmentConfig::default(),
+        Arc::clone(&observability),
+    );
+
+    flush_batch(&mut batch, &mut storage_blocked, &mut summary, &context).await;
+
+    assert!(batch.is_empty());
+    assert_eq!(observability.snapshot().writer_logs_written, 2);
+    assert_eq!(observability.snapshot().writer_logs_discarded, 1);
+    let rows = db::tail_logs(&pool, None, None, None, 10).unwrap();
+    assert_eq!(rows.len(), 2);
+}
+
+#[tokio::test]
+async fn flush_batch_retains_bounded_entries_for_large_retryable_failures() {
+    let (pool, storage, _dir) = test_pool();
+    let metrics = db::get_storage_metrics(&pool, &storage).unwrap();
+    let lock_conn = rusqlite::Connection::open(&storage.db_path).unwrap();
+    lock_conn.execute_batch("BEGIN EXCLUSIVE;").unwrap();
+    let storage_state = Arc::new(Mutex::new(Some(db::StorageBudgetState {
+        metrics,
+        write_blocked: false,
+    })));
+    let mut batch = (0..(FAILED_BATCH_RETAIN_LIMIT + 5))
+        .map(|i| make_entry(&format!("locked row {i}")))
+        .collect::<Vec<_>>();
+    let mut storage_blocked = false;
+    let mut summary = IngestSummary::default();
+    let observability = Arc::new(crate::observability::RuntimeObservability::default());
+    let context = WriterContext::new(
+        Arc::clone(&pool),
+        storage.clone(),
+        Arc::clone(&storage_state),
+        crate::syslog::enrichment::EnrichmentConfig::default(),
+        Arc::clone(&observability),
+    );
+
+    flush_batch(&mut batch, &mut storage_blocked, &mut summary, &context).await;
+
+    assert_eq!(batch.len(), FAILED_BATCH_RETAIN_LIMIT);
+    assert_eq!(observability.snapshot().writer_logs_retained, 1000);
+    assert_eq!(observability.snapshot().writer_logs_discarded, 5);
+    lock_conn.execute_batch("ROLLBACK;").unwrap();
+}
+
+#[test]
+fn failed_batch_retains_disk_full_errors_instead_of_discarding_rows() {
+    let (pool, _storage, _dir) = test_pool();
+    let batch = vec![make_entry("disk full retained")];
+    let error = anyhow::anyhow!(rusqlite::Error::SqliteFailure(
+        rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_FULL),
+        Some("database or disk is full".to_string()),
+    ));
+
+    let outcome = handle_failed_batch(&pool, batch, &error);
+
+    assert_eq!(outcome.retained_entries.len(), 1);
+    assert_eq!(outcome.retained_chunks, 1);
+    assert_eq!(outcome.discarded_count, 0);
+}
+
+#[test]
+fn ingest_summary_aggregates_cardinality_overflow() {
+    let mut summary = IngestSummary::default();
+    let entries = (0..(INGEST_SUMMARY_CARDINALITY_LIMIT + 5))
+        .map(|i| {
+            make_entry_for_sender(
+                &format!("host-{i}"),
+                &format!("192.0.2.{}:514", i % 255),
+                &format!("message {i}"),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    summary.record_batch(&entries);
+
+    assert_eq!(summary.total_logs, INGEST_SUMMARY_CARDINALITY_LIMIT + 5);
+    assert_eq!(summary.host_counts.len(), INGEST_SUMMARY_CARDINALITY_LIMIT);
+    assert_eq!(summary.host_overflow_count, 5);
+    assert!(!summary.host_counts.contains_key(OTHER_SUMMARY_LABEL));
+    assert_eq!(summary.sender_overflow_count, 5);
+    assert!(!summary.sender_counts.contains_key(&(
+        OTHER_SUMMARY_LABEL.to_string(),
+        OTHER_SUMMARY_LABEL.to_string()
+    )));
+}
 #[test]
 fn source_addr_ip_strips_socket_ports() {
     assert_eq!(source_addr_ip("100.75.111.118:49238"), "100.75.111.118");
@@ -110,7 +234,20 @@ fn summarize_top_senders_pairs_hostnames_with_source_ips() {
     ]);
 
     assert_eq!(
-        summarize_top_senders(&counts, 2),
+        summarize_top_senders(&counts, 0, 2),
         "dookie@172.19.0.1=29, vivobook@100.104.50.17=28"
+    );
+}
+
+#[test]
+fn summarize_top_senders_includes_other_bucket_deterministically() {
+    let counts = HashMap::from([
+        (("dookie".to_string(), "172.19.0.1".to_string()), 29),
+        (("vivobook".to_string(), "100.104.50.17".to_string()), 28),
+    ]);
+
+    assert_eq!(
+        summarize_top_senders(&counts, 31, 2),
+        "__other__@__other__=31, dookie@172.19.0.1=29"
     );
 }


### PR DESCRIPTION
## Summary
- Close ingestion full-review epic syslog-mcp-vzg8 and all 17 child issues.
- Bound TCP syslog frame reads before allocation and add oversized-frame regression coverage.
- Validate zero-valued syslog ingest config at startup.
- Harden Docker ingest supervisor policy/backoff, add observability, and move supervisor tests to sidecar.
- Improve writer failed-batch handling and cap ingest summary cardinality.
- Extend TCP smoke coverage, add migration/Docker ingest docs, and bump version to 0.14.1.

## Verification
- cargo test -- --nocapture
- RUSTC_WRAPPER= cargo clippy -- --deny warnings
- bash scripts/check-version-sync.sh
- bash -n scripts/smoke-test.sh
- git diff --check
- pre-push hook: cargo test

## Notes
- bd dolt push skipped because this repo has no configured Dolt remote.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens syslog ingestion across UDP/TCP and Docker with bounded TCP frame reads, safer writer retries, deterministic jittered reconnect backoff with observability, and live TCP smoke coverage. Aligns with Linear epic syslog-mcp-vzg8.

- **New Features**
  - Docker ingest: deterministic jittered reconnect backoff with 30s durable-stream reset; lifecycle event policy (start/restart/rename/stop) drives task actions; runtime stats for events, log entries, parse errors, reconnects/failures, tasks, and active host/container streams; added supervisor tests.
  - Writer: on batch failures, retry in chunks and binary-search bad rows; retain up to 1000 retryable rows and discard unrecoverable ones; cap ingest summary to 256 keys with an `__other__` bucket; added tests.
  - Smoke test: seeds a TCP frame with a unique marker and verifies it via `tail` and `search`.
  - Docs/runbooks: clarified per-frame TCP limits and Docker ingest trust boundaries/test path; added heavy SQLite migration runbook and a tracked ingestion full-review report; version bumped to `0.14.2`.

- **Bug Fixes**
  - TCP ingest: bounded newline-delimited frame reads; drop oversized newline-delimited frames and keep the connection; close on oversized unterminated frames to avoid unbounded allocation; added regression tests.
  - Config: fail-fast validation for zero-valued syslog ingest settings (`max_message_size`, `max_tcp_connections`, `tcp_idle_timeout_secs`, `batch_size`, `flush_interval`); warn on insecure `SYSLOG_DOCKER_HOSTS` expansions.

<sup>Written for commit e6b61d6d2520eb9452526eb84145f3501cf61bc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

