### PR TITLE
fix(oauth): fail-conservative unknown scope + bearer-only static token scopes

### DIFF
--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -91,6 +91,15 @@ pub struct AppState {
 /// `AuthLayer` MUST NOT add any DB write path. JWT validation is stateless
 /// RS256 verify; static token is constant-time compare. If audit logging is
 /// ever needed, push to an async background channel.
+///
+/// # Static token scopes (bearer-only)
+/// When `auth_state` is `None` (bearer-only mode), `AuthLayer::new()` starts
+/// with `static_token_scopes: Vec::new()` and `with_auth_state(None)` does
+/// not set scopes (it only reads scopes from a `Some(AuthState)`). Without an
+/// explicit call to `with_static_token_scopes`, a static-bearer request would
+/// produce an `AuthContext` with no scopes and fail every scope check.
+/// We therefore call `with_static_token_scopes` unconditionally so that the
+/// bearer-only path grants the same scopes as the OAuth path.
 pub fn build_auth_layer(
     policy: &AuthPolicy,
     static_token: Option<Arc<str>>,
@@ -102,6 +111,11 @@ pub fn build_auth_layer(
             AuthLayer::new()
                 .with_static_token(static_token)
                 .with_auth_state(auth_state.clone())
+                // When auth_state is None (bearer-only), with_auth_state does not
+                // populate static_token_scopes (it only copies from Some(AuthState)).
+                // Explicitly set here so static bearer tokens receive full scopes
+                // in both bearer-only and OAuth modes.
+                .with_static_token_scopes(vec!["syslog:read".into(), "syslog:admin".into()])
                 .with_resource_url(resource_url)
                 .with_allow_session_cookie(false),
         ),

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -330,8 +330,15 @@ fn check_scope(auth: &AuthContext, required_scope: &str, action: &str) -> Result
 /// Returns `None` for informational actions that require AuthContext (when
 /// Mounted) but no specific scope — e.g. `help`.
 /// Returns `Some(scope)` for actions that require an explicit scope grant.
-/// Unknown actions default to `syslog:read` so that future actions added
-/// without a mapping entry are denied rather than accidentally permitted.
+///
+/// Unknown actions return `Some("syslog:__deny__")` — a sentinel scope that
+/// is never granted to any caller, so unmapped actions are unconditionally
+/// rejected. This is fail-closed: a future action added to the dispatcher
+/// but not added here will be denied, not silently permitted with read access.
+///
+/// Note: `None` does NOT deny — it bypasses the scope check and relies on
+/// `execute_tool` to reject invalid actions. `Some("syslog:__deny__")` is
+/// the correct mechanism to guarantee rejection at the auth layer.
 fn required_scope_for(action: &str) -> Option<&'static str> {
     match action {
         // Informational — AuthContext required when Mounted, but no scope gate.
@@ -339,8 +346,9 @@ fn required_scope_for(action: &str) -> Option<&'static str> {
         // All current read actions require syslog:read.
         "search" | "tail" | "errors" | "hosts" | "correlate" | "stats" => Some("syslog:read"),
         // Future write/admin actions would map to syslog:admin here.
-        // Default: unknown actions fall through to syslog:read (fail-conservative).
-        _ => Some("syslog:read"),
+        // Default: unknown actions use an ungrantable sentinel scope so they
+        // are denied at the auth layer rather than falling through to dispatch.
+        _ => Some("syslog:__deny__"),
     }
 }
 

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -800,3 +800,39 @@ async fn scope_check_fires_before_db_execution() {
         "no result should be present when scope check fails; response: {response}"
     );
 }
+
+/// Unknown action → denied by `syslog:__deny__` sentinel, not passed through.
+///
+/// The catch-all arm of `required_scope_for` returns `Some("syslog:__deny__")`
+/// — a scope that is never granted — so unknown actions are rejected at the
+/// auth layer rather than falling through to `execute_tool`.
+/// This prevents future actions added to dispatch but not to the scope map
+/// from being silently accessible with only `syslog:read`.
+#[tokio::test]
+async fn unknown_action_is_denied_by_sentinel_scope() {
+    let (state, _pool, _dir) = mounted_state();
+    // syslog:read + syslog:admin — both real scopes, but neither matches __deny__
+    let auth = auth_ctx_with_scopes(vec!["syslog:read", "syslog:admin"]);
+    let router = rmcp_router_with_auth(state, auth);
+
+    let (status, response) = post_rmcp(
+        router,
+        jsonrpc_request(
+            100,
+            "tools/call",
+            Some(json!({"name": "syslog", "arguments": {"action": "not_a_real_action"}})),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    // Must be a JSON-RPC error — the sentinel scope is never granted.
+    assert_eq!(
+        response["error"]["code"], -32600,
+        "unknown action must be denied by sentinel scope; response: {response}"
+    );
+    let msg = response["error"]["message"].as_str().unwrap_or("");
+    assert!(
+        msg.contains("requires scope"),
+        "denial message should reference scope requirement; got: {msg}"
+    );
+}

--- a/src/mcp/routes_tests.rs
+++ b/src/mcp/routes_tests.rs
@@ -468,6 +468,36 @@ async fn mounted_cookie_without_bearer_is_rejected() {
     );
 }
 
+/// Bearer-only mode: valid static token + scope-gated action (stats) → 200.
+///
+/// Regression test for the bug where `build_auth_layer` built an `AuthLayer`
+/// with `static_token_scopes: Vec::new()` in bearer-only mode because
+/// `AuthLayer::with_auth_state(None)` does not populate scopes.
+/// After the fix, `build_auth_layer` explicitly calls `.with_static_token_scopes`
+/// so the `AuthContext` injected by the layer carries `["syslog:read", "syslog:admin"]`
+/// and scope-gated actions succeed.
+#[tokio::test]
+async fn mounted_static_bearer_valid_token_can_call_scope_gated_action() {
+    let h = TestHarness::with_token("static-secret".into());
+    // `stats` requires syslog:read — it is scope-gated at the rmcp layer.
+    let body = jsonrpc_request(
+        25,
+        "tools/call",
+        Some(serde_json::json!({"name": "syslog", "arguments": {"action": "stats"}})),
+    );
+    let (status, response) = mcp_post(router(h.state), body, Some("static-secret")).await;
+    assert_eq!(status, StatusCode::OK, "response: {response}");
+    // Must be a successful result, not a JSON-RPC scope-denial error.
+    assert!(
+        response.get("error").is_none() || response["error"].is_null(),
+        "static bearer token must pass scope check for stats; response: {response}"
+    );
+    assert!(
+        response["result"].is_object(),
+        "stats result expected; response: {response}"
+    );
+}
+
 /// /health stays unauthenticated even when Mounted policy is active.
 #[tokio::test]
 async fn health_unauthenticated_under_mounted_policy() {


### PR DESCRIPTION
Two bugs found during axon_rust PR #76 audit:

1. **required_scope_for catch-all was fail-permissive** — `_ => Some("syslog:read")` meant unknown/typo'd actions silently granted read access. Changed to `Some("syslog:__deny__")` sentinel so they're rejected.

2. **Bearer-only mode had empty scopes** — `build_auth_layer` with `auth_state: None` (no OAuth, just static token) built an `AuthLayer` with no `static_token_scopes`, making every scope-gated action return 403 for static bearer token holders. Fixed by adding `.with_static_token_scopes(["syslog:read", "syslog:admin"])`.

321 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tighten auth by denying unknown actions and restore scopes for bearer-only tokens. Unknown actions now fail closed, and static bearer tokens get `syslog:read` and `syslog:admin` so scope-gated calls work; regression tests included.

- **Bug Fixes**
  - `required_scope_for`: map unknown actions to `syslog:__deny__` (was `syslog:read`) to reject typos and unmapped actions at the auth layer.
  - `build_auth_layer`: always set `.with_static_token_scopes(["syslog:read", "syslog:admin"])` so bearer-only tokens pass scope checks; tests cover both regressions.

<sup>Written for commit 30afb7bec705f159fd5e7ba1646cdc06981b5858. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bearer-only authentication mode now grants the same token scopes as OAuth mode.

* **Bug Fixes**
  * Unknown MCP actions are now securely denied at the authorization layer instead of defaulting to read permissions.

* **Tests**
  * Added tests verifying bearer token authentication and proper denial of unmapped actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->