### PR TITLE
fix: close full-review auth and plugin gaps

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,8 @@
+[advisories]
+ignore = [
+  # lab-auth requires RS256 for Google OAuth/JWK validation and its local JWT
+  # signing path. RUSTSEC-2023-0071 has no patched rsa release; keep the audit
+  # gate active for all other advisories and revisit when upstream RSA support
+  # has a patched migration path.
+  "RUSTSEC-2023-0071",
+]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -97,7 +97,13 @@
     "syslog_port": {
       "type": "number",
       "title": "Syslog port",
-      "description": "UDP and TCP port the syslog receiver binds to (the same port serves both protocols). Default 1514 avoids needing CAP_NET_BIND_SERVICE for the privileged port 514. If clients can only forward to 514 (some routers, IoT gear), keep 1514 here and add an iptables PREROUTING redirect 514→1514 — see docs/SETUP.md. Server mode only.",
+      "description": "UDP and TCP port the syslog receiver binds to inside the server process (the same port serves both protocols). Keep this at 1514 unless you intentionally grant CAP_NET_BIND_SERVICE or run as root. Server mode only.",
+      "default": 1514
+    },
+    "syslog_host_port": {
+      "type": "number",
+      "title": "Docker syslog host port",
+      "description": "Host port published by Docker Compose to the container's syslog bind port 1514. Set this to 514 when devices can only forward to the privileged syslog port, while leaving syslog_port at 1514 inside the container. Docker server mode only.",
       "default": 1514
     },
     "mcp_host": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "description": "Syslog management via MCP",
   "author": { "name": "jmagar" },
   "repository": "https://github.com/jmagar/syslog-mcp",
@@ -97,13 +97,13 @@
     "syslog_port": {
       "type": "number",
       "title": "Syslog port",
-      "description": "UDP and TCP port the syslog receiver binds to inside the server process (the same port serves both protocols). Keep this at 1514 unless you intentionally grant CAP_NET_BIND_SERVICE or run as root. Server mode only.",
+      "description": "UDP and TCP port the syslog receiver binds to inside the server process or Docker container (the same port serves both protocols). Keep this at 1514 unless you intentionally grant CAP_NET_BIND_SERVICE or run as root. Server mode only.",
       "default": 1514
     },
     "syslog_host_port": {
       "type": "number",
       "title": "Docker syslog host port",
-      "description": "Host port published by Docker Compose to the container's syslog bind port 1514. Set this to 514 when devices can only forward to the privileged syslog port, while leaving syslog_port at 1514 inside the container. Docker server mode only.",
+      "description": "Host port published by Docker Compose to the container's syslog bind port. Set this to 514 when devices can only forward to the privileged syslog port, while leaving syslog_port at 1514 inside the container. Docker server mode only.",
       "default": 1514
     },
     "mcp_host": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "Syslog management via MCP",
   "author": { "name": "jmagar" },
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.7] - 2026-05-09
+
+### Fixed
+
+- **Docker syslog port mapping**: Compose now maps the container-side syslog
+  port to `SYSLOG_PORT`, keeping Docker publishes aligned with the server bind
+  port and avoiding silent ingest breaks when the bind port is customized.
+- **Security audit gate**: documented the temporary `rsa` RustSec exception for
+  `lab-auth` RS256/JWK support while preserving cargo-audit enforcement for all
+  other advisories.
+- **Review hardening**: added cross-references for MCP read scope drift and
+  asserted that unsafe OAuth-only OTLP startup rejection happens before DB
+  initialization side effects.
+
 ## [0.17.6] - 2026-05-09
 
 ### Fixed
@@ -860,7 +874,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.17.6...HEAD
+[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.17.7...HEAD
+[0.17.7]: https://github.com/jmagar/syslog-mcp/compare/v0.17.6...v0.17.7
 [0.17.6]: https://github.com/jmagar/syslog-mcp/compare/v0.17.5...v0.17.6
 [0.17.5]: https://github.com/jmagar/syslog-mcp/compare/v0.17.4...v0.17.5
 [0.17.4]: https://github.com/jmagar/syslog-mcp/compare/v0.17.3...v0.17.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -853,7 +853,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.17.4...HEAD
+[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.17.5...HEAD
+[0.17.5]: https://github.com/jmagar/syslog-mcp/compare/v0.17.4...v0.17.5
 [0.17.4]: https://github.com/jmagar/syslog-mcp/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/jmagar/syslog-mcp/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/jmagar/syslog-mcp/compare/v0.17.1...v0.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   like the other read-only actions, instead of falling through to the
   fail-closed unknown-action scope sentinel.
 
+- **OAuth-only OTLP exposure**: non-loopback OAuth deployments now refuse to
+  start without `SYSLOG_MCP_TOKEN`, because OTLP `/v1/logs` currently supports
+  only static Bearer-token auth.
+- **MCP OAuth scopes**: all current public read-only MCP actions now require
+  `syslog:read`, with exhaustive mounted-auth coverage to prevent action/scope
+  drift.
+- **Plugin deployment config**: setup writes the primary `SYSLOG_MCP_TOKEN`,
+  migrates legacy `SYSLOG_MCP_API_TOKEN`, exposes Docker host syslog port
+  mapping separately from the in-container bind port, and validates the current
+  plugin marketplace layout.
+- **Docker and docs drift**: Docker metadata and Compose privileged-port
+  guidance now match the actual `1514` container listener, and MCP docs list
+  the current action surface without stale `/sse` guidance.
+
 ## [0.17.4] - 2026-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.17.5] - 2026-05-08
+## [0.17.6] - 2026-05-09
 
 ### Fixed
-
-- **MCP status scope mapping**: `syslog status` now requires `syslog:read`
-  like the other read-only actions, instead of falling through to the
-  fail-closed unknown-action scope sentinel.
 
 - **OAuth-only OTLP exposure**: non-loopback OAuth deployments now refuse to
   start without `SYSLOG_MCP_TOKEN`, because OTLP `/v1/logs` currently supports
@@ -21,13 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MCP OAuth scopes**: all current public read-only MCP actions now require
   `syslog:read`, with exhaustive mounted-auth coverage to prevent action/scope
   drift.
+- **MCP resource auth**: mounted-auth deployments now require an auth context
+  before listing or reading MCP resources, matching the tools surface.
 - **Plugin deployment config**: setup writes the primary `SYSLOG_MCP_TOKEN`,
-  migrates legacy `SYSLOG_MCP_API_TOKEN`, exposes Docker host syslog port
-  mapping separately from the in-container bind port, and validates the current
-  plugin marketplace layout.
+  permits tokenless OAuth only for loopback server mode, validates configured
+  ports early, migrates legacy `SYSLOG_MCP_API_TOKEN`, exposes Docker host
+  syslog port mapping separately from the in-container bind port, and validates
+  the current plugin marketplace layout.
 - **Docker and docs drift**: Docker metadata and Compose privileged-port
   guidance now match the actual `1514` container listener, and MCP docs list
   the current action surface without stale `/sse` guidance.
+
+## [0.17.5] - 2026-05-08
+
+### Fixed
+
+- **MCP status scope mapping**: `syslog status` now requires `syslog:read`
+  like the other read-only actions, instead of falling through to the
+  fail-closed unknown-action scope sentinel.
 
 ## [0.17.4] - 2026-05-08
 
@@ -853,7 +860,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.17.5...HEAD
+[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.17.6...HEAD
+[0.17.6]: https://github.com/jmagar/syslog-mcp/compare/v0.17.5...v0.17.6
 [0.17.5]: https://github.com/jmagar/syslog-mcp/compare/v0.17.4...v0.17.5
 [0.17.4]: https://github.com/jmagar/syslog-mcp/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/jmagar/syslog-mcp/compare/v0.17.2...v0.17.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Tests: unit tests live in sidecar files beside their source modules (e.g. `src/d
 | Port | Protocol | Purpose |
 |------|----------|---------|
 | 1514 | UDP + TCP | Syslog receiver (not 514 — avoids `CAP_NET_BIND_SERVICE`) |
-| 3100 | TCP | MCP HTTP endpoint (`POST /mcp`, `GET /health`, `GET /sse`) |
+| 3100 | TCP | MCP HTTP endpoint (`POST /mcp`, `GET /health`) |
 
 ## MCP Tools
 
@@ -64,6 +64,18 @@ One MCP tool: **`syslog`** — dispatches by `action` argument.
 | `hosts` | All known hosts with first/last seen + log counts |
 | `correlate` | Cross-host event correlation in a time window |
 | `stats` | DB stats (total logs, logical/physical size, free disk, configured thresholds, write-block state, time range) |
+| `status` | Lightweight runtime and DB health |
+| `apps` | Distinct application names with log and host counts |
+| `source_ips` | Distinct source identifiers with hostname breakdown |
+| `timeline` | Bucketed counts over time |
+| `patterns` | Near-duplicate message template clusters |
+| `context` | Surrounding logs around a log id or timestamp |
+| `get` | One log entry by id, including raw frame |
+| `ingest_rate` | Recent ingest throughput and write-block state |
+| `silent_hosts` | Hosts whose last_seen is older than a threshold |
+| `clock_skew` | Per-host received_at minus timestamp distribution |
+| `anomalies` | Recent vs baseline volume/error comparison |
+| `compare` | Side-by-side comparison of two time ranges |
 | `help` | Built-in usage reference |
 
 ## Plugin Commands
@@ -153,7 +165,7 @@ RUST_LOG=info
 - **Cargo.lock is tracked** — binary crates should commit Cargo.lock for reproducible builds (Cargo docs guidance)
 - **FTS5 query syntax** — `syslog action=search` uses SQLite FTS5: `error AND nginx`, `"disk full"`, `kern OR syslog`; invalid FTS5 syntax returns a db error. **Hyphen is the FTS5 NOT operator** — to search for hyphenated terms, use phrase syntax: `"smoke-test"` not `smoke-test`
 - **WAL mode** — SQLite runs in WAL mode; copying `.db`, `.db-wal`, and `.db-shm` together without a checkpoint captures potentially inconsistent state. Safe backup options: (1) run `PRAGMA wal_checkpoint(FULL);` first, then copy all three files, or (2) use `sqlite3 source.db '.backup dest.db'` which is WAL-safe and requires no manual checkpoint
-- **SSE proxy** — nginx/SWAG must set `proxy_buffering off`, `chunked_transfer_encoding off`, and `proxy_http_version 1.1` for SSE (`GET /sse`) to stream correctly
+- **MCP transport** — HTTP MCP runs in stateless JSON-response mode on `POST /mcp`; SSE streams (`GET /mcp` or `/sse`) are not enabled in the current server.
 - **Data volume** — DB lives in `./data/` (bind mount); `*.db` is gitignored so the database files won't be committed
 - **Retention purge** — `retention_days` defaults to 90; logs older than 90 days are **permanently deleted hourly** with no recovery path. Set `SYSLOG_MCP_RETENTION_DAYS=0` to disable purging entirely.
 - **Storage guardrail** — Logical DB size and free-disk limits are enabled by default (`1024/900 MB` DB, `512/768 MB` free disk). When thresholds are breached, the server deletes oldest logs by `received_at` until recovery targets are met. If cleanup still cannot recover enough space, the batch writer blocks new writes until storage becomes healthy again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Tests: unit tests live in sidecar files beside their source modules (e.g. `src/d
 | Port | Protocol | Purpose |
 |------|----------|---------|
 | 1514 | UDP + TCP | Syslog receiver (not 514 — avoids `CAP_NET_BIND_SERVICE`) |
-| 3100 | TCP | MCP HTTP endpoint (`POST /mcp`, `GET /health`) |
+| 3100 | TCP | Shared HTTP listener for MCP (`POST /mcp`, `GET /health`) and OTLP HTTP ingest (`POST /v1/logs`); non-loopback OAuth-only `/v1/logs` exposure is blocked at startup unless `SYSLOG_MCP_TOKEN` is set |
 
 ## MCP Tools
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.17.6"
+version = "0.17.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.17.6"
+version = "0.17.7"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.17.5"
+version = "0.17.6"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The daemon listens on a single port for both UDP and TCP syslog (default `1514`)
 
 One MCP tool, `syslog`, is exposed. Use the required `action` argument to run `search`, `tail`, `errors`, `hosts`, `correlate`, `stats`, `status`, `apps`, `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`, `silent_hosts`, `clock_skew`, `anomalies`, `compare`, or `help`.
 
+For the complete action-specific parameter reference, see [`docs/mcp/SCHEMA.md`](docs/mcp/SCHEMA.md).
+
 | Action | Purpose |
 | --- | --- |
 | `search` | Full-text search with filters |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/syslog-mcp)](https://crates.io/crates/syslog-mcp) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Fsyslog--mcp-blue?logo=docker)](https://github.com/jmagar/syslog-mcp/pkgs/container/syslog-mcp)
 
-Rust syslog receiver and MCP server for homelab log intelligence. Ingests syslog over UDP and TCP, stores it in SQLite with FTS5 full-text indexing, and exposes search, tail, error summary, correlation, and stats tools to MCP clients.
+Rust syslog receiver and MCP server for homelab log intelligence. Ingests syslog over UDP and TCP, stores it in SQLite with FTS5 full-text indexing, and exposes action-based log search, inventory, correlation, status, and analysis tools to MCP clients.
 
 ## Overview
 
@@ -24,7 +24,29 @@ The daemon listens on a single port for both UDP and TCP syslog (default `1514`)
 
 ## Tools
 
-One MCP tool, `syslog`, is exposed. Use the required `action` argument to run `search`, `tail`, `errors`, `hosts`, `correlate`, `stats`, `status`, or `help`.
+One MCP tool, `syslog`, is exposed. Use the required `action` argument to run `search`, `tail`, `errors`, `hosts`, `correlate`, `stats`, `status`, `apps`, `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`, `silent_hosts`, `clock_skew`, `anomalies`, `compare`, or `help`.
+
+| Action | Purpose |
+| --- | --- |
+| `search` | Full-text search with filters |
+| `tail` | Recent log entries |
+| `errors` | Error/warning summary by host and severity |
+| `hosts` | Host registry with first/last seen |
+| `correlate` | Cross-host event correlation in a time window |
+| `stats` | Database statistics and storage health |
+| `status` | Lightweight runtime and DB health |
+| `apps` | Distinct application names with log and host counts |
+| `source_ips` | Distinct source identifiers with hostname breakdown |
+| `timeline` | Bucketed counts over time |
+| `patterns` | Near-duplicate message template clusters |
+| `context` | Surrounding logs around a log id or timestamp |
+| `get` | One log entry by id, including raw frame |
+| `ingest_rate` | Recent ingest throughput and write-block state |
+| `silent_hosts` | Hosts whose last_seen is older than a threshold |
+| `clock_skew` | Per-host received_at minus timestamp distribution |
+| `anomalies` | Recent vs baseline volume/error comparison |
+| `compare` | Side-by-side comparison of two time ranges |
+| `help` | Markdown reference for all actions |
 
 ### `syslog search`
 
@@ -433,6 +455,7 @@ The plain JSON API is disabled by default. When enabled, it is mounted under `/a
 |----------|----------|---------|-------------|
 | `SYSLOG_HOST` | no | `0.0.0.0` | Bind host for UDP + TCP syslog listeners |
 | `SYSLOG_PORT` | no | `1514` | Bind port for UDP + TCP syslog listeners |
+| `SYSLOG_HOST_PORT` | no | `1514` | Docker Compose host port published to container port `1514` |
 | `SYSLOG_MAX_MESSAGE_SIZE` | no | `8192` | Max bytes per UDP datagram or newline-delimited TCP frame. Oversized newline-delimited TCP frames are dropped and the connection stays open; oversized unterminated frames are dropped and the connection is closed. |
 | `SYSLOG_MAX_TCP_CONNECTIONS` | no | `1024` | Maximum simultaneous TCP syslog connections |
 | `SYSLOG_TCP_IDLE_TIMEOUT_SECS` | no | `300` | Idle timeout per TCP read before closing inactive connections |
@@ -661,7 +684,7 @@ sudo apt install iptables-persistent
 sudo netfilter-persistent save
 ```
 
-On Unraid, map container port `514:1514/udp` and `514:1514/tcp` directly in the Docker template.
+For Docker Compose, set `SYSLOG_HOST_PORT=514` to publish host port `514` while the container keeps binding unprivileged port `1514`. On Unraid, map host port `514` to container port `1514` for both UDP and TCP in the Docker template (`514:1514/udp` and `514:1514/tcp`).
 
 ### Firewall rules
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -32,7 +32,7 @@ ENV SYSLOG_MCP_DB_PATH=/data/syslog.db
 
 USER 1000:1000
 
-EXPOSE 514/udp 514/tcp 3100/tcp
+EXPOSE 1514/udp 1514/tcp 3100/tcp
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD curl -sf http://localhost:3100/health || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,14 @@ services:
       - path: .env
         required: false
     ports:
-      - "${SYSLOG_HOST_PORT:-1514}:1514/udp"
-      - "${SYSLOG_HOST_PORT:-1514}:1514/tcp"
+      - "${SYSLOG_HOST_PORT:-1514}:${SYSLOG_PORT:-1514}/udp"
+      - "${SYSLOG_HOST_PORT:-1514}:${SYSLOG_PORT:-1514}/tcp"
       - "${SYSLOG_MCP_PORT:-3100}:3100/tcp"
     volumes:
       - ${SYSLOG_MCP_DATA_VOLUME:-syslog-mcp-data}:/data
-    # The container listens on 1514. To serve host port 514, set
-    # SYSLOG_HOST_PORT=514 or add host-level firewall/NAT redirects from 514 to 1514.
+    # The container listens on SYSLOG_PORT (default 1514). To serve host port
+    # 514, set SYSLOG_HOST_PORT=514 while leaving SYSLOG_PORT at 1514, or add
+    # host-level firewall/NAT redirects from 514 to 1514.
     # NET_BIND_SERVICE is only needed if the container itself binds port 514.
     # cap_add:
     #   - NET_BIND_SERVICE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,14 @@ services:
       - path: .env
         required: false
     ports:
-      - "${SYSLOG_PORT:-1514}:1514/udp"
-      - "${SYSLOG_PORT:-1514}:1514/tcp"
+      - "${SYSLOG_HOST_PORT:-1514}:1514/udp"
+      - "${SYSLOG_HOST_PORT:-1514}:1514/tcp"
       - "${SYSLOG_MCP_PORT:-3100}:3100/tcp"
     volumes:
       - ${SYSLOG_MCP_DATA_VOLUME:-syslog-mcp-data}:/data
-    # Needed if redirecting privileged port 514 -> 1514 inside container
+    # The container listens on 1514. To serve host port 514, set
+    # SYSLOG_HOST_PORT=514 or add host-level firewall/NAT redirects from 514 to 1514.
+    # NET_BIND_SERVICE is only needed if the container itself binds port 514.
     # cap_add:
     #   - NET_BIND_SERVICE
     networks:

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -11,6 +11,17 @@ syslog-mcp exposes one MCP tool named `syslog`. The required `action` argument s
 - `correlate`
 - `stats`
 - `status`
+- `apps`
+- `source_ips`
+- `timeline`
+- `patterns`
+- `context`
+- `get`
+- `ingest_rate`
+- `silent_hosts`
+- `clock_skew`
+- `anomalies`
+- `compare`
 - `help`
 
 The schema is defined in `src/mcp/schemas.rs` as a `serde_json::json!()` object returned by `tool_definitions()`.
@@ -26,15 +37,72 @@ json!({
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["search", "tail", "errors", "hosts", "correlate", "stats", "status", "help"]
+                "enum": [
+                    "search",
+                    "tail",
+                    "errors",
+                    "hosts",
+                    "correlate",
+                    "stats",
+                    "status",
+                    "apps",
+                    "source_ips",
+                    "timeline",
+                    "patterns",
+                    "context",
+                    "get",
+                    "ingest_rate",
+                    "silent_hosts",
+                    "clock_skew",
+                    "anomalies",
+                    "compare",
+                    "help"
+                ]
             },
             "query": { "type": "string" },
             "hostname": { "type": "string" },
+            "source_ip": { "type": "string" },
             "severity": {
                 "type": "string",
                 "enum": ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug"]
             },
-            "limit": { "type": "integer" }
+            "severity_min": {
+                "type": "string",
+                "enum": ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug"]
+            },
+            "app_name": { "type": "string" },
+            "facility": { "type": "string" },
+            "process_id": { "type": "string" },
+            "from": { "type": "string" },
+            "to": { "type": "string" },
+            "limit": { "type": "integer" },
+            "n": { "type": "integer" },
+            "reference_time": { "type": "string" },
+            "window_minutes": { "type": "integer" },
+            "group_by": {
+                "type": "string",
+                "enum": ["app_name", "hostname", "host", "severity", "sev", "app"]
+            },
+            "bucket": {
+                "type": "string",
+                "enum": ["minute", "min", "m", "hour", "h", "day", "d"]
+            },
+            "scan_limit": { "type": "integer" },
+            "top_n": { "type": "integer" },
+            "log_id": { "type": "integer" },
+            "timestamp": { "type": "string" },
+            "before": { "type": "integer" },
+            "after": { "type": "integer" },
+            "id": { "type": "integer" },
+            "by_host": { "type": "boolean" },
+            "silent_minutes": { "type": "integer" },
+            "since": { "type": "string" },
+            "recent_minutes": { "type": "integer" },
+            "baseline_minutes": { "type": "integer" },
+            "a_from": { "type": "string" },
+            "a_to": { "type": "string" },
+            "b_from": { "type": "string" },
+            "b_to": { "type": "string" }
         },
         "required": ["action"]
     }
@@ -65,7 +133,7 @@ Input validation happens in the action handlers, not only at the schema level:
 - `action` is required and must be one of the supported actions
 - `limit` values are capped at their action-specific maximum
 - `severity` and `severity_min` are validated against known syslog levels
-- `reference_time`, `from`, and `to` timestamps are parsed as RFC 3339 and normalized to UTC
+- `reference_time`, `from`, `to`, `timestamp`, `since`, `a_from`, `a_to`, `b_from`, and `b_to` timestamps are parsed as RFC 3339 and normalized to UTC where required
 - Unknown parameters are ignored
 
 ## See Also

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -89,11 +89,17 @@ json!({
             },
             "scan_limit": { "type": "integer" },
             "top_n": { "type": "integer" },
-            "log_id": { "type": "integer" },
+            "log_id": {
+                "type": "integer",
+                "description": "For action=context: identifies the log entry for context lookup."
+            },
             "timestamp": { "type": "string" },
             "before": { "type": "integer" },
             "after": { "type": "integer" },
-            "id": { "type": "integer" },
+            "id": {
+                "type": "integer",
+                "description": "For action=get: identifies the record to retrieve."
+            },
             "by_host": { "type": "boolean" },
             "silent_minutes": { "type": "integer" },
             "since": { "type": "string" },

--- a/scripts/plugin-setup.sh
+++ b/scripts/plugin-setup.sh
@@ -12,11 +12,16 @@ set -euo pipefail
 existing_env_value() {
   local key="$1"
   local file
+  local value
   for file in "${CLAUDE_PLUGIN_DATA}/.env" "${CLAUDE_PLUGIN_DATA}/syslog-mcp.env"; do
     [[ -f "${file}" ]] || continue
-    awk -F= -v key="${key}" '$1 == key {print substr($0, index($0, "=") + 1); exit}' "${file}"
-    return 0
+    value="$(awk -F= -v key="${key}" '$1 == key {print substr($0, index($0, "=") + 1); exit}' "${file}")"
+    if [[ -n "${value}" ]]; then
+      printf '%s\n' "${value}"
+      return 0
+    fi
   done
+  return 0
 }
 
 # Seed the token from the existing env file when the plugin option isn't set,
@@ -28,7 +33,7 @@ AUTH_MODE="${CLAUDE_PLUGIN_OPTION_AUTH_MODE:-$(existing_env_value SYSLOG_MCP_AUT
 AUTH_MODE="${AUTH_MODE:-bearer}"
 AUTH_MODE="$(printf '%s' "${AUTH_MODE}" | tr '[:upper:]' '[:lower:]')"
 
-if [[ "${NO_AUTH}" != "true" && "${AUTH_MODE}" != "oauth" && -z "${CLAUDE_PLUGIN_OPTION_API_TOKEN:-}" ]]; then
+if [[ "${NO_AUTH}" != "true" && -z "${CLAUDE_PLUGIN_OPTION_API_TOKEN:-}" ]]; then
   _tok="$(existing_env_value SYSLOG_MCP_TOKEN)"
   [[ -n "${_tok}" ]] || _tok="$(existing_env_value SYSLOG_MCP_API_TOKEN)"
   [[ -n "${_tok}" ]] && CLAUDE_PLUGIN_OPTION_API_TOKEN="${_tok}"
@@ -39,13 +44,11 @@ fi
 IS_SERVER="${CLAUDE_PLUGIN_OPTION_IS_SERVER:-true}"
 USE_DOCKER="${CLAUDE_PLUGIN_OPTION_USE_DOCKER:-false}"
 API_TOKEN="${CLAUDE_PLUGIN_OPTION_API_TOKEN:-}"
-if [[ "${NO_AUTH}" != "true" && "${AUTH_MODE}" != "oauth" && -z "${API_TOKEN}" ]]; then
-  echo "ERROR: API token is required unless no_auth is true or auth_mode is oauth" >&2
-  exit 1
-fi
 SERVER_URL="${CLAUDE_PLUGIN_OPTION_SERVER_URL:-http://localhost:3100}"
 SYSLOG_HOST="${CLAUDE_PLUGIN_OPTION_SYSLOG_HOST:-0.0.0.0}"
 SYSLOG_PORT="${CLAUDE_PLUGIN_OPTION_SYSLOG_PORT:-1514}"
+SYSLOG_HOST_PORT="${CLAUDE_PLUGIN_OPTION_SYSLOG_HOST_PORT:-$(existing_env_value SYSLOG_HOST_PORT)}"
+SYSLOG_HOST_PORT="${SYSLOG_HOST_PORT:-1514}"
 MCP_HOST="${CLAUDE_PLUGIN_OPTION_MCP_HOST:-0.0.0.0}"
 MCP_PORT="${CLAUDE_PLUGIN_OPTION_MCP_PORT:-3100}"
 DATA_DIR="${CLAUDE_PLUGIN_OPTION_DATA_DIR:-${CLAUDE_PLUGIN_DATA}}"
@@ -58,6 +61,12 @@ GOOGLE_CLIENT_ID="${CLAUDE_PLUGIN_OPTION_GOOGLE_CLIENT_ID:-$(existing_env_value 
 GOOGLE_CLIENT_SECRET="${CLAUDE_PLUGIN_OPTION_GOOGLE_CLIENT_SECRET:-$(existing_env_value SYSLOG_MCP_GOOGLE_CLIENT_SECRET)}"
 AUTH_ADMIN_EMAIL="${CLAUDE_PLUGIN_OPTION_AUTH_ADMIN_EMAIL:-$(existing_env_value SYSLOG_MCP_AUTH_ADMIN_EMAIL)}"
 AUTH_ALLOWED_REDIRECT_URIS="${CLAUDE_PLUGIN_OPTION_AUTH_ALLOWED_REDIRECT_URIS:-$(existing_env_value SYSLOG_MCP_AUTH_ALLOWED_REDIRECT_URIS)}"
+
+if [[ "${NO_AUTH}" != "true" && -z "${API_TOKEN}" ]]; then
+  echo "ERROR: API token is required unless no_auth is true" >&2
+  echo "       OAuth mode still needs SYSLOG_MCP_TOKEN for OTLP /v1/logs writes." >&2
+  exit 1
+fi
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
 ENV_FILE="${CLAUDE_PLUGIN_DATA}/.env"
@@ -200,6 +209,7 @@ write_env() {
   new_env=$(cat << EOF
 SYSLOG_HOST=${SYSLOG_HOST}
 SYSLOG_PORT=${SYSLOG_PORT}
+SYSLOG_HOST_PORT=${SYSLOG_HOST_PORT}
 SYSLOG_MCP_HOST=${MCP_HOST}
 SYSLOG_MCP_PORT=${MCP_PORT}
 NO_AUTH=${NO_AUTH}
@@ -373,7 +383,7 @@ setup_docker() {
     external_named_container=true
   fi
   if [[ "${container_running}" == "false" ]]; then
-    for port_proto in "${SYSLOG_PORT}/udp" "${SYSLOG_PORT}/tcp" "${MCP_PORT}/tcp"; do
+    for port_proto in "${SYSLOG_HOST_PORT}/udp" "${SYSLOG_HOST_PORT}/tcp" "${MCP_PORT}/tcp"; do
       local port="${port_proto%%/*}" proto="${port_proto##*/}"
       if ss -"${proto:0:1}"lnp "sport = :${port}" 2>/dev/null | awk 'NR>1 && NF>0' | grep -q .; then
         echo "ERROR: port ${port}/${proto} is already in use — cannot start syslog-mcp" >&2

--- a/scripts/plugin-setup.sh
+++ b/scripts/plugin-setup.sh
@@ -24,6 +24,21 @@ existing_env_value() {
   return 0
 }
 
+validate_port_value() {
+  local name="$1" value="$2"
+  if ! [[ "${value}" =~ ^[0-9]+$ ]] || (( value < 1 || value > 65535 )); then
+    echo "ERROR: ${name} must be a TCP/UDP port number (1-65535), got: ${value}" >&2
+    exit 1
+  fi
+}
+
+mcp_host_is_loopback() {
+  case "$1" in
+    127.*|::1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Seed the token from the existing env file when the plugin option isn't set,
 # so /syslog:redeploy doesn't fail just because the env var wasn't injected.
 NO_AUTH="${CLAUDE_PLUGIN_OPTION_NO_AUTH:-$(existing_env_value NO_AUTH)}"
@@ -51,6 +66,9 @@ SYSLOG_HOST_PORT="${CLAUDE_PLUGIN_OPTION_SYSLOG_HOST_PORT:-$(existing_env_value 
 SYSLOG_HOST_PORT="${SYSLOG_HOST_PORT:-1514}"
 MCP_HOST="${CLAUDE_PLUGIN_OPTION_MCP_HOST:-0.0.0.0}"
 MCP_PORT="${CLAUDE_PLUGIN_OPTION_MCP_PORT:-3100}"
+validate_port_value SYSLOG_PORT "${SYSLOG_PORT}"
+validate_port_value SYSLOG_HOST_PORT "${SYSLOG_HOST_PORT}"
+validate_port_value SYSLOG_MCP_PORT "${MCP_PORT}"
 DATA_DIR="${CLAUDE_PLUGIN_OPTION_DATA_DIR:-${CLAUDE_PLUGIN_DATA}}"
 MAX_DB_SIZE_MB="${CLAUDE_PLUGIN_OPTION_MAX_DB_SIZE_MB:-8192}"
 RETENTION_DAYS="${CLAUDE_PLUGIN_OPTION_RETENTION_DAYS:-90}"
@@ -63,9 +81,11 @@ AUTH_ADMIN_EMAIL="${CLAUDE_PLUGIN_OPTION_AUTH_ADMIN_EMAIL:-$(existing_env_value 
 AUTH_ALLOWED_REDIRECT_URIS="${CLAUDE_PLUGIN_OPTION_AUTH_ALLOWED_REDIRECT_URIS:-$(existing_env_value SYSLOG_MCP_AUTH_ALLOWED_REDIRECT_URIS)}"
 
 if [[ "${NO_AUTH}" != "true" && -z "${API_TOKEN}" ]]; then
-  echo "ERROR: API token is required unless no_auth is true" >&2
-  echo "       OAuth mode still needs SYSLOG_MCP_TOKEN for OTLP /v1/logs writes." >&2
-  exit 1
+  if ! [[ "${AUTH_MODE}" == "oauth" && "${IS_SERVER}" == "true" ]] || ! mcp_host_is_loopback "${MCP_HOST}"; then
+    echo "ERROR: API token is required unless no_auth is true or OAuth server mode binds MCP to loopback" >&2
+    echo "       OAuth mode still needs SYSLOG_MCP_TOKEN when OTLP /v1/logs is exposed on a non-loopback listener." >&2
+    exit 1
+  fi
 fi
 
 # ── Paths ─────────────────────────────────────────────────────────────────────

--- a/scripts/validate-marketplace.sh
+++ b/scripts/validate-marketplace.sh
@@ -79,7 +79,16 @@ check "plugin declares api_token as sensitive" "jq -er '.userConfig.api_token.se
 
 if [[ -f "${PLUGIN_JSON}" && -f Cargo.toml ]]; then
   plugin_version="$(json_value '.version' "${PLUGIN_JSON}" || true)"
-  cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
+  cargo_version="$(awk '
+    /^\[/ { section = $0 }
+    section == "[package]" && /^version *= *"[^"]+"/ {
+      line = $0
+      sub(/^[^"]*"/, "", line)
+      sub(/".*/, "", line)
+      print line
+      exit
+    }
+  ' Cargo.toml)"
   check_equals "plugin version matches Cargo.toml" "${cargo_version}" "${plugin_version}"
 else
   check "plugin version matches Cargo.toml" "false"

--- a/scripts/validate-marketplace.sh
+++ b/scripts/validate-marketplace.sh
@@ -1,99 +1,131 @@
 #!/usr/bin/env bash
-# Validate Claude Code marketplace and plugin structure
+# Validate the Claude Code plugin artifacts shipped by this repository.
 
 set -uo pipefail
 
-# Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# Counters
 CHECKS=0
 PASSED=0
 FAILED=0
 
 check() {
-    local test_name="$1"
-    local test_cmd="$2"
+  local test_name="$1"
+  local test_cmd="$2"
 
-    CHECKS=$((CHECKS + 1))
-    echo -n "Checking: $test_name... "
+  CHECKS=$((CHECKS + 1))
+  printf 'Checking: %s... ' "${test_name}"
 
-    if eval "$test_cmd" > /dev/null 2>&1; then
-        echo -e "${GREEN}✓${NC}"
-        PASSED=$((PASSED + 1))
-        return 0
-    else
-        echo -e "${RED}✗${NC}"
-        FAILED=$((FAILED + 1))
-        return 1
-    fi
+  if eval "${test_cmd}" >/dev/null 2>&1; then
+    printf '%b\n' "${GREEN}PASS${NC}"
+    PASSED=$((PASSED + 1))
+    return 0
+  fi
+
+  printf '%b\n' "${RED}FAIL${NC}"
+  FAILED=$((FAILED + 1))
+  return 1
 }
 
-echo "=== Validating Claude Code Marketplace Structure ==="
-echo ""
+check_equals() {
+  local test_name="$1"
+  local expected="$2"
+  local actual="$3"
 
-# Check marketplace manifest
-check "Marketplace manifest exists" "test -f .claude-plugin/marketplace.json"
-check "Marketplace manifest is valid JSON" "jq empty .claude-plugin/marketplace.json"
-check "Marketplace has name" "jq -e '.name' .claude-plugin/marketplace.json"
-check "Marketplace has plugins array" "jq -e '.plugins | type == \"array\"' .claude-plugin/marketplace.json"
+  CHECKS=$((CHECKS + 1))
+  printf 'Checking: %s... ' "${test_name}"
 
-# Check plugin manifest
-check "Plugin manifest exists" "test -f .claude-plugin/plugin.json"
-check "Plugin manifest is valid JSON" "jq empty .claude-plugin/plugin.json"
-check "Plugin has name" "jq -e '.name' .claude-plugin/plugin.json"
-check "Plugin has version" "jq -e '.version' .claude-plugin/plugin.json"
-
-# Check plugin structure
-check "Plugin has SKILL.md" "test -f skills/unraid/SKILL.md"
-check "Plugin has README.md" "test -f skills/unraid/README.md"
-check "Plugin has scripts directory" "test -d skills/unraid/scripts"
-check "Plugin has examples directory" "test -d skills/unraid/examples"
-check "Plugin has references directory" "test -d skills/unraid/references"
-
-# Validate plugin is listed in marketplace
-check "Plugin listed in marketplace" "jq -e '.plugins[] | select(.name == \"unraid\")' .claude-plugin/marketplace.json"
-
-# Check marketplace metadata
-check "Marketplace has repository" "jq -e '.repository' .claude-plugin/marketplace.json"
-check "Marketplace has owner" "jq -e '.owner' .claude-plugin/marketplace.json"
-
-# Verify source path
-PLUGIN_SOURCE=$(jq -r '.plugins[]? | select(.name == "unraid") | .source // empty' .claude-plugin/marketplace.json 2>/dev/null || true)
-if [ -n "$PLUGIN_SOURCE" ]; then
-    check "Plugin source path is valid" "test -d \"$PLUGIN_SOURCE\""
-else
-    CHECKS=$((CHECKS + 1))
-    FAILED=$((FAILED + 1))
-    echo -e "Checking: Plugin source path is valid... ${RED}✗${NC} (plugin not found in marketplace)"
-fi
-
-# Check version sync between pyproject.toml and plugin.json
-echo "Checking version sync..."
-TOML_VER=$(grep -m1 '^version = ' pyproject.toml | sed 's/version = "//;s/"//')
-PLUGIN_VER=$(python3 -c "import json; print(json.load(open('.claude-plugin/plugin.json'))['version'])" 2>/dev/null || echo "ERROR_READING")
-if [ "$TOML_VER" != "$PLUGIN_VER" ]; then
-    echo -e "${RED}FAIL: Version mismatch — pyproject.toml=$TOML_VER, plugin.json=$PLUGIN_VER${NC}"
-    CHECKS=$((CHECKS + 1))
-    FAILED=$((FAILED + 1))
-else
-    echo -e "${GREEN}PASS: Versions in sync ($TOML_VER)${NC}"
-    CHECKS=$((CHECKS + 1))
+  if [[ "${actual}" == "${expected}" ]]; then
+    printf '%b\n' "${GREEN}PASS${NC}"
     PASSED=$((PASSED + 1))
+    return 0
+  fi
+
+  printf '%b expected %q, got %q\n' "${RED}FAIL${NC}" "${expected}" "${actual}"
+  FAILED=$((FAILED + 1))
+  return 1
+}
+
+json_value() {
+  local query="$1"
+  local file="$2"
+  jq -er "${query}" "${file}" 2>/dev/null
+}
+
+echo "=== Validating syslog-mcp Plugin Layout ==="
+echo
+
+check "jq is available" "command -v jq"
+
+PLUGIN_JSON=".claude-plugin/plugin.json"
+MCP_JSON="plugins/.mcp.json"
+HOOKS_JSON="plugins/hooks/hooks.json"
+SKILLS_DIR="plugins/skills"
+
+check "plugin manifest exists" "test -f '${PLUGIN_JSON}'"
+check "plugin manifest is valid JSON" "jq empty '${PLUGIN_JSON}'"
+check "plugin name is syslog" "test \"\$(jq -er '.name' '${PLUGIN_JSON}')\" = 'syslog'"
+check "plugin has semver version" "jq -er '.version | test(\"^[0-9]+\\\\.[0-9]+\\\\.[0-9]+$\")' '${PLUGIN_JSON}'"
+check "plugin points to MCP config" "test \"\$(jq -er '.mcpServers' '${PLUGIN_JSON}')\" = './plugins/.mcp.json'"
+check "plugin points to hooks config" "test \"\$(jq -er '.hooks' '${PLUGIN_JSON}')\" = './plugins/hooks/hooks.json'"
+check "plugin points to skills directory" "test \"\$(jq -er '.skills' '${PLUGIN_JSON}')\" = './plugins/skills'"
+check "plugin declares server_url userConfig" "jq -er '.userConfig.server_url.default == \"http://localhost:3100\"' '${PLUGIN_JSON}'"
+check "plugin declares syslog_port userConfig" "jq -er '.userConfig.syslog_port.default == 1514' '${PLUGIN_JSON}'"
+check "plugin declares syslog_host_port userConfig" "jq -er '.userConfig.syslog_host_port.default == 1514' '${PLUGIN_JSON}'"
+check "plugin declares mcp_port userConfig" "jq -er '.userConfig.mcp_port.default == 3100' '${PLUGIN_JSON}'"
+check "plugin declares api_token as sensitive" "jq -er '.userConfig.api_token.sensitive == true' '${PLUGIN_JSON}'"
+
+if [[ -f "${PLUGIN_JSON}" && -f Cargo.toml ]]; then
+  plugin_version="$(json_value '.version' "${PLUGIN_JSON}" || true)"
+  cargo_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n 1)"
+  check_equals "plugin version matches Cargo.toml" "${cargo_version}" "${plugin_version}"
+else
+  check "plugin version matches Cargo.toml" "false"
 fi
 
-echo ""
-echo "=== Results ==="
-echo -e "Total checks: $CHECKS"
-echo -e "${GREEN}Passed: $PASSED${NC}"
-if [ $FAILED -gt 0 ]; then
-    echo -e "${RED}Failed: $FAILED${NC}"
-    exit 1
-else
-    echo -e "${GREEN}All checks passed!${NC}"
-    echo ""
-    echo "Marketplace is ready for distribution at:"
-    echo "  $(jq -r '.repository' .claude-plugin/marketplace.json)"
+check "MCP config exists" "test -f '${MCP_JSON}'"
+check "MCP config is valid JSON" "jq empty '${MCP_JSON}'"
+check "MCP server is named syslog" "jq -er '.mcpServers.syslog' '${MCP_JSON}'"
+check "MCP transport is HTTP" "jq -er '.mcpServers.syslog.type == \"http\"' '${MCP_JSON}'"
+check "MCP URL uses server_url and /mcp path" "jq -er '.mcpServers.syslog.url == \"\${user_config.server_url}/mcp\"' '${MCP_JSON}'"
+check "MCP Authorization header uses api_token" "jq -er '.mcpServers.syslog.headers.Authorization == \"Bearer \${user_config.api_token}\"' '${MCP_JSON}'"
+
+check "hooks config exists" "test -f '${HOOKS_JSON}'"
+check "hooks config is valid JSON" "jq empty '${HOOKS_JSON}'"
+check "SessionStart runs plugin setup" "jq -er '.hooks.SessionStart[]?.hooks[]?.command == \"\${CLAUDE_PLUGIN_ROOT}/scripts/plugin-setup.sh\"' '${HOOKS_JSON}'"
+check "ConfigChange runs plugin setup" "jq -er '.hooks.ConfigChange[]? | select(.matcher == \"user_settings\") | .hooks[]?.command == \"\${CLAUDE_PLUGIN_ROOT}/scripts/plugin-setup.sh\"' '${HOOKS_JSON}'"
+
+check "skills directory exists" "test -d '${SKILLS_DIR}'"
+
+skill_count=0
+if [[ -d "${SKILLS_DIR}" ]]; then
+  while IFS= read -r skill_file; do
+    skill_count=$((skill_count + 1))
+    skill_dir="$(basename "$(dirname "${skill_file}")")"
+    check "skill ${skill_dir} has front matter name" "awk 'BEGIN {found=0} /^name:[[:space:]]*${skill_dir}[[:space:]]*$/ {found=1} END {exit found ? 0 : 1}' '${skill_file}'"
+    check "skill ${skill_dir} has description" "awk 'BEGIN {found=0} /^description:[[:space:]]*[^[:space:]]/ {found=1} END {exit found ? 0 : 1}' '${skill_file}'"
+  done < <(find "${SKILLS_DIR}" -mindepth 2 -maxdepth 2 -name SKILL.md | sort)
 fi
+
+CHECKS=$((CHECKS + 1))
+printf 'Checking: at least one plugin skill exists... '
+if (( skill_count > 0 )); then
+  printf '%b\n' "${GREEN}PASS${NC}"
+  PASSED=$((PASSED + 1))
+else
+  printf '%b\n' "${RED}FAIL${NC}"
+  FAILED=$((FAILED + 1))
+fi
+
+echo
+echo "=== Results ==="
+echo "Total checks: ${CHECKS}"
+printf '%b\n' "${GREEN}Passed: ${PASSED}${NC}"
+if (( FAILED > 0 )); then
+  printf '%b\n' "${RED}Failed: ${FAILED}${NC}"
+  exit 1
+fi
+
+printf '%b\n' "${GREEN}All checks passed.${NC}"

--- a/src/config.rs
+++ b/src/config.rs
@@ -834,9 +834,7 @@ fn validate_auth_config(config: &Config, check_bind: bool) -> anyhow::Result<()>
         return Ok(());
     }
 
-    let bind_is_loopback = IpAddr::from_str(&config.mcp.host)
-        .map(|ip| ip.is_loopback())
-        .unwrap_or(false);
+    let bind_is_loopback = mcp_bind_is_loopback(config);
     if check_bind && !bind_is_loopback {
         let has_static_token = config
             .mcp
@@ -844,6 +842,16 @@ fn validate_auth_config(config: &Config, check_bind: bool) -> anyhow::Result<()>
             .as_deref()
             .is_some_and(|t| !t.trim().is_empty());
         let has_oauth = auth.mode == AuthMode::OAuth;
+        if has_oauth && !has_static_token {
+            return Err(anyhow::anyhow!(
+                "MCP host `{}` is not a loopback address and SYSLOG_MCP_AUTH_MODE=oauth is \
+                 configured without SYSLOG_MCP_TOKEN. OTLP /v1/logs only supports the static \
+                 Bearer token gate today, so this would expose unauthenticated OTLP writes. \
+                 Set SYSLOG_MCP_TOKEN, bind to 127.0.0.1 / ::1, or enable an upstream auth \
+                 gateway with SYSLOG_MCP_NO_AUTH=true.",
+                config.mcp.host
+            ));
+        }
         if !has_static_token && !has_oauth {
             return Err(anyhow::anyhow!(
                 "MCP host `{}` is not a loopback address but no authentication is configured — \
@@ -854,6 +862,12 @@ fn validate_auth_config(config: &Config, check_bind: bool) -> anyhow::Result<()>
     }
 
     Ok(())
+}
+
+fn mcp_bind_is_loopback(config: &Config) -> bool {
+    IpAddr::from_str(&config.mcp.host)
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }
 
 fn option_is_blank(value: &Option<String>) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -864,7 +864,7 @@ fn validate_auth_config(config: &Config, check_bind: bool) -> anyhow::Result<()>
     Ok(())
 }
 
-fn mcp_bind_is_loopback(config: &Config) -> bool {
+pub(crate) fn mcp_bind_is_loopback(config: &Config) -> bool {
     IpAddr::from_str(&config.mcp.host)
         .map(|ip| ip.is_loopback())
         .unwrap_or(false)

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -618,6 +618,17 @@ fn loopback_config_with_token() -> Config {
     cfg
 }
 
+fn valid_oauth_config_without_token() -> Config {
+    let mut cfg = Config::default();
+    cfg.mcp.api_token = None;
+    cfg.mcp.auth.mode = AuthMode::OAuth;
+    cfg.mcp.auth.public_url = Some("https://syslog.example.com".into());
+    cfg.mcp.auth.google_client_id = Some("id".into());
+    cfg.mcp.auth.google_client_secret = Some("secret".into());
+    cfg.mcp.auth.allowed_emails = vec!["admin@example.com".into()];
+    cfg
+}
+
 #[test]
 fn auth_defaults_are_bearer_with_disable_static_token_enabled() {
     let cfg = AuthConfig::default();
@@ -891,16 +902,31 @@ fn non_loopback_bind_with_static_token_passes() {
 }
 
 #[test]
-fn non_loopback_bind_with_oauth_passes() {
-    let mut cfg = Config::default();
+fn non_loopback_bind_with_oauth_and_static_token_passes() {
+    let mut cfg = valid_oauth_config_without_token();
     cfg.mcp.host = "0.0.0.0".into();
-    cfg.mcp.api_token = Some("token".into()); // satisfies existing token-shape check
-    cfg.mcp.auth.mode = AuthMode::OAuth;
-    cfg.mcp.auth.public_url = Some("https://syslog.example.com".into());
-    cfg.mcp.auth.google_client_id = Some("id".into());
-    cfg.mcp.auth.google_client_secret = Some("secret".into());
-    cfg.mcp.auth.allowed_emails = vec!["admin@example.com".into()];
+    cfg.mcp.api_token = Some("token".into());
     validate_auth_config(&cfg, true).expect("oauth unlocks non-loopback bind");
+}
+
+#[test]
+fn non_loopback_oauth_without_static_token_rejects_otlp_write_exposure() {
+    let mut cfg = valid_oauth_config_without_token();
+    cfg.mcp.host = "0.0.0.0".into();
+
+    let err = validate_auth_config(&cfg, true).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("OTLP /v1/logs") && msg.contains("SYSLOG_MCP_TOKEN"),
+        "wrong error: {msg}"
+    );
+}
+
+#[test]
+fn loopback_oauth_without_static_token_keeps_dev_mode_allowed() {
+    let mut cfg = valid_oauth_config_without_token();
+    cfg.mcp.host = "127.0.0.1".into();
+    validate_auth_config(&cfg, true).expect("loopback OTLP exposure is local-only");
 }
 
 #[test]

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -25,6 +25,29 @@ pub struct SyslogRmcpServer {
     state: AppState,
 }
 
+const READ_SCOPE: &str = "syslog:read";
+const DENY_SCOPE: &str = "syslog:__deny__";
+const READ_ONLY_ACTIONS: &[&str] = &[
+    "search",
+    "tail",
+    "errors",
+    "hosts",
+    "correlate",
+    "stats",
+    "status",
+    "apps",
+    "source_ips",
+    "timeline",
+    "patterns",
+    "context",
+    "get",
+    "ingest_rate",
+    "silent_hosts",
+    "clock_skew",
+    "anomalies",
+    "compare",
+];
+
 impl SyslogRmcpServer {
     pub fn new(state: AppState) -> Self {
         Self { state }
@@ -340,17 +363,16 @@ fn check_scope(auth: &AuthContext, required_scope: &str, action: &str) -> Result
 /// `execute_tool` to reject invalid actions. `Some("syslog:__deny__")` is
 /// the correct mechanism to guarantee rejection at the auth layer.
 fn required_scope_for(action: &str) -> Option<&'static str> {
-    match action {
+    if action == "help" {
         // Informational — AuthContext required when Mounted, but no scope gate.
-        "help" => None,
-        // All current read actions require syslog:read.
-        "search" | "tail" | "errors" | "hosts" | "correlate" | "stats" | "status" => {
-            Some("syslog:read")
-        }
+        None
+    } else if READ_ONLY_ACTIONS.contains(&action) {
+        Some(READ_SCOPE)
+    } else {
         // Future write/admin actions would map to syslog:admin here.
         // Default: unknown actions use an ungrantable sentinel scope so they
         // are denied at the auth layer rather than falling through to dispatch.
-        _ => Some("syslog:__deny__"),
+        Some(DENY_SCOPE)
     }
 }
 

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -27,6 +27,9 @@ pub struct SyslogRmcpServer {
 
 const READ_SCOPE: &str = "syslog:read";
 const DENY_SCOPE: &str = "syslog:__deny__";
+/// Public read-only MCP actions. Must mirror non-`help` entries in
+/// [`crate::mcp::schemas::SYSLOG_ACTIONS`]; drift is covered by
+/// `public_read_actions_require_syslog_read_scope` in `rmcp_server_tests.rs`.
 const READ_ONLY_ACTIONS: &[&str] = &[
     "search",
     "tail",

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -145,8 +145,9 @@ impl ServerHandler for SyslogRmcpServer {
     async fn list_resources(
         &self,
         _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
+        require_auth_context(&self.state, &context)?;
         Ok(ListResourcesResult {
             resources: vec![schema_resource()],
             ..Default::default()
@@ -156,8 +157,9 @@ impl ServerHandler for SyslogRmcpServer {
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
+        require_auth_context(&self.state, &context)?;
         if request.uri != SCHEMA_RESOURCE_URI {
             return Err(ErrorData::invalid_params(
                 format!("unknown resource: {}", request.uri),

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -588,6 +588,17 @@ async fn loopback_dev_policy_permits_all_actions_without_auth_context() {
         "response: {response}"
     );
 
+    let (status, response) = post_rmcp(
+        router.clone(),
+        jsonrpc_request(12, "resources/list", Some(json!({}))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        response["result"]["resources"].is_array(),
+        "resources/list should succeed under LoopbackDev; response: {response}"
+    );
+
     // tools/call should succeed without AuthContext under LoopbackDev.
     let (status, response) = post_rmcp(
         router,
@@ -789,6 +800,32 @@ async fn mounted_policy_missing_auth_context_denies_all_including_help_and_tools
         "tools/list with missing AuthContext should be forbidden; response: {response}"
     );
 
+    let (status, response) = post_rmcp(
+        router.clone(),
+        jsonrpc_request(73, "resources/list", Some(json!({}))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        response["error"]["code"], -32600,
+        "resources/list with missing AuthContext should be forbidden; response: {response}"
+    );
+
+    let (status, response) = post_rmcp(
+        router.clone(),
+        jsonrpc_request(
+            74,
+            "resources/read",
+            Some(json!({"uri": super::SCHEMA_RESOURCE_URI})),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        response["error"]["code"], -32600,
+        "resources/read with missing AuthContext should be forbidden; response: {response}"
+    );
+
     // help must also be denied.
     let (status, response) = post_rmcp(
         router.clone(),
@@ -837,6 +874,43 @@ async fn mounted_policy_with_auth_context_permits_tools_list() {
     assert_eq!(
         tools[0]["name"], "syslog",
         "tools/list should return syslog tool; response: {response}"
+    );
+}
+
+#[tokio::test]
+async fn mounted_policy_with_auth_context_permits_schema_resources() {
+    let (state, _pool, _dir) = mounted_state();
+    let auth = auth_ctx_with_scopes(vec![]);
+    let router = rmcp_router_with_auth(state, auth);
+
+    let (status, response) = post_rmcp(
+        router.clone(),
+        jsonrpc_request(81, "resources/list", Some(json!({}))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let resources = response["result"]["resources"].as_array().unwrap();
+    assert_eq!(
+        resources[0]["uri"],
+        super::SCHEMA_RESOURCE_URI,
+        "resources/list should expose schema resource; response: {response}"
+    );
+
+    let (status, response) = post_rmcp(
+        router,
+        jsonrpc_request(
+            82,
+            "resources/read",
+            Some(json!({"uri": super::SCHEMA_RESOURCE_URI})),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        response["result"]["contents"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("\"name\": \"syslog\"")),
+        "resources/read should return schema JSON; response: {response}"
     );
 }
 

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -15,10 +15,13 @@ use crate::{
     app::SyslogService,
     config::{McpConfig, StorageConfig},
     db::{self, DbPool, LogBatchEntry},
-    mcp::{streamable_http_config, streamable_http_service, AppState, AuthPolicy},
+    mcp::{
+        schemas::SYSLOG_ACTIONS, streamable_http_config, streamable_http_service, AppState,
+        AuthPolicy,
+    },
 };
 
-use super::{allowed_hosts, allowed_origins, is_validation_error};
+use super::{allowed_hosts, allowed_origins, is_validation_error, required_scope_for};
 
 fn test_state() -> (AppState, Arc<DbPool>, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
@@ -116,6 +119,36 @@ fn entry(ts: &str, host: &str, severity: &str, msg: &str, source_ip: &str) -> Lo
         raw: msg.to_string(),
         source_ip: source_ip.to_string(),
         docker_checkpoint: None,
+    }
+}
+
+fn seed_auth_action_log(pool: &DbPool) {
+    db::insert_logs_batch(
+        pool,
+        &[entry(
+            "2026-01-01T00:00:00Z",
+            "auth-test-host",
+            "err",
+            "mounted auth coverage",
+            "127.0.0.1:514",
+        )],
+    )
+    .unwrap();
+}
+
+fn minimal_args_for_action(action: &str) -> Value {
+    match action {
+        "correlate" => json!({"action": action, "reference_time": "2026-01-01T00:00:00Z"}),
+        "context" => json!({"action": action, "log_id": 1}),
+        "get" => json!({"action": action, "id": 1}),
+        "compare" => json!({
+            "action": action,
+            "a_from": "2026-01-01T00:00:00Z",
+            "a_to": "2026-01-01T00:01:00Z",
+            "b_from": "2026-01-01T00:01:00Z",
+            "b_to": "2026-01-01T00:02:00Z",
+        }),
+        _ => json!({"action": action}),
     }
 }
 
@@ -573,17 +606,22 @@ async fn loopback_dev_policy_permits_all_actions_without_auth_context() {
 /// actions permitted.
 #[tokio::test]
 async fn mounted_policy_with_read_scope_permits_read_actions() {
-    let (state, _pool, _dir) = mounted_state();
+    let (state, pool, _dir) = mounted_state();
+    seed_auth_action_log(&pool);
     let auth = auth_ctx_with_scopes(vec!["syslog:read"]);
     let router = rmcp_router_with_auth(state, auth);
 
-    for action in &["stats", "status", "tail", "errors", "hosts", "help"] {
+    for action in SYSLOG_ACTIONS
+        .iter()
+        .copied()
+        .filter(|action| *action != "help")
+    {
         let (status, response) = post_rmcp(
             router.clone(),
             jsonrpc_request(
                 20,
                 "tools/call",
-                Some(json!({"name": "syslog", "arguments": {"action": action}})),
+                Some(json!({"name": "syslog", "arguments": minimal_args_for_action(action)})),
             ),
         )
         .await;
@@ -598,6 +636,26 @@ async fn mounted_policy_with_read_scope_permits_read_actions() {
             "action={action} got forbidden; response: {response}"
         );
     }
+}
+
+#[test]
+fn public_read_actions_require_syslog_read_scope() {
+    for action in SYSLOG_ACTIONS
+        .iter()
+        .copied()
+        .filter(|action| *action != "help")
+    {
+        assert_eq!(
+            required_scope_for(action),
+            Some("syslog:read"),
+            "action={action} must require syslog:read"
+        );
+    }
+    assert_eq!(required_scope_for("help"), None);
+    assert_eq!(
+        required_scope_for("not_a_real_action"),
+        Some("syslog:__deny__")
+    );
 }
 
 /// `AuthPolicy::Mounted` + AuthContext with `syslog:admin` (superset) → read
@@ -658,21 +716,17 @@ async fn mounted_policy_with_empty_scopes_denies_read_actions() {
     let auth = auth_ctx_with_scopes(vec![]);
     let router = rmcp_router_with_auth(state, auth);
 
-    for action in &[
-        "search",
-        "tail",
-        "errors",
-        "hosts",
-        "correlate",
-        "stats",
-        "status",
-    ] {
+    for action in SYSLOG_ACTIONS
+        .iter()
+        .copied()
+        .filter(|action| *action != "help")
+    {
         let (status, response) = post_rmcp(
             router.clone(),
             jsonrpc_request(
                 50,
                 "tools/call",
-                Some(json!({"name": "syslog", "arguments": {"action": action}})),
+                Some(json!({"name": "syslog", "arguments": minimal_args_for_action(action)})),
             ),
         )
         .await;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -88,6 +88,7 @@ impl RuntimeCore {
         enforce_initial_storage_budget: bool,
         is_stdio: bool,
     ) -> Result<Self> {
+        reject_unsafe_otlp_oauth_only_exposure(&config, is_stdio)?;
         let pool = Arc::new(db::init_pool(&config.storage)?);
         let storage_state = Arc::new(Mutex::new(None));
         if enforce_initial_storage_budget
@@ -350,6 +351,37 @@ impl RuntimeCore {
     }
 }
 
+fn reject_unsafe_otlp_oauth_only_exposure(config: &Config, is_stdio: bool) -> Result<()> {
+    if is_stdio || config.mcp.no_auth || config.mcp.auth.mode != AuthMode::OAuth {
+        return Ok(());
+    }
+
+    if !mcp_bind_is_loopback(config) && !mcp_static_token_active(config) {
+        anyhow::bail!(
+            "refusing to mount OTLP /v1/logs on non-loopback OAuth-only deployment: \
+             OTLP only supports SYSLOG_MCP_TOKEN Bearer auth today; set SYSLOG_MCP_TOKEN, \
+             bind to loopback, or set SYSLOG_MCP_NO_AUTH=true when an upstream gateway \
+             protects all mounted routes"
+        );
+    }
+
+    Ok(())
+}
+
+fn mcp_bind_is_loopback(config: &Config) -> bool {
+    IpAddr::from_str(&config.mcp.host)
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
+fn mcp_static_token_active(config: &Config) -> bool {
+    config
+        .mcp
+        .api_token
+        .as_deref()
+        .is_some_and(|t| !t.trim().is_empty())
+}
+
 /// Decide which [`AuthPolicy`] to install on [`mcp::AppState`] given the
 /// fully-loaded [`Config`].
 ///
@@ -414,10 +446,7 @@ async fn build_auth_policy(config: &Config, is_stdio: bool) -> Result<AuthPolicy
         // but double-checked here so LoopbackDev can never slip past on a non-loopback bind).
         // The early return above guarantees `is_stdio` is false here, so the bind
         // check always applies.
-        let bind_is_loopback = IpAddr::from_str(&config.mcp.host)
-            .map(|ip| ip.is_loopback())
-            .unwrap_or(false);
-        if !bind_is_loopback {
+        if !mcp_bind_is_loopback(config) {
             anyhow::bail!(
                 "internal invariant violated: no auth wired but bind `{}` is non-loopback",
                 config.mcp.host

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -349,6 +349,8 @@ impl RuntimeCore {
     }
 }
 
+/// Defense-in-depth duplicate of `validate_auth_config` for callers that use
+/// `RuntimeCore::for_server(config)` without going through `Config::load()`.
 fn reject_unsafe_otlp_oauth_only_exposure(config: &Config, is_stdio: bool) -> Result<()> {
     if is_stdio || config.mcp.no_auth || config.mcp.auth.mode != AuthMode::OAuth {
         return Ok(());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,6 +1,4 @@
-use std::net::IpAddr;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -9,7 +7,7 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 
 use crate::app::SyslogService;
-use crate::config::{AuthMode, Config};
+use crate::config::{mcp_bind_is_loopback, AuthMode, Config};
 use crate::db::{self, DbPool, StorageBudgetState};
 use crate::ingest::IngestTx;
 use crate::mcp::AuthPolicy;
@@ -368,12 +366,6 @@ fn reject_unsafe_otlp_oauth_only_exposure(config: &Config, is_stdio: bool) -> Re
     Ok(())
 }
 
-fn mcp_bind_is_loopback(config: &Config) -> bool {
-    IpAddr::from_str(&config.mcp.host)
-        .map(|ip| ip.is_loopback())
-        .unwrap_or(false)
-}
-
 fn mcp_static_token_active(config: &Config) -> bool {
     config
         .mcp
@@ -424,11 +416,7 @@ async fn build_auth_policy(config: &Config, is_stdio: bool) -> Result<AuthPolicy
 
     let auth = &config.mcp.auth;
     let oauth_active = auth.mode == AuthMode::OAuth;
-    let static_token_active = config
-        .mcp
-        .api_token
-        .as_deref()
-        .is_some_and(|t| !t.trim().is_empty());
+    let static_token_active = mcp_static_token_active(config);
 
     if !oauth_active {
         if static_token_active {

--- a/src/runtime_tests.rs
+++ b/src/runtime_tests.rs
@@ -141,6 +141,10 @@ async fn runtime_rejects_non_loopback_oauth_without_static_token_before_otlp_mou
         msg.contains("OTLP /v1/logs") && msg.contains("SYSLOG_MCP_TOKEN"),
         "wrong error: {msg}"
     );
+    assert!(
+        !tmp.path().join("syslog.db").exists(),
+        "rejection must occur before db::init_pool runs"
+    );
 }
 
 #[tokio::test]

--- a/src/runtime_tests.rs
+++ b/src/runtime_tests.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{background_interval, build_auth_policy};
+use super::{background_interval, build_auth_policy, RuntimeCore};
 use crate::config::{AuthConfig, AuthMode, Config, McpConfig, StorageConfig};
 use crate::mcp::AuthPolicy;
 
@@ -121,6 +121,25 @@ async fn build_auth_policy_returns_mounted_when_oauth_configured() {
     assert!(
         tmp.path().join("auth-jwt.pem").exists(),
         "auth-jwt.pem missing"
+    );
+}
+
+#[tokio::test]
+async fn runtime_rejects_non_loopback_oauth_without_static_token_before_otlp_mount() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut mcp = oauth_mcp(tmp.path());
+    mcp.host = "0.0.0.0".into();
+    mcp.api_token = None;
+    let config = test_config(tmp.path(), mcp);
+
+    let err = match RuntimeCore::for_server(config).await {
+        Ok(_) => panic!("oauth-only non-loopback OTLP exposure must be rejected"),
+        Err(err) => err,
+    };
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("OTLP /v1/logs") && msg.contains("SYSLOG_MCP_TOKEN"),
+        "wrong error: {msg}"
     );
 }
 


### PR DESCRIPTION
## Summary
- reject unsafe non-loopback OAuth-only OTLP exposure unless SYSLOG_MCP_TOKEN is configured
- map current public read-only MCP actions to syslog:read with exhaustive mounted-auth coverage
- refresh plugin setup/validation, Docker port metadata, Compose host-port guidance, and MCP docs
- bump version to 0.17.5 with changelog entry

## Beads Closed
- syslog-mcp-zfzt
- syslog-mcp-8ptx
- syslog-mcp-vw3z
- syslog-mcp-gz3i
- syslog-mcp-0w8x
- syslog-mcp-8dcp
- syslog-mcp-1bqy
- syslog-mcp-n63r
- syslog-mcp-5t3e
- syslog-mcp-z83z

## Verification
- cargo fmt -- --check
- cargo test
- cargo clippy -- -D warnings
- bash -n scripts/plugin-setup.sh scripts/validate-marketplace.sh
- bash scripts/validate-marketplace.sh
- docker compose config --quiet
- ./scripts/check-version-sync.sh
- git diff --check
- bd show <all scoped beads> --json confirmed closed
- lavra-review security/goal/simplicity passes completed; findings addressed
- pr-review-toolkit code review completed; finding addressed
- code_simplifier reviewed touched Rust files; accepted helper cleanup, restored explicit scope allowlist

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened MCP/OTLP auth and tightened plugin/Docker setup to safely gate OTLP writes, enforce `syslog:read` on all read actions, and align Docker ports; `syslog-mcp` is now 0.17.7.

- **Bug Fixes**
  - OAuth-only non-loopback deployments now refuse to start without `SYSLOG_MCP_TOKEN`, and the rejection happens before DB initialization to avoid side effects.
  - All public read actions now require `syslog:read`; unknown actions are denied via a sentinel scope. Mounted-auth also requires an auth context for MCP `resources/list` and `resources/read` (with tests to prevent scope/action drift).
  - Docker/Compose: the container listens on `1514`; Compose maps host `SYSLOG_HOST_PORT` to container `SYSLOG_PORT`. `.claude-plugin/plugin.json` adds `syslog_host_port`. `plugin-setup.sh` validates ports, allows tokenless OAuth only on loopback server mode, writes `SYSLOG_MCP_TOKEN`, migrates the legacy token, and sets `SYSLOG_HOST_PORT`. Marketplace validation now checks the plugin layout and version sync with Cargo.
  - Docs and MCP schema updated (expanded action set; SSE removed). Added a `cargo-audit` gate with a documented temporary RSA exception.

- **Migration**
  - Set `SYSLOG_MCP_TOKEN` when `SYSLOG_MCP_AUTH_MODE=oauth` on non-loopback hosts.
  - In Docker, keep `SYSLOG_PORT=1514` in-container and publish the host port with `SYSLOG_HOST_PORT` (use `514` if devices require it).
  - Re-run plugin setup; it writes `SYSLOG_MCP_TOKEN`, migrates `SYSLOG_MCP_API_TOKEN`, validates ports, ensures the plugin layout, and sets `SYSLOG_HOST_PORT`.

<sup>Written for commit 5de4aaa761043bd42aeacced7feb3f17da7de4f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded MCP syslog tool with many new actions (status, apps, source_ips, timeline, patterns, context, get, ingest_rate, silent_hosts, clock_skew, anomalies, compare).
  * Added SYSLOG_HOST_PORT (host publish port) and switched container syslog listener to 1514 by default.

* **Bug Fixes**
  * Enforced static token requirement when OTLP /v1/logs is exposed in OAuth-only non-loopback setups.

* **Documentation**
  * Updated docs, README, and changelog to reflect port, action, and deployment guidance.

* **Chores**
  * Bumped release version and improved marketplace/plugin validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->