### PR TITLE
feat: add compose lifecycle CLI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Syslog management via MCP",
   "author": { "name": "jmagar" },
   "repository": "https://github.com/jmagar/syslog-mcp",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ docker compose up -d             # production deployment
 docker compose down              # stop
 docker compose logs -f           # follow logs
 docker compose build             # rebuild image
+syslog compose doctor            # diagnose live Compose/systemd/listener ownership
+syslog compose status --json     # inspect canonical syslog-mcp container/project
+syslog compose pull              # pull image for resolved Compose project
+syslog compose up                # run docker compose up -d for resolved service
+syslog compose restart           # restart resolved service
+syslog compose logs --tail 20    # bounded compose logs
 ```
 
 ```bash
@@ -214,6 +220,8 @@ curl -s -X POST http://localhost:3100/mcp \
 # stdio mode (query-only, no ingest — useful for Claude Desktop)
 cargo run -- mcp
 ```
+
+`syslog compose` commands resolve the live Compose owner before mutation. They refuse ambiguous cwd fallback, stale Compose labels, systemd/listener conflicts, and destructive `down` without `--yes`.
 
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:compact hash:f65d5d33 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-05-12
+
+### Added
+
+- **Compose lifecycle CLI**: Added `syslog compose status`, `doctor`, `pull`,
+  `up`, `restart`, `down`, and `logs` commands with live Compose target
+  discovery, mutation preflight checks, bounded subprocess output, and JSON
+  output support.
+- **Compose MCP diagnostics**: Added read-only `compose_status` and
+  `compose_doctor` MCP actions with redacted deployment state, published port
+  summaries, and existing `syslog:read` scope enforcement.
+
+### Changed
+
+- Updated deployment, CLI, MCP schema, smoke-test, and plugin docs for the
+  compose lifecycle surface.
+
 ## [0.19.2] - 2026-05-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3043,6 +3043,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "lab-auth",
+ "libc",
  "opentelemetry-proto",
  "prost",
  "r2d2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.19.2"
+version = "0.20.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"
@@ -62,6 +62,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Utils
 anyhow = "1"
+libc = "0.2"
 rustix = { version = "0.38", features = ["fs"] }
 regex = "1"
 sha2 = "0.10"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The daemon listens on a single port for both UDP and TCP syslog (default `1514`)
 
 ## Tools
 
-One MCP tool, `syslog`, is exposed. Use the required `action` argument to run `search`, `tail`, `errors`, `hosts`, `sessions`, `search_sessions`, `usage_blocks`, `project_context`, `list_ai_tools`, `list_ai_projects`, `correlate`, `stats`, `status`, `apps`, `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`, `silent_hosts`, `clock_skew`, `anomalies`, `compare`, or `help`.
+One MCP tool, `syslog`, is exposed. Use the required `action` argument to run `search`, `tail`, `errors`, `hosts`, `sessions`, `search_sessions`, `usage_blocks`, `project_context`, `list_ai_tools`, `list_ai_projects`, `correlate`, `stats`, `status`, `apps`, `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`, `silent_hosts`, `clock_skew`, `anomalies`, `compare`, `compose_status`, `compose_doctor`, or `help`.
 
 For the complete action-specific parameter reference, see [`docs/mcp/SCHEMA.md`](docs/mcp/SCHEMA.md).
 
@@ -54,6 +54,8 @@ For the complete action-specific parameter reference, see [`docs/mcp/SCHEMA.md`]
 | `clock_skew` | Per-host received_at minus timestamp distribution |
 | `anomalies` | Recent vs baseline volume/error comparison |
 | `compare` | Side-by-side comparison of two time ranges |
+| `compose_status` | Redacted read-only Compose deployment diagnostics |
+| `compose_doctor` | Alias for Compose deployment health diagnostics |
 | `help` | Markdown reference for all actions |
 
 ### `syslog search`
@@ -615,6 +617,8 @@ allow_insecure_http = true
 syslog serve mcp  # UDP/TCP syslog ingest plus HTTP MCP on /mcp
 syslog mcp        # query-only MCP stdio transport
 syslog stats      # query the SQLite DB directly from the CLI
+syslog compose doctor          # diagnose live Compose/systemd/listener ownership
+syslog compose status --json   # inspect canonical syslog-mcp container/project
 ```
 
 Both modes use the same config and environment variable loader. `syslog mcp` is for local child-process MCP clients that can read `SYSLOG_MCP_DB_PATH`; it does not bind network ports or run retention/storage cleanup jobs.
@@ -628,7 +632,13 @@ syslog errors --from 2026-01-01T00:00:00Z
 syslog hosts
 syslog correlate --reference-time 2026-01-01T12:00:00Z --window-minutes 10 --severity-min warning
 syslog stats --json
+syslog compose pull            # pull image for resolved Compose project
+syslog compose up              # run docker compose up -d for resolved service
+syslog compose restart         # restart resolved service
+syslog compose logs --tail 20  # bounded compose logs
 ```
+
+`syslog compose` commands resolve the live Compose owner before mutation. They refuse ambiguous cwd fallback, stale Compose labels, systemd/listener conflicts, and destructive `down` without `--yes`.
 
 See [docs/CLI.md](docs/CLI.md) for the full direct CLI reference, including flags, JSON output, and how CLI commands map to MCP actions.
 
@@ -876,6 +886,9 @@ just up        # docker compose up -d
 just logs      # docker compose logs -f
 just down      # docker compose down
 just restart   # docker compose restart
+syslog compose doctor
+syslog compose status --json
+syslog compose logs --tail 20
 ```
 
 Generate a bearer token:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -252,10 +252,12 @@ Mutation flags:
 | `--allow-cwd-target` | Permit cwd `docker-compose.yml` fallback for mutation |
 | `--yes` | Required for non-interactive destructive `down` |
 
-`syslog compose` refuses ambiguous target discovery, cwd fallback without
-confirmation, project-name-only mutations, missing Compose files, systemd owner
-conflicts, non-target listeners on syslog ports, and destructive `down` without
-`--yes`.
+`syslog compose` refuses ambiguous target discovery, mismatched requested
+project/service selectors, cwd fallback without confirmation,
+project-name-only mutations, missing Compose files, systemd owner conflicts,
+non-target listeners on syslog ports, and destructive service stop without
+`--yes`. `down` is intentionally service-scoped (`docker compose stop
+syslog-mcp`), not a project-wide `docker compose down`.
 
 ## Relationship to MCP
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,11 +1,13 @@
 # Direct CLI Reference -- syslog-mcp
 
-The `syslog` binary includes direct query commands for humans and shell scripts.
-These commands read the configured SQLite database and call the same shared
-`SyslogService` methods used by the MCP tool.
+The `syslog` binary includes direct query and deployment-lifecycle commands for
+humans and shell scripts. Query commands read the configured SQLite database and
+call the same shared `SyslogService` methods used by the MCP tool. Compose
+lifecycle commands inspect Docker/Compose directly and do not load the SQLite
+query runtime.
 
-Direct CLI mode does not start syslog listeners, the HTTP MCP server, the REST
-API, OTLP routes, retention purge, Docker ingest, or storage-budget cleanup
+Direct query CLI mode does not start syslog listeners, the HTTP MCP server, the
+REST API, OTLP routes, retention purge, Docker ingest, or storage-budget cleanup
 tasks. Keep `syslog serve mcp` running somewhere for ingestion.
 
 ## Configuration
@@ -216,6 +218,45 @@ syslog stats
 syslog stats --json
 ```
 
+### `syslog compose`
+
+Diagnose and manage the Docker Compose deployment without opening the SQLite
+database.
+
+```bash
+syslog compose doctor
+syslog compose status --json
+syslog compose pull
+syslog compose up
+syslog compose restart
+syslog compose logs --tail 20
+syslog compose down --yes
+```
+
+Common target flags:
+
+| Flag | Description |
+| --- | --- |
+| `--compose-file FILE` | Explicit Compose file |
+| `--project-dir DIR` | Explicit Compose project directory |
+| `--project-name NAME` | Compose project name, only safe with a file/dir or live labels |
+| `--service NAME` | Compose service name, default `syslog-mcp` |
+| `--container NAME` | Container name, default `syslog-mcp` |
+| `--json` | Print JSON response |
+
+Mutation flags:
+
+| Flag | Description |
+| --- | --- |
+| `--dry-run` | Resolve and preflight without running Docker |
+| `--allow-cwd-target` | Permit cwd `docker-compose.yml` fallback for mutation |
+| `--yes` | Required for non-interactive destructive `down` |
+
+`syslog compose` refuses ambiguous target discovery, cwd fallback without
+confirmation, project-name-only mutations, missing Compose files, systemd owner
+conflicts, non-target listeners on syslog ports, and destructive `down` without
+`--yes`.
+
 ## Relationship to MCP
 
 The direct CLI and MCP tool share the same business layer:
@@ -234,10 +275,12 @@ The direct CLI and MCP tool share the same business layer:
 | `syslog ai projects` | `syslog` with `action="list_ai_projects"` |
 | `syslog correlate` | `syslog` with `action="correlate"` |
 | `syslog stats` | `syslog` with `action="stats"` |
+| `syslog compose status` | `syslog` with `action="compose_status"` (redacted read-only projection only) |
+| `syslog compose doctor` | `syslog` with `action="compose_doctor"` (redacted read-only projection only) |
 
 The MCP-only `status` and `help` actions are runtime/protocol helpers, not
-direct database queries. Use `syslog action=status` through MCP for live server
-queue/backpressure state, and use `syslog --help` for direct CLI usage.
+direct database queries. Compose mutations (`up`, `down`, `restart`, `pull`,
+`logs`) are CLI-only and are not exposed over MCP.
 
 Use direct CLI mode for terminal queries and scripts on a host that can read the
 SQLite database. Use MCP HTTP or `syslog mcp` when an MCP client needs tool

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -78,6 +78,19 @@ just restart    # docker compose restart
 just logs       # docker compose logs -f
 ```
 
+The installed `syslog` binary also provides guarded lifecycle diagnostics and mutations:
+
+```bash
+syslog compose doctor
+syslog compose status --json
+syslog compose pull
+syslog compose up
+syslog compose restart
+syslog compose logs --tail 50
+```
+
+MCP exposes only redacted read-only Compose diagnostics (`compose_status`, `compose_doctor`). Lifecycle mutations remain CLI-only: ask the assistant to run `syslog compose ...` locally rather than invoking MCP actions.
+
 ### Container conventions
 
 | Concern | Pattern |

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -28,6 +28,8 @@ syslog-mcp exposes one MCP tool named `syslog`. The required `action` argument s
 - `clock_skew`
 - `anomalies`
 - `compare`
+- `compose_status`
+- `compose_doctor`
 - `help`
 
 The schema is defined in `src/mcp/schemas.rs` as a `serde_json::json!()` object returned by `tool_definitions()`.
@@ -68,6 +70,8 @@ json!({
                     "clock_skew",
                     "anomalies",
                     "compare",
+                    "compose_status",
+                    "compose_doctor",
                     "help"
                 ]
             },

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -45,7 +45,8 @@ Action registry covered by live/script references: `search`, `tail`, `errors`,
 `hosts`, `sessions`, `search_sessions`, `usage_blocks`, `project_context`,
 `list_ai_tools`, `list_ai_projects`, `correlate`, `stats`, `status`, `apps`,
 `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`,
-`silent_hosts`, `clock_skew`, `anomalies`, `compare`, `help`.
+`silent_hosts`, `clock_skew`, `anomalies`, `compare`, `compose_status`,
+`compose_doctor`, `help`.
 
 ### mcporter-based testing
 
@@ -71,6 +72,8 @@ mcporter call --config config/mcporter.json syslog.syslog action=silent_hosts
 mcporter call --config config/mcporter.json syslog.syslog action=clock_skew
 mcporter call --config config/mcporter.json syslog.syslog action=anomalies
 mcporter call --config config/mcporter.json syslog.syslog action=compare a_from=2026-01-01T00:00:00Z a_to=2026-01-01T01:00:00Z b_from=2026-01-01T01:00:00Z b_to=2026-01-01T02:00:00Z
+mcporter call --config config/mcporter.json syslog.syslog action=compose_status
+mcporter call --config config/mcporter.json syslog.syslog action=compose_doctor
 ```
 
 ### curl-based testing

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -40,6 +40,8 @@ just test-live
 ```
 
 The smoke test (`scripts/smoke-test.sh`) exercises all `syslog` actions via mcporter.
+Compose diagnostics are non-mutating and are validated only for redacted shape,
+so the smoke test can pass on either Docker-backed or non-Docker deployments.
 
 Action registry covered by live/script references: `search`, `tail`, `errors`,
 `hosts`, `sessions`, `search_sessions`, `usage_blocks`, `project_context`,

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -32,7 +32,7 @@ syslog-mcp exposes one read-only MCP tool named `syslog`. The required
 | `anomalies` | Recent vs baseline volume/error comparison |
 | `compare` | Side-by-side comparison of two time ranges |
 | `compose_status` | Redacted read-only Compose deployment diagnostics |
-| `compose_doctor` | Alias for Compose deployment health diagnostics |
+| `compose_doctor` | Strict Compose deployment health diagnostics |
 | `help` | Markdown reference for all actions |
 
 ## syslog search
@@ -145,7 +145,7 @@ Target override arguments such as `project_dir`, `compose_file`, `project_name`,
 
 ## syslog compose_doctor
 
-Alias of `compose_status` for deployment health checks. Compose lifecycle mutations are CLI-only.
+Run strict deployment-health checks for the canonical syslog-mcp Compose deployment. It returns the same redacted diagnostic shape as `compose_status` when healthy, and returns a tool error when Docker/Compose ownership or runtime checks are not ready for lifecycle work. Compose lifecycle mutations are CLI-only.
 
 Required argument: `action = "compose_doctor"`
 

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -31,6 +31,8 @@ syslog-mcp exposes one read-only MCP tool named `syslog`. The required
 | `clock_skew` | Per-host received_at minus timestamp distribution |
 | `anomalies` | Recent vs baseline volume/error comparison |
 | `compare` | Side-by-side comparison of two time ranges |
+| `compose_status` | Redacted read-only Compose deployment diagnostics |
+| `compose_doctor` | Alias for Compose deployment health diagnostics |
 | `help` | Markdown reference for all actions |
 
 ## syslog search
@@ -132,6 +134,20 @@ Required argument: `action = "stats"`
 Get lightweight runtime status without the full DB statistics query.
 
 Required argument: `action = "status"`
+
+## syslog compose_status
+
+Get redacted read-only Docker Compose diagnostics for the canonical syslog-mcp deployment. MCP output omits host paths, mount sources, image ids, and raw command output.
+
+Required argument: `action = "compose_status"`
+
+Target override arguments such as `project_dir`, `compose_file`, `project_name`, `container`, and `container_name` are rejected.
+
+## syslog compose_doctor
+
+Alias of `compose_status` for deployment health checks. Compose lifecycle mutations are CLI-only.
+
+Required argument: `action = "compose_doctor"`
 
 ## syslog help
 

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -6,37 +6,38 @@
 # 1. Pull latest code
 git pull origin main
 
-# 2. Build new image
-docker compose build
+# 2. Diagnose the current owner before mutation
+syslog compose doctor
 
 # 3. Run smoke test against current running instance (optional)
 bash scripts/smoke-test.sh
 
-# 4. Rolling restart — new container replaces old
-docker compose up -d
+# 4. Pull/build as needed, then start the resolved Compose service
+syslog compose pull
+syslog compose up
 
 # 5. Wait for health check to pass (30s interval, 3 retries)
-docker compose ps   # should show "healthy"
+syslog compose status   # should show healthy Compose ownership
 # or:
 curl -sf http://localhost:3100/health
 
 # 6. Verify logs are flowing
-docker compose logs -f --tail=20 syslog-mcp
+syslog compose logs --tail 20
 ```
 
 ## Rollback
 
 ```bash
 # Option 1: Revert to previous image (if tagged)
-docker compose down
+syslog compose down --yes
 git checkout <previous-tag>
-docker compose build
-docker compose up -d
+syslog compose pull
+syslog compose up
 
 # Option 2: Revert to previous commit
 git log --oneline -5   # find the good commit
 git revert HEAD         # or git reset --hard <sha>
-docker compose build && docker compose up -d
+syslog compose pull && syslog compose up
 ```
 
 ## Health Check

--- a/plugins/skills/syslog/SKILL.md
+++ b/plugins/skills/syslog/SKILL.md
@@ -37,6 +37,8 @@ A single MCP tool, `mcp__syslog__syslog`, dispatches on a required `action` argu
 | `clock_skew` | Per-host clock skew distribution |
 | `anomalies` | Recent vs baseline volume/error comparison |
 | `compare` | Compare two time ranges |
+| `compose_status` | Redacted read-only Compose deployment diagnostics |
+| `compose_doctor` | Alias for Compose deployment health diagnostics |
 | `help` | Canonical in-tree action reference (use as ground truth if this doc drifts) |
 
 **Always prefer the MCP tool**. Fall back to HTTP only when MCP is unavailable.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -9,7 +9,7 @@
 #
 # Requirements: mcporter, nc, curl, python3
 #
-# Action inventory reference (not every action is exercised by this smoke test):
+# Action inventory reference:
 #   mcp_call search, mcp_call tail, mcp_call errors, mcp_call hosts,
 #   mcp_call sessions, mcp_call search_sessions, mcp_call usage_blocks,
 #   mcp_call project_context, mcp_call list_ai_tools, mcp_call list_ai_projects,
@@ -569,6 +569,36 @@ fi
 # Missing required arg must return an error
 CORRELATE_NO_REF=$(mcp_call correlate 2>&1 || true)
 assert_is_error "correlate(missing reference_time): returns error" "$CORRELATE_NO_REF"
+
+# ── compose diagnostics ───────────────────────────────────────────────────────
+echo ""
+echo "Action: compose_status"
+COMPOSE_STATUS=$(mcp_call compose_status 2>&1)
+assert_no_error "compose_status: no error" "$COMPOSE_STATUS"
+COMPOSE_STATUS_VALID=$(echo "$COMPOSE_STATUS" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for key in ('container_name', 'ownership', 'runtime_state', 'published_ports', 'diagnostics'):
+    assert key in d, f'{key} missing'
+text = json.dumps(d)
+assert 'compose_working_dir' not in text, 'host working dir leaked'
+assert 'image_id' not in text, 'image id leaked'
+print('ok')
+" 2>/dev/null || echo "error")
+assert_eq "compose_status: redacted response structure valid" "$COMPOSE_STATUS_VALID" "ok"
+
+echo ""
+echo "Action: compose_doctor"
+COMPOSE_DOCTOR=$(mcp_call compose_doctor 2>&1)
+assert_no_error "compose_doctor: no error" "$COMPOSE_DOCTOR"
+COMPOSE_DOCTOR_VALID=$(echo "$COMPOSE_DOCTOR" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for key in ('container_name', 'ownership', 'runtime_state'):
+    assert key in d, f'{key} missing'
+print('ok')
+" 2>/dev/null || echo "error")
+assert_eq "compose_doctor: response structure valid" "$COMPOSE_DOCTOR_VALID" "ok"
 
 # ── help ──────────────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -16,7 +16,6 @@
 #   mcp_call correlate, mcp_call stats, mcp_call status, mcp_call apps,
 #   mcp_call source_ips, mcp_call timeline, mcp_call patterns, mcp_call context,
 #   mcp_call get, mcp_call ingest_rate, mcp_call silent_hosts,
-
 #   mcp_call clock_skew, mcp_call anomalies, mcp_call compare,
 #   mcp_call compose_status, mcp_call compose_doctor, mcp_call help
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -583,9 +583,13 @@ for key in ('container_name', 'ownership', 'runtime_state', 'published_ports', '
 text = json.dumps(d)
 assert 'compose_working_dir' not in text, 'host working dir leaked'
 assert 'image_id' not in text, 'image id leaked'
+assert d['runtime_state'] != 'docker_unavailable', 'docker unavailable'
+assert d['ownership'] != 'unknown', 'ownership unknown'
+for diag in d.get('diagnostics') or []:
+    assert diag.get('severity') not in ('error', 'unsafe'), f'unsafe diagnostic: {diag}'
 print('ok')
 " 2>/dev/null || echo "error")
-assert_eq "compose_status: redacted response structure valid" "$COMPOSE_STATUS_VALID" "ok"
+assert_eq "compose_status: redacted safe response valid" "$COMPOSE_STATUS_VALID" "ok"
 
 echo ""
 echo "Action: compose_doctor"
@@ -596,9 +600,13 @@ import sys, json
 d = json.load(sys.stdin)
 for key in ('container_name', 'ownership', 'runtime_state'):
     assert key in d, f'{key} missing'
+assert d['runtime_state'] != 'docker_unavailable', 'docker unavailable'
+assert d['ownership'] == 'compose_owned', f'unexpected ownership: {d.get(\"ownership\")}'
+for diag in d.get('diagnostics') or []:
+    assert diag.get('severity') not in ('error', 'unsafe'), f'unsafe diagnostic: {diag}'
 print('ok')
 " 2>/dev/null || echo "error")
-assert_eq "compose_doctor: response structure valid" "$COMPOSE_DOCTOR_VALID" "ok"
+assert_eq "compose_doctor: safe response valid" "$COMPOSE_DOCTOR_VALID" "ok"
 
 # ── help ──────────────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -17,7 +17,8 @@
 #   mcp_call source_ips, mcp_call timeline, mcp_call patterns, mcp_call context,
 #   mcp_call get, mcp_call ingest_rate, mcp_call silent_hosts,
 
-#   mcp_call clock_skew, mcp_call anomalies, mcp_call compare, mcp_call help
+#   mcp_call clock_skew, mcp_call anomalies, mcp_call compare,
+#   mcp_call compose_status, mcp_call compose_doctor, mcp_call help
 
 set -euo pipefail
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -582,10 +582,6 @@ for key in ('container_name', 'ownership', 'runtime_state', 'published_ports', '
 text = json.dumps(d)
 assert 'compose_working_dir' not in text, 'host working dir leaked'
 assert 'image_id' not in text, 'image id leaked'
-assert d['runtime_state'] != 'docker_unavailable', 'docker unavailable'
-assert d['ownership'] != 'unknown', 'ownership unknown'
-for diag in d.get('diagnostics') or []:
-    assert diag.get('severity') not in ('error', 'unsafe'), f'unsafe diagnostic: {diag}'
 print('ok')
 " 2>/dev/null || echo "error")
 assert_eq "compose_status: redacted safe response valid" "$COMPOSE_STATUS_VALID" "ok"
@@ -599,10 +595,6 @@ import sys, json
 d = json.load(sys.stdin)
 for key in ('container_name', 'ownership', 'runtime_state'):
     assert key in d, f'{key} missing'
-assert d['runtime_state'] != 'docker_unavailable', 'docker unavailable'
-assert d['ownership'] == 'compose_owned', f'unexpected ownership: {d.get(\"ownership\")}'
-for diag in d.get('diagnostics') or []:
-    assert diag.get('severity') not in ('error', 'unsafe'), f'unsafe diagnostic: {diag}'
 print('ok')
 " 2>/dev/null || echo "error")
 assert_eq "compose_doctor: safe response valid" "$COMPOSE_DOCTOR_VALID" "ok"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -53,6 +53,7 @@ done
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 PASS=0
 FAIL=0
+SKIP=0
 ERRORS=()
 
 COLOR_GREEN='\033[0;32m'
@@ -62,6 +63,7 @@ COLOR_BOLD='\033[1m'
 
 pass() { echo -e "${COLOR_GREEN}PASS${COLOR_RESET}  $1"; (( PASS++ )) || true; }
 fail() { echo -e "${COLOR_RED}FAIL${COLOR_RESET}  $1"; ERRORS+=("$1"); (( FAIL++ )) || true; }
+skip() { echo "SKIP  $1"; (( SKIP++ )) || true; }
 
 mcp_call() {
     local action="$1"; shift
@@ -585,19 +587,28 @@ assert 'image_id' not in text, 'image id leaked'
 print('ok')
 " 2>/dev/null || echo "error")
 assert_eq "compose_status: redacted safe response valid" "$COMPOSE_STATUS_VALID" "ok"
+COMPOSE_STATUS_DOCTORABLE=$(echo "$COMPOSE_STATUS" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print('yes' if d.get('runtime_state') != 'docker_unavailable' and d.get('ownership') == 'compose_owned' else 'no')
+" 2>/dev/null || echo "no")
 
 echo ""
 echo "Action: compose_doctor"
-COMPOSE_DOCTOR=$(mcp_call compose_doctor 2>&1)
-assert_no_error "compose_doctor: no error" "$COMPOSE_DOCTOR"
-COMPOSE_DOCTOR_VALID=$(echo "$COMPOSE_DOCTOR" | python3 -c "
+if [[ "$COMPOSE_STATUS_DOCTORABLE" == "yes" ]]; then
+    COMPOSE_DOCTOR=$(mcp_call compose_doctor 2>&1)
+    assert_no_error "compose_doctor: no error" "$COMPOSE_DOCTOR"
+    COMPOSE_DOCTOR_VALID=$(echo "$COMPOSE_DOCTOR" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 for key in ('container_name', 'ownership', 'runtime_state'):
     assert key in d, f'{key} missing'
 print('ok')
 " 2>/dev/null || echo "error")
-assert_eq "compose_doctor: safe response valid" "$COMPOSE_DOCTOR_VALID" "ok"
+    assert_eq "compose_doctor: safe response valid" "$COMPOSE_DOCTOR_VALID" "ok"
+else
+    skip "compose_doctor: deployment is not doctorable from compose_status"
+fi
 
 # ── help ──────────────────────────────────────────────────────────────────────
 echo ""
@@ -650,6 +661,7 @@ echo "────────────────────────�
 TOTAL=$((PASS + FAIL))
 echo -e "  Passed:  ${COLOR_GREEN}${PASS}${COLOR_RESET} / ${TOTAL}"
 echo -e "  Failed:  ${COLOR_RED}${FAIL}${COLOR_RESET} / ${TOTAL}"
+echo "  Skipped: ${SKIP}"
 
 if [[ ${#ERRORS[@]} -gt 0 ]]; then
     echo ""

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -776,9 +776,7 @@ fn parse_compose_mutation(args: &[String], destructive: bool) -> Result<ComposeM
             "--allow-cwd-target" => parsed.options.allow_cwd_target = true,
             "--yes" => parsed.options.yes = true,
             _ if is_compose_common_arg(&arg) => {
-                if !arg.contains('=') && needs_value(&arg) {
-                    let _ = flags.value(&arg)?;
-                }
+                consume_compose_common_value(&mut flags, &arg)?;
             }
             _ if arg.starts_with("--") => bail!("unknown compose option: {arg}"),
             _ => bail!("unexpected compose argument: {arg}"),
@@ -803,9 +801,7 @@ fn parse_compose_logs(args: &[String]) -> Result<ComposeLogsArgs> {
             }
             "--follow" => bail!("syslog compose logs --follow is deferred"),
             _ if is_compose_common_arg(&arg) => {
-                if !arg.contains('=') && needs_value(&arg) {
-                    let _ = flags.value(&arg)?;
-                }
+                consume_compose_common_value(&mut flags, &arg)?;
             }
             _ if arg.starts_with("--") => bail!("unknown compose logs option: {arg}"),
             _ => bail!("unexpected compose logs argument: {arg}"),
@@ -856,9 +852,7 @@ fn reject_unknown_compose_args(command: &str, args: &[String], extra: &[&str]) -
             continue;
         }
         if is_compose_common_arg(&arg) {
-            if !arg.contains('=') && needs_value(&arg) {
-                let _ = flags.value(&arg)?;
-            }
+            consume_compose_common_value(&mut flags, &arg)?;
             continue;
         }
         if arg.starts_with("--") {
@@ -890,6 +884,13 @@ fn needs_value(arg: &str) -> bool {
         arg,
         "--compose-file" | "--project-dir" | "--project-name" | "--service" | "--container"
     )
+}
+
+fn consume_compose_common_value(flags: &mut FlagCursor<'_>, arg: &str) -> Result<()> {
+    if !arg.contains('=') && needs_value(arg) {
+        let _ = flags.value(arg)?;
+    }
+    Ok(())
 }
 
 fn parse_correlate(args: &[String]) -> Result<CliCommand> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -359,9 +359,14 @@ pub(crate) fn run_compose(command: CliCommand) -> Result<()> {
     };
     let service = ComposeService::new(CliDockerInspect, ProcessRunner, ComposeDefaults::default());
     match command {
-        ComposeCommand::Status(args) | ComposeCommand::Doctor(args) => {
+        ComposeCommand::Status(args) => {
             let status = service.status(&args.target)?;
             print_compose_status_response(&status, args.json)
+        }
+        ComposeCommand::Doctor(args) => {
+            let status = service.status(&args.target)?;
+            print_compose_status_response(&status, args.json)?;
+            ensure_compose_doctor_success(&status)
         }
         ComposeCommand::Up(args) => print_compose_command_response(
             &service.run_mutation(ComposeMutation::Up, &args.target, &args.options)?,
@@ -1283,20 +1288,52 @@ fn print_compose_status_response(status: &ComposeStatus, json: bool) -> Result<(
 }
 
 fn print_compose_command_response(output: &Option<CommandOutput>, json: bool) -> Result<()> {
-    if json {
-        return print_json(output);
-    }
     match output {
         Some(output) => {
-            print!("{}", output.stdout);
-            eprint!("{}", output.stderr);
+            if json {
+                print_json(output)?;
+            } else {
+                print!("{}", output.stdout);
+                eprint!("{}", output.stderr);
+            }
             ensure_command_success(output)
         }
         None => {
-            println!("Dry run passed");
+            if json {
+                print_json(output)?;
+            } else {
+                println!("Dry run passed");
+            }
             Ok(())
         }
     }
+}
+
+fn ensure_compose_doctor_success(status: &ComposeStatus) -> Result<()> {
+    let unsafe_diagnostics = status.diagnostics.iter().any(|diagnostic| {
+        matches!(
+            diagnostic.severity,
+            syslog_mcp::compose::DiagnosticSeverity::Error
+                | syslog_mcp::compose::DiagnosticSeverity::Unsafe
+        )
+    });
+    let projected = syslog_mcp::compose::mcp_projection(status);
+    if unsafe_diagnostics
+        || projected.ownership != syslog_mcp::compose::ComposeOwnershipState::ComposeOwned
+        || matches!(
+            projected.runtime_state,
+            syslog_mcp::compose::ComposeRuntimeState::DockerUnavailable
+                | syslog_mcp::compose::ComposeRuntimeState::Unknown
+        )
+    {
+        bail!(
+            "compose doctor failed: ownership={:?} runtime_state={:?} diagnostics={:?}",
+            projected.ownership,
+            projected.runtime_state,
+            status.diagnostics
+        );
+    }
+    Ok(())
 }
 
 fn ensure_command_success(output: &CommandOutput) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -769,7 +769,6 @@ fn parse_compose_mutation(args: &[String], destructive: bool) -> Result<ComposeM
         match arg.as_str() {
             "--dry-run" => parsed.options.dry_run = true,
             "--allow-cwd-target" => parsed.options.allow_cwd_target = true,
-            "--allow-foreign-project" => parsed.options.allow_foreign_project = true,
             "--yes" => parsed.options.yes = true,
             _ if is_compose_common_arg(&arg) => {
                 if !arg.contains('=') && needs_value(&arg) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,8 +8,8 @@ use syslog_mcp::app::{
     TailLogsRequest, UsageBlocksRequest, UsageBlocksResponse,
 };
 use syslog_mcp::compose::{
-    CliDockerInspect, CommandOutput, ComposeDefaults, ComposeMutation, ComposeService,
-    ComposeStatus, ComposeTarget, MutationOptions, ProcessRunner,
+    CliDockerInspect, CommandOutput, ComposeCommandResult, ComposeDefaults, ComposeMutation,
+    ComposeService, ComposeStatus, ComposeTarget, MutationOptions, ProcessRunner,
 };
 use syslog_mcp::scanner::IndexResult;
 
@@ -366,7 +366,7 @@ pub(crate) fn run_compose(command: CliCommand) -> Result<()> {
         ComposeCommand::Doctor(args) => {
             let status = service.status(&args.target)?;
             print_compose_status_response(&status, args.json)?;
-            ensure_compose_doctor_success(&status)
+            syslog_mcp::compose::ensure_doctor_ready(&status)
         }
         ComposeCommand::Up(args) => print_compose_command_response(
             &service.run_mutation(ComposeMutation::Up, &args.target, &args.options)?,
@@ -1288,9 +1288,9 @@ fn print_compose_status_response(status: &ComposeStatus, json: bool) -> Result<(
     Ok(())
 }
 
-fn print_compose_command_response(output: &Option<CommandOutput>, json: bool) -> Result<()> {
-    match output {
-        Some(output) => {
+fn print_compose_command_response(result: &ComposeCommandResult, json: bool) -> Result<()> {
+    match result {
+        ComposeCommandResult::Executed(output) => {
             if json {
                 print_json(output)?;
             } else {
@@ -1299,42 +1299,15 @@ fn print_compose_command_response(output: &Option<CommandOutput>, json: bool) ->
             }
             ensure_command_success(output)
         }
-        None => {
+        ComposeCommandResult::DryRun(dry_run) => {
             if json {
-                print_json(output)?;
+                print_json(dry_run)?;
             } else {
-                println!("Dry run passed");
+                println!("Dry run passed: {}", dry_run.command.join(" "));
             }
             Ok(())
         }
     }
-}
-
-fn ensure_compose_doctor_success(status: &ComposeStatus) -> Result<()> {
-    let unsafe_diagnostics = status.diagnostics.iter().any(|diagnostic| {
-        matches!(
-            diagnostic.severity,
-            syslog_mcp::compose::DiagnosticSeverity::Error
-                | syslog_mcp::compose::DiagnosticSeverity::Unsafe
-        )
-    });
-    let projected = syslog_mcp::compose::mcp_projection(status);
-    if unsafe_diagnostics
-        || projected.ownership != syslog_mcp::compose::ComposeOwnershipState::ComposeOwned
-        || matches!(
-            projected.runtime_state,
-            syslog_mcp::compose::ComposeRuntimeState::DockerUnavailable
-                | syslog_mcp::compose::ComposeRuntimeState::Unknown
-        )
-    {
-        bail!(
-            "compose doctor failed: ownership={:?} runtime_state={:?} diagnostics={:?}",
-            projected.ownership,
-            projected.runtime_state,
-            status.diagnostics
-        );
-    }
-    Ok(())
 }
 
 fn ensure_command_success(output: &CommandOutput) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,10 @@ use syslog_mcp::app::{
     SearchLogsResponse, SearchSessionsRequest, SearchSessionsResponse, SyslogService,
     TailLogsRequest, UsageBlocksRequest, UsageBlocksResponse,
 };
+use syslog_mcp::compose::{
+    CliDockerInspect, CommandOutput, ComposeDefaults, ComposeMutation, ComposeService,
+    ComposeStatus, ComposeTarget, MutationOptions, ProcessRunner,
+};
 use syslog_mcp::scanner::IndexResult;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,6 +23,7 @@ pub(crate) enum CliCommand {
     Ai(AiCommand),
     Correlate(CorrelateArgs),
     Stats(OutputArgs),
+    Compose(ComposeCommand),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,8 +37,39 @@ pub(crate) enum AiCommand {
     Add(AiAddArgs),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ComposeCommand {
+    Status(ComposeArgs),
+    Doctor(ComposeArgs),
+    Up(ComposeMutationArgs),
+    Down(ComposeMutationArgs),
+    Restart(ComposeMutationArgs),
+    Pull(ComposeMutationArgs),
+    Logs(ComposeLogsArgs),
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct OutputArgs {
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ComposeArgs {
+    pub target: ComposeTarget,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ComposeMutationArgs {
+    pub target: ComposeTarget,
+    pub options: MutationOptions,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ComposeLogsArgs {
+    pub target: ComposeTarget,
+    pub tail: Option<u32>,
     pub json: bool,
 }
 
@@ -152,6 +188,7 @@ impl CliCommand {
             "ai" => parse_ai(rest),
             "correlate" => parse_correlate(rest),
             "stats" => parse_stats(rest),
+            "compose" => parse_compose(rest),
             _ => bail!("unknown CLI command: {command}"),
         }
     }
@@ -309,8 +346,50 @@ pub(crate) async fn run(service: SyslogService, command: CliCommand) -> Result<(
             let response = service.get_stats().await?;
             print_stats_response(&response, args.json)?;
         }
+        CliCommand::Compose(_) => {
+            bail!("compose commands must run through run_compose");
+        }
     }
     Ok(())
+}
+
+pub(crate) fn run_compose(command: CliCommand) -> Result<()> {
+    let CliCommand::Compose(command) = command else {
+        bail!("run_compose called with non-compose command");
+    };
+    let service = ComposeService::new(CliDockerInspect, ProcessRunner, ComposeDefaults::default());
+    match command {
+        ComposeCommand::Status(args) | ComposeCommand::Doctor(args) => {
+            let status = service.status(&args.target)?;
+            print_compose_status_response(&status, args.json)
+        }
+        ComposeCommand::Up(args) => print_compose_command_response(
+            &service.run_mutation(ComposeMutation::Up, &args.target, &args.options)?,
+            args.json,
+        ),
+        ComposeCommand::Down(args) => print_compose_command_response(
+            &service.run_mutation(ComposeMutation::Down, &args.target, &args.options)?,
+            args.json,
+        ),
+        ComposeCommand::Restart(args) => print_compose_command_response(
+            &service.run_mutation(ComposeMutation::Restart, &args.target, &args.options)?,
+            args.json,
+        ),
+        ComposeCommand::Pull(args) => print_compose_command_response(
+            &service.run_mutation(ComposeMutation::Pull, &args.target, &args.options)?,
+            args.json,
+        ),
+        ComposeCommand::Logs(args) => {
+            let output = service.logs(&args.target, args.tail)?;
+            if args.json {
+                print_json(&output)?;
+            } else {
+                print!("{}", output.stdout);
+                eprint!("{}", output.stderr);
+            }
+            ensure_command_success(&output)
+        }
+    }
 }
 
 fn parse_search(args: &[String]) -> Result<CliCommand> {
@@ -639,6 +718,174 @@ fn parse_ai_add(args: &[String]) -> Result<CliCommand> {
 
 fn parse_stats(args: &[String]) -> Result<CliCommand> {
     Ok(CliCommand::Stats(parse_output_args("stats", args)?))
+}
+
+fn parse_compose(args: &[String]) -> Result<CliCommand> {
+    let (subcommand, rest) = args
+        .split_first()
+        .ok_or_else(|| anyhow!("compose requires a subcommand"))?;
+    match subcommand.as_str() {
+        "status" => Ok(CliCommand::Compose(ComposeCommand::Status(
+            parse_compose_args(rest)?,
+        ))),
+        "doctor" => Ok(CliCommand::Compose(ComposeCommand::Doctor(
+            parse_compose_args(rest)?,
+        ))),
+        "up" => Ok(CliCommand::Compose(ComposeCommand::Up(
+            parse_compose_mutation(rest, false)?,
+        ))),
+        "down" => Ok(CliCommand::Compose(ComposeCommand::Down(
+            parse_compose_mutation(rest, true)?,
+        ))),
+        "restart" => Ok(CliCommand::Compose(ComposeCommand::Restart(
+            parse_compose_mutation(rest, false)?,
+        ))),
+        "pull" => Ok(CliCommand::Compose(ComposeCommand::Pull(
+            parse_compose_mutation(rest, false)?,
+        ))),
+        "logs" => Ok(CliCommand::Compose(ComposeCommand::Logs(
+            parse_compose_logs(rest)?,
+        ))),
+        "config" => bail!("syslog compose config is deferred from the first pass"),
+        "upgrade" => bail!(
+            "syslog compose upgrade is deferred; run `syslog compose pull` then `syslog compose up`"
+        ),
+        other => bail!("unknown compose subcommand: {other}"),
+    }
+}
+
+fn parse_compose_args(args: &[String]) -> Result<ComposeArgs> {
+    let mut parsed = ComposeArgs::default();
+    parse_compose_common(args, &mut parsed.target, &mut parsed.json)?;
+    reject_unknown_compose_args("compose", args, &[])?;
+    Ok(parsed)
+}
+
+fn parse_compose_mutation(args: &[String], destructive: bool) -> Result<ComposeMutationArgs> {
+    let mut parsed = ComposeMutationArgs::default();
+    parse_compose_common(args, &mut parsed.target, &mut parsed.json)?;
+    let mut flags = FlagCursor::new(args);
+    while let Some(arg) = flags.next() {
+        match arg.as_str() {
+            "--dry-run" => parsed.options.dry_run = true,
+            "--allow-cwd-target" => parsed.options.allow_cwd_target = true,
+            "--allow-foreign-project" => parsed.options.allow_foreign_project = true,
+            "--yes" => parsed.options.yes = true,
+            _ if is_compose_common_arg(&arg) => {
+                if !arg.contains('=') && needs_value(&arg) {
+                    let _ = flags.value(&arg)?;
+                }
+            }
+            _ if arg.starts_with("--") => bail!("unknown compose option: {arg}"),
+            _ => bail!("unexpected compose argument: {arg}"),
+        }
+    }
+    parsed.options.non_interactive = destructive;
+    Ok(parsed)
+}
+
+fn parse_compose_logs(args: &[String]) -> Result<ComposeLogsArgs> {
+    let mut parsed = ComposeLogsArgs::default();
+    parse_compose_common(args, &mut parsed.target, &mut parsed.json)?;
+    let mut flags = FlagCursor::new(args);
+    while let Some(arg) = flags.next() {
+        match arg.as_str() {
+            "--tail" => parsed.tail = Some(parse_u32_flag("--tail", flags.value("--tail")?)?),
+            _ if arg.starts_with("--tail=") => {
+                parsed.tail = Some(parse_u32_flag(
+                    "--tail",
+                    value_after_equals(arg, "--tail")?,
+                )?)
+            }
+            "--follow" => bail!("syslog compose logs --follow is deferred"),
+            _ if is_compose_common_arg(&arg) => {
+                if !arg.contains('=') && needs_value(&arg) {
+                    let _ = flags.value(&arg)?;
+                }
+            }
+            _ if arg.starts_with("--") => bail!("unknown compose logs option: {arg}"),
+            _ => bail!("unexpected compose logs argument: {arg}"),
+        }
+    }
+    Ok(parsed)
+}
+
+fn parse_compose_common(
+    args: &[String],
+    target: &mut ComposeTarget,
+    json: &mut bool,
+) -> Result<()> {
+    let mut flags = FlagCursor::new(args);
+    while let Some(arg) = flags.next() {
+        match arg.as_str() {
+            "--json" => *json = true,
+            "--compose-file" => target.compose_file = Some(flags.value("--compose-file")?.into()),
+            "--project-dir" => target.project_dir = Some(flags.value("--project-dir")?.into()),
+            "--project-name" => target.project_name = Some(flags.value("--project-name")?),
+            "--service" => target.service = Some(flags.value("--service")?),
+            "--container" => target.container_name = Some(flags.value("--container")?),
+            _ if arg.starts_with("--compose-file=") => {
+                target.compose_file = Some(value_after_equals(arg, "--compose-file")?.into())
+            }
+            _ if arg.starts_with("--project-dir=") => {
+                target.project_dir = Some(value_after_equals(arg, "--project-dir")?.into())
+            }
+            _ if arg.starts_with("--project-name=") => {
+                target.project_name = Some(value_after_equals(arg, "--project-name")?)
+            }
+            _ if arg.starts_with("--service=") => {
+                target.service = Some(value_after_equals(arg, "--service")?)
+            }
+            _ if arg.starts_with("--container=") => {
+                target.container_name = Some(value_after_equals(arg, "--container")?)
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn reject_unknown_compose_args(command: &str, args: &[String], extra: &[&str]) -> Result<()> {
+    let mut flags = FlagCursor::new(args);
+    while let Some(arg) = flags.next() {
+        if extra.contains(&arg.as_str()) {
+            continue;
+        }
+        if is_compose_common_arg(&arg) {
+            if !arg.contains('=') && needs_value(&arg) {
+                let _ = flags.value(&arg)?;
+            }
+            continue;
+        }
+        if arg.starts_with("--") {
+            bail!("unknown {command} option: {arg}");
+        }
+        bail!("unexpected {command} argument: {arg}");
+    }
+    Ok(())
+}
+
+fn is_compose_common_arg(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--json"
+            | "--compose-file"
+            | "--project-dir"
+            | "--project-name"
+            | "--service"
+            | "--container"
+    ) || arg.starts_with("--compose-file=")
+        || arg.starts_with("--project-dir=")
+        || arg.starts_with("--project-name=")
+        || arg.starts_with("--service=")
+        || arg.starts_with("--container=")
+}
+
+fn needs_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--compose-file" | "--project-dir" | "--project-name" | "--service" | "--container"
+    )
 }
 
 fn parse_correlate(args: &[String]) -> Result<CliCommand> {
@@ -1008,6 +1255,61 @@ fn print_stats_response(stats: &DbStats, json: bool) -> Result<()> {
     println!("write_blocked: {}", stats.write_blocked);
     println!("phantom_fts_rows: {}", stats.phantom_fts_rows);
     Ok(())
+}
+
+fn print_compose_status_response(status: &ComposeStatus, json: bool) -> Result<()> {
+    if json {
+        return print_json(status);
+    }
+    println!("Container: {}", status.container_name);
+    if let Some(value) = &status.status {
+        println!("Status: {value}");
+    }
+    if let Some(value) = &status.health {
+        println!("Docker health: {value}");
+    }
+    if let Some(value) = &status.image {
+        println!("Image: {value}");
+    }
+    if let Some(value) = &status.compose_project {
+        println!("Compose project: {value}");
+    }
+    if let Some(value) = &status.compose_working_dir {
+        println!("Compose working dir: {}", value.display());
+    }
+    for diag in &status.diagnostics {
+        println!("{:?}: {} - {}", diag.severity, diag.code, diag.message);
+    }
+    Ok(())
+}
+
+fn print_compose_command_response(output: &Option<CommandOutput>, json: bool) -> Result<()> {
+    if json {
+        return print_json(output);
+    }
+    match output {
+        Some(output) => {
+            print!("{}", output.stdout);
+            eprint!("{}", output.stderr);
+            ensure_command_success(output)
+        }
+        None => {
+            println!("Dry run passed");
+            Ok(())
+        }
+    }
+}
+
+fn ensure_command_success(output: &CommandOutput) -> Result<()> {
+    if output.exit_status == Some(0) && !output.timed_out {
+        return Ok(());
+    }
+    bail!(
+        "compose command failed: status={:?} timed_out={} stderr={}",
+        output.exit_status,
+        output.timed_out,
+        output.stderr
+    )
 }
 
 #[cfg(test)]

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -142,3 +142,52 @@ fn parse_search_help_points_to_top_level_usage() {
 
     assert!(err.to_string().contains("syslog --help"));
 }
+
+#[test]
+fn parse_compose_status_collects_target() {
+    let parsed = CliCommand::parse(strings(&[
+        "compose",
+        "status",
+        "--compose-file",
+        "/tmp/docker-compose.yml",
+        "--project-name=syslog",
+        "--json",
+    ]))
+    .unwrap();
+    match parsed {
+        CliCommand::Compose(ComposeCommand::Status(args)) => {
+            assert_eq!(
+                args.target.compose_file.unwrap(),
+                std::path::PathBuf::from("/tmp/docker-compose.yml")
+            );
+            assert_eq!(args.target.project_name.as_deref(), Some("syslog"));
+            assert!(args.json);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn parse_compose_upgrade_is_deferred() {
+    let err = CliCommand::parse(strings(&["compose", "upgrade"])).unwrap_err();
+    assert!(err.to_string().contains("deferred"));
+}
+
+#[test]
+fn parse_compose_logs_follow_is_deferred() {
+    let err = CliCommand::parse(strings(&["compose", "logs", "--follow"])).unwrap_err();
+    assert!(err.to_string().contains("deferred"));
+}
+
+#[test]
+fn parse_compose_down_collects_yes_and_dry_run() {
+    let parsed = CliCommand::parse(strings(&["compose", "down", "--yes", "--dry-run"])).unwrap();
+    match parsed {
+        CliCommand::Compose(ComposeCommand::Down(args)) => {
+            assert!(args.options.yes);
+            assert!(args.options.dry_run);
+            assert!(args.options.non_interactive);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -265,62 +265,67 @@ impl<I, R> ComposeService<I, R> {
         target: &ResolvedComposeTarget,
         mutation: ComposeMutation,
     ) -> ComposeInvocation {
-        let mut args = Vec::new();
-        if let Some(project_dir) = &target.compose_working_dir {
-            args.push("--project-directory".into());
-            args.push(project_dir.display().to_string());
-        }
-        for file in &target.compose_files {
-            args.push("-f".into());
-            args.push(file.display().to_string());
-        }
-        if let Some(project_name) = &target.compose_project {
-            args.push("--project-name".into());
-            args.push(project_name.clone());
-        }
-        match mutation {
-            ComposeMutation::Up => {
-                args.push("up".into());
-                args.push("-d".into());
-                args.push(target.target.service.clone());
-            }
-            ComposeMutation::Restart => {
-                args.push("restart".into());
-                args.push(target.target.service.clone());
-            }
-            ComposeMutation::Pull => {
-                args.push("pull".into());
-                args.push(target.target.service.clone());
-            }
-            ComposeMutation::Down => {
-                args.push("stop".into());
-                args.push(target.target.service.clone());
-            }
-        }
+        let mut args = compose_base_args(target);
+        args.extend(compose_mutation_args(mutation, &target.target.service));
+        self.invocation(target, args)
+    }
+
+    fn logs_invocation(&self, target: &ResolvedComposeTarget, tail: u32) -> ComposeInvocation {
+        let mut args = compose_base_args(target);
+        args.push("logs".into());
+        args.push("--tail".into());
+        args.push(tail.to_string());
+        args.push(target.target.service.clone());
+        self.invocation(target, args)
+    }
+
+    fn invocation(&self, target: &ResolvedComposeTarget, args: Vec<String>) -> ComposeInvocation {
         ComposeInvocation {
             program: "docker".into(),
-            args: {
-                let mut all = vec!["compose".into()];
-                all.extend(args);
-                all
-            },
+            args,
             current_dir: target.compose_working_dir.clone(),
             timeout: self.defaults.timeout,
             output_limit_bytes: self.defaults.output_limit_bytes,
         }
     }
+}
 
-    fn logs_invocation(&self, target: &ResolvedComposeTarget, tail: u32) -> ComposeInvocation {
-        let mut invocation = self.compose_invocation(target, ComposeMutation::Pull);
-        invocation
-            .args
-            .truncate(invocation.args.len().saturating_sub(2));
-        invocation.args.push("logs".into());
-        invocation.args.push("--tail".into());
-        invocation.args.push(tail.to_string());
-        invocation.args.push(target.target.service.clone());
-        invocation
+fn compose_base_args(target: &ResolvedComposeTarget) -> Vec<String> {
+    let mut args = vec!["compose".into()];
+    if let Some(project_dir) = &target.compose_working_dir {
+        args.push("--project-directory".into());
+        args.push(project_dir.display().to_string());
     }
+    for file in &target.compose_files {
+        args.push("-f".into());
+        args.push(file.display().to_string());
+    }
+    if let Some(project_name) = &target.compose_project {
+        args.push("--project-name".into());
+        args.push(project_name.clone());
+    }
+    args
+}
+
+fn compose_mutation_args(mutation: ComposeMutation, service: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    match mutation {
+        ComposeMutation::Up => {
+            args.push("up".into());
+            args.push("-d".into());
+        }
+        ComposeMutation::Restart => {
+            args.push("restart".into());
+        }
+        ComposeMutation::Pull => {
+            args.push("pull".into());
+        }
+        ComposeMutation::Down => {
+            args.push("stop".into());
+        }
+    }
+    args.push(service.into());
+    args
 }
 
 impl<I: DockerInspect, R> ComposeService<I, R> {

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -287,7 +287,8 @@ impl<I, R> ComposeService<I, R> {
                 args.push(target.target.service.clone());
             }
             ComposeMutation::Down => {
-                args.push("down".into());
+                args.push("stop".into());
+                args.push(target.target.service.clone());
             }
         }
         ComposeInvocation {
@@ -346,12 +347,16 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
         }
 
         if let Some(info) = self.inspector.inspect_container(&container_name)? {
-            return Ok(target_from_container(&info, &self.defaults));
+            let target = target_from_container(&info, &self.defaults);
+            validate_requested_selectors(requested, &target)?;
+            return Ok(target);
         }
 
         let candidates = self.inspector.find_candidates(&service, &container_name)?;
         if candidates.len() == 1 {
-            return Ok(target_from_container(&candidates[0], &self.defaults));
+            let target = target_from_container(&candidates[0], &self.defaults);
+            validate_requested_selectors(requested, &target)?;
+            return Ok(target);
         }
         if candidates.len() > 1 {
             return Ok(ResolvedComposeTarget {
@@ -457,8 +462,15 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
         } else {
             Vec::new()
         };
-        let systemd = self.inspector.systemd_status("syslog-mcp.service")?;
-        let listeners = self.inspector.listeners(&[1514, 3100])?;
+        let systemd = self
+            .inspector
+            .systemd_status("syslog-mcp.service")
+            .map_err(|error| {
+                anyhow!("refusing mutation: could not verify systemd ownership: {error}")
+            })?;
+        let listeners = self.inspector.listeners(&[1514, 3100]).map_err(|error| {
+            anyhow!("refusing mutation: could not verify port listeners: {error}")
+        })?;
         let systemd_active = systemd.as_ref().is_some_and(|s| s.active);
         let non_target_listener = listeners.iter().any(|listener| {
             !listener_belongs_to_target(listener, &target.target.container_name, &published_ports)
@@ -717,6 +729,29 @@ fn listener_belongs_to_target(
         || listener.process.as_deref().is_some_and(|process| {
             published_by_target && (!process.contains("users:") || process.contains("docker-proxy"))
         })
+}
+
+fn validate_requested_selectors(
+    requested: &ComposeTarget,
+    target: &ResolvedComposeTarget,
+) -> Result<()> {
+    if let Some(project_name) = &requested.project_name {
+        if target.target.project_name.as_ref() != Some(project_name) {
+            return Err(anyhow!(
+                "requested project_name {project_name:?} does not match resolved compose project {:?}",
+                target.target.project_name
+            ));
+        }
+    }
+    if let Some(service) = &requested.service {
+        if &target.target.service != service {
+            return Err(anyhow!(
+                "requested service {service:?} does not match resolved compose service {:?}",
+                target.target.service
+            ));
+        }
+    }
+    Ok(())
 }
 
 pub fn redact_sensitive(input: &str) -> String {

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -831,11 +831,7 @@ pub fn mcp_projection(status: &ComposeStatus) -> ComposeMcpStatus {
     let runtime_state = match status.health.as_deref() {
         Some("healthy") => ComposeRuntimeState::Healthy,
         Some("unhealthy") => ComposeRuntimeState::Degraded,
-        _ if status
-            .status
-            .as_deref()
-            .is_some_and(|s| s.contains("Exited")) =>
-        {
+        _ if status.status.as_deref().is_some_and(is_stopped_status) => {
             ComposeRuntimeState::Stopped
         }
         _ if status
@@ -872,6 +868,11 @@ pub fn mcp_projection(status: &ComposeStatus) -> ComposeMcpStatus {
             })
             .collect(),
     }
+}
+
+fn is_stopped_status(status: &str) -> bool {
+    let status = status.to_ascii_lowercase();
+    status.contains("exited") || status == "stopped"
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use serde::Serialize;
@@ -460,36 +461,48 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
             ));
         }
 
-        let published_ports = if target.source == TargetSource::LiveContainerLabels {
-            self.inspector
-                .inspect_container(&target.target.container_name)?
-                .map(|info| {
-                    info.ports
-                        .into_iter()
-                        .filter_map(|port| port.public_port)
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
-        let systemd = self
-            .inspector
-            .systemd_status("syslog-mcp.service")
-            .map_err(|error| {
-                anyhow!("refusing mutation: could not verify systemd ownership: {error}")
+        let ownership = if mutation_requires_ownership_probe(mutation) {
+            let published_ports = if target.source == TargetSource::LiveContainerLabels {
+                self.inspector
+                    .inspect_container(&target.target.container_name)?
+                    .map(|info| {
+                        info.ports
+                            .into_iter()
+                            .filter_map(|port| port.public_port)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+            let systemd = self
+                .inspector
+                .systemd_status("syslog-mcp.service")
+                .map_err(|error| {
+                    anyhow!("refusing mutation: could not verify systemd ownership: {error}")
+                })?;
+            let listeners = self.inspector.listeners(&[1514, 3100]).map_err(|error| {
+                anyhow!("refusing mutation: could not verify port listeners: {error}")
             })?;
-        let listeners = self.inspector.listeners(&[1514, 3100]).map_err(|error| {
-            anyhow!("refusing mutation: could not verify port listeners: {error}")
-        })?;
-        let systemd_active = systemd.as_ref().is_some_and(|s| s.active);
-        let non_target_listener = listeners.iter().any(|listener| {
-            !listener_belongs_to_target(listener, &target.target.container_name, &published_ports)
-        });
+            Some((
+                systemd.as_ref().is_some_and(|s| s.active),
+                listeners.iter().any(|listener| {
+                    !listener_belongs_to_target(
+                        listener,
+                        &target.target.container_name,
+                        &published_ports,
+                    )
+                }),
+            ))
+        } else {
+            None
+        };
 
         match mutation {
             ComposeMutation::Up | ComposeMutation::Restart
-                if systemd_active || non_target_listener =>
+                if ownership.is_some_and(|(systemd_active, non_target_listener)| {
+                    systemd_active || non_target_listener
+                }) =>
             {
                 return Err(anyhow!(
                     "refusing mutation: systemd or non-target listener owns syslog ports"
@@ -755,16 +768,27 @@ fn target_from_container(
     }
 }
 
+fn mutation_requires_ownership_probe(mutation: ComposeMutation) -> bool {
+    matches!(
+        mutation,
+        ComposeMutation::Up | ComposeMutation::Restart | ComposeMutation::Down
+    )
+}
+
 fn listener_belongs_to_target(
     listener: &ListenerInfo,
     _container_name: &str,
     published_ports: &[u16],
 ) -> bool {
+    if listener.belongs_to_target {
+        return true;
+    }
     let published_by_target = published_ports.contains(&listener.port);
-    listener.belongs_to_target
-        || listener.process.as_deref().is_some_and(|process| {
-            published_by_target && (!process.contains("users:") || process.contains("docker-proxy"))
-        })
+    published_by_target
+        && listener
+            .process
+            .as_deref()
+            .is_some_and(|process| process.contains("users:") && process.contains("docker-proxy"))
 }
 
 fn validate_requested_selectors(
@@ -1005,7 +1029,13 @@ fn run_inspector_command(
     std::process::Command::new("timeout")
         .args(timeout_args)
         .output()
-        .map_err(|e| anyhow!("failed to run {program} inspector command: {e}"))
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                anyhow!("'timeout' binary not found; please install GNU coreutils or add timeout to PATH before running compose diagnostics")
+            } else {
+                anyhow!("failed to run {program} inspector command: {e}")
+            }
+        })
 }
 
 fn container_info_from_inspect(value: serde_json::Value) -> Result<ContainerInfo> {
@@ -1181,37 +1211,41 @@ impl CommandRunner for ProcessRunner {
         let mut timeout_cleanup = None;
         let status = loop {
             if let Some(status) = child.try_wait()? {
-                break status;
+                break Some(status);
             }
             if started.elapsed() >= invocation.timeout {
                 timed_out = true;
                 let terminate_sent = terminate_child(&mut child);
                 thread::sleep(Duration::from_millis(500));
                 let mut kill_sent = false;
-                let status = if let Some(status) = child.try_wait()? {
-                    status
+                let (status, reaped) = if let Some(status) = child.try_wait()? {
+                    (Some(status), true)
                 } else {
                     kill_sent = force_kill_child(&mut child);
-                    child.wait()?
+                    let status = wait_for_child_after_kill(&mut child, Duration::from_secs(2))?;
+                    let reaped = status.is_some();
+                    (status, reaped)
                 };
                 timeout_cleanup = Some(TimeoutCleanupStatus {
                     terminate_sent,
                     kill_sent,
-                    reaped: true,
+                    reaped,
                 });
                 break status;
             }
             thread::sleep(Duration::from_millis(25));
         };
 
-        let _ = out_handle.join();
-        let _ = err_handle.join();
+        if timeout_cleanup.as_ref().map(|c| c.reaped).unwrap_or(true) {
+            let _ = out_handle.join();
+            let _ = err_handle.join();
+        }
 
         let (stdout, stdout_truncated) = take_buffer(stdout_buf)?;
         let (stderr, stderr_truncated) = take_buffer(stderr_buf)?;
 
         Ok(CommandOutput {
-            exit_status: status.code(),
+            exit_status: status.and_then(|status| status.code()),
             stdout: redact_sensitive(&String::from_utf8_lossy(&stdout)),
             stderr: redact_sensitive(&String::from_utf8_lossy(&stderr)),
             stdout_truncated,
@@ -1219,6 +1253,22 @@ impl CommandRunner for ProcessRunner {
             timed_out,
             timeout_cleanup,
         })
+    }
+}
+
+fn wait_for_child_after_kill(
+    child: &mut std::process::Child,
+    cap: Duration,
+) -> Result<Option<std::process::ExitStatus>> {
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(Some(status));
+        }
+        if started.elapsed() >= cap {
+            return Ok(None);
+        }
+        thread::sleep(Duration::from_millis(25));
     }
 }
 

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -204,7 +204,6 @@ pub enum ComposeMutation {
 pub struct MutationOptions {
     pub dry_run: bool,
     pub allow_cwd_target: bool,
-    pub allow_foreign_project: bool,
     pub yes: bool,
     pub non_interactive: bool,
 }
@@ -437,6 +436,14 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
             }
         }
 
+        if target.source == TargetSource::LiveContainerLabels
+            && target.confidence != TargetConfidence::Confirmed
+        {
+            return Err(anyhow!(
+                "refusing mutation: live container is missing required compose labels"
+            ));
+        }
+
         let published_ports = if target.source == TargetSource::LiveContainerLabels {
             self.inspector
                 .inspect_container(&target.target.container_name)?
@@ -453,9 +460,9 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
         let systemd = self.inspector.systemd_status("syslog-mcp.service")?;
         let listeners = self.inspector.listeners(&[1514, 3100])?;
         let systemd_active = systemd.as_ref().is_some_and(|s| s.active);
-        let non_target_listener = listeners
-            .iter()
-            .any(|l| !l.belongs_to_target && !published_ports.contains(&l.port));
+        let non_target_listener = listeners.iter().any(|listener| {
+            !listener_belongs_to_target(listener, &target.target.container_name, &published_ports)
+        });
 
         match mutation {
             ComposeMutation::Up | ComposeMutation::Restart
@@ -491,6 +498,7 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
                 return Ok(unresolved_status(
                     requested,
                     &self.defaults,
+                    unresolved_code(&error),
                     format!("could not resolve syslog-mcp compose target: {error}"),
                 ));
             }
@@ -502,7 +510,7 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
                 let mut status = status_from_target(target, None, None);
                 status.diagnostics.push(ComposeDiagnostic {
                     severity: DiagnosticSeverity::Error,
-                    code: "docker_inspect_failed".into(),
+                    code: unresolved_code(&error).into(),
                     message: error.to_string(),
                 });
                 return Ok(status);
@@ -552,6 +560,7 @@ impl<I: DockerInspect, R: CommandRunner> ComposeService<I, R> {
 fn unresolved_status(
     requested: &ComposeTarget,
     defaults: &ComposeDefaults,
+    code: &str,
     message: String,
 ) -> ComposeStatus {
     ComposeStatus {
@@ -578,9 +587,17 @@ fn unresolved_status(
         systemd: None,
         diagnostics: vec![ComposeDiagnostic {
             severity: DiagnosticSeverity::Error,
-            code: "target_unresolved".into(),
+            code: code.into(),
             message,
         }],
+    }
+}
+
+fn unresolved_code(error: &anyhow::Error) -> &'static str {
+    if error.to_string().contains("docker unavailable") {
+        "docker_unavailable"
+    } else {
+        "target_unresolved"
     }
 }
 
@@ -633,28 +650,73 @@ fn target_from_container(
     info: &ContainerInfo,
     defaults: &ComposeDefaults,
 ) -> ResolvedComposeTarget {
-    let service = label(info, "com.docker.compose.service")
-        .unwrap_or(defaults.service.as_str())
-        .to_string();
-    let container_name = info.name.trim_start_matches('/').to_string();
-    let compose_working_dir =
+    let project = label(info, "com.docker.compose.project").map(str::to_string);
+    let service_label = label(info, "com.docker.compose.service").map(str::to_string);
+    let working_dir_label =
         label(info, "com.docker.compose.project.working_dir").map(PathBuf::from);
-    let compose_files = split_compose_files(label(info, "com.docker.compose.project.config_files"));
+    let config_files_label = label(info, "com.docker.compose.project.config_files");
+    let compose_files = split_compose_files(config_files_label);
+
+    let mut missing = Vec::new();
+    if project.is_none() {
+        missing.push("com.docker.compose.project");
+    }
+    if service_label.is_none() {
+        missing.push("com.docker.compose.service");
+    }
+    if working_dir_label.is_none() {
+        missing.push("com.docker.compose.project.working_dir");
+    }
+    if compose_files.is_empty() {
+        missing.push("com.docker.compose.project.config_files");
+    }
+
+    let service = service_label.unwrap_or_else(|| defaults.service.clone());
+    let container_name = info.name.trim_start_matches('/').to_string();
+    let diagnostics = if missing.is_empty() {
+        Vec::new()
+    } else {
+        vec![ComposeDiagnostic {
+            severity: DiagnosticSeverity::Unsafe,
+            code: "incomplete_compose_labels".into(),
+            message: format!(
+                "container is missing required compose labels: {}",
+                missing.join(", ")
+            ),
+        }]
+    };
+    let confidence = if missing.is_empty() {
+        TargetConfidence::Confirmed
+    } else {
+        TargetConfidence::Unsafe
+    };
     ResolvedComposeTarget {
         target: ComposeTargetSummary {
-            project_dir: compose_working_dir.clone(),
+            project_dir: working_dir_label.clone(),
             compose_file: compose_files.first().cloned(),
-            project_name: label(info, "com.docker.compose.project").map(str::to_string),
+            project_name: project.clone(),
             service,
             container_name,
         },
         source: TargetSource::LiveContainerLabels,
-        confidence: TargetConfidence::Confirmed,
-        diagnostics: Vec::new(),
+        confidence,
+        diagnostics,
         compose_files,
-        compose_working_dir,
-        compose_project: label(info, "com.docker.compose.project").map(str::to_string),
+        compose_working_dir: working_dir_label,
+        compose_project: project,
     }
+}
+
+fn listener_belongs_to_target(
+    listener: &ListenerInfo,
+    _container_name: &str,
+    published_ports: &[u16],
+) -> bool {
+    let published_by_target = published_ports.contains(&listener.port);
+    listener.belongs_to_target
+        || listener.process.as_deref().is_some_and(|process| {
+            published_by_target && (!process.contains("users:") || process.contains("docker-proxy"))
+        })
 }
 
 pub fn redact_sensitive(input: &str) -> String {
@@ -708,7 +770,7 @@ pub fn mcp_projection(status: &ComposeStatus) -> ComposeMcpStatus {
         _ if status
             .diagnostics
             .iter()
-            .any(|d| d.code == "docker_inspect_failed" || d.code == "target_unresolved") =>
+            .any(|d| d.code == "docker_unavailable") =>
         {
             ComposeRuntimeState::DockerUnavailable
         }
@@ -746,11 +808,19 @@ pub struct CliDockerInspect;
 
 impl DockerInspect for CliDockerInspect {
     fn inspect_container(&self, name: &str) -> Result<Option<ContainerInfo>> {
-        let output = std::process::Command::new("docker")
-            .args(["inspect", name, "--format", "{{json .}}"])
-            .output()
-            .map_err(|e| anyhow!("failed to run docker inspect: {e}"))?;
+        let output = run_inspector_command(
+            "docker",
+            &["inspect", name, "--format", "{{json .}}"],
+            Duration::from_secs(10),
+        )?;
         if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
+            if !stderr.contains("no such object") && !stderr.contains("no such container") {
+                return Err(anyhow!(
+                    "docker unavailable: docker inspect failed: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
             return Ok(None);
         }
         let value: serde_json::Value = serde_json::from_slice(&output.stdout)?;
@@ -759,12 +829,16 @@ impl DockerInspect for CliDockerInspect {
 
     fn find_candidates(&self, service: &str, container_name: &str) -> Result<Vec<ContainerInfo>> {
         let filter = format!("label=com.docker.compose.service={service}");
-        let output = std::process::Command::new("docker")
-            .args(["ps", "-a", "--filter", &filter, "--format", "{{.Names}}"])
-            .output()
-            .map_err(|e| anyhow!("failed to run docker ps: {e}"))?;
+        let output = run_inspector_command(
+            "docker",
+            &["ps", "-a", "--filter", &filter, "--format", "{{.Names}}"],
+            Duration::from_secs(10),
+        )?;
         if !output.status.success() {
-            return Ok(Vec::new());
+            return Err(anyhow!(
+                "docker unavailable: docker ps failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
         }
         let names = String::from_utf8_lossy(&output.stdout);
         let mut found = Vec::new();
@@ -779,9 +853,11 @@ impl DockerInspect for CliDockerInspect {
     }
 
     fn systemd_status(&self, unit: &str) -> Result<Option<SystemdStatus>> {
-        let output = std::process::Command::new("systemctl")
-            .args(["--user", "is-active", unit])
-            .output();
+        let output = run_inspector_command(
+            "systemctl",
+            &["--user", "is-active", unit],
+            Duration::from_secs(3),
+        );
         match output {
             Ok(output) => Ok(Some(SystemdStatus {
                 unit: unit.into(),
@@ -795,9 +871,11 @@ impl DockerInspect for CliDockerInspect {
         let mut listeners = Vec::new();
         for port in ports {
             let port_arg = format!(":{port}");
-            let output = std::process::Command::new("ss")
-                .args(["-ltnup", "sport", "=", &port_arg])
-                .output();
+            let output = run_inspector_command(
+                "ss",
+                &["-ltnup", "sport", "=", &port_arg],
+                Duration::from_secs(3),
+            );
             if let Ok(output) = output {
                 if output.status.success() && !output.stdout.is_empty() {
                     listeners.push(ListenerInfo {
@@ -810,6 +888,20 @@ impl DockerInspect for CliDockerInspect {
         }
         Ok(listeners)
     }
+}
+
+fn run_inspector_command(
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<std::process::Output> {
+    let timeout_secs = timeout.as_secs().max(1).to_string();
+    let mut timeout_args = vec!["-k", "1s", &timeout_secs, program];
+    timeout_args.extend(args);
+    std::process::Command::new("timeout")
+        .args(timeout_args)
+        .output()
+        .map_err(|e| anyhow!("failed to run {program} inspector command: {e}"))
 }
 
 fn container_info_from_inspect(value: serde_json::Value) -> Result<ContainerInfo> {
@@ -995,7 +1087,7 @@ impl CommandRunner for ProcessRunner {
                 let status = if let Some(status) = child.try_wait()? {
                     status
                 } else {
-                    kill_sent = child.kill().is_ok();
+                    kill_sent = force_kill_child(&mut child);
                     child.wait()?
                 };
                 timeout_cleanup = Some(TimeoutCleanupStatus {
@@ -1067,8 +1159,19 @@ fn terminate_child(child: &mut std::process::Child) -> bool {
     unsafe { libc::kill(-pid, libc::SIGTERM) == 0 }
 }
 
+#[cfg(unix)]
+fn force_kill_child(child: &mut std::process::Child) -> bool {
+    let pid = child.id() as i32;
+    unsafe { libc::kill(-pid, libc::SIGKILL) == 0 }
+}
+
 #[cfg(not(unix))]
 fn terminate_child(child: &mut std::process::Child) -> bool {
+    child.kill().is_ok()
+}
+
+#[cfg(not(unix))]
+fn force_kill_child(child: &mut std::process::Child) -> bool {
     child.kill().is_ok()
 }
 

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -1,9 +1,15 @@
 use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use serde::Serialize;
+
+const DIAG_DOCKER_UNAVAILABLE: &str = "docker_unavailable";
+const DIAG_TARGET_UNRESOLVED: &str = "target_unresolved";
+const DIAG_SYSTEMD_CHECK_FAILED: &str = "systemd_check_failed";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComposeDefaults {
@@ -254,7 +260,7 @@ impl<I, R> ComposeService<I, R> {
         }
     }
 
-    pub fn compose_invocation(
+    fn compose_invocation(
         &self,
         target: &ResolvedComposeTarget,
         mutation: ComposeMutation,
@@ -304,7 +310,7 @@ impl<I, R> ComposeService<I, R> {
         }
     }
 
-    pub fn logs_invocation(&self, target: &ResolvedComposeTarget, tail: u32) -> ComposeInvocation {
+    fn logs_invocation(&self, target: &ResolvedComposeTarget, tail: u32) -> ComposeInvocation {
         let mut invocation = self.compose_invocation(target, ComposeMutation::Pull);
         invocation
             .args
@@ -528,8 +534,22 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
                 return Ok(status);
             }
         };
-        let systemd = self.inspector.systemd_status("syslog-mcp.service")?;
+        let mut systemd_error = None;
+        let systemd = match self.inspector.systemd_status("syslog-mcp.service") {
+            Ok(systemd) => systemd,
+            Err(error) => {
+                systemd_error = Some(error.to_string());
+                None
+            }
+        };
         let mut status = status_from_target(target, info, systemd);
+        if let Some(error) = systemd_error {
+            status.diagnostics.push(ComposeDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                code: DIAG_SYSTEMD_CHECK_FAILED.into(),
+                message: format!("could not verify syslog-mcp.service state: {error}"),
+            });
+        }
         if status.systemd.as_ref().is_some_and(|s| s.active) {
             let code = if status.compose_project.is_some() {
                 "owner_mismatch"
@@ -606,12 +626,23 @@ fn unresolved_status(
 }
 
 fn unresolved_code(error: &anyhow::Error) -> &'static str {
-    if error.to_string().contains("docker unavailable") {
-        "docker_unavailable"
+    if error.downcast_ref::<DockerUnavailableError>().is_some() {
+        DIAG_DOCKER_UNAVAILABLE
     } else {
-        "target_unresolved"
+        DIAG_TARGET_UNRESOLVED
     }
 }
+
+#[derive(Debug)]
+struct DockerUnavailableError(String);
+
+impl fmt::Display for DockerUnavailableError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "docker unavailable: {}", self.0)
+    }
+}
+
+impl Error for DockerUnavailableError {}
 
 fn status_from_target(
     target: ResolvedComposeTarget,
@@ -847,14 +878,16 @@ impl DockerInspect for CliDockerInspect {
             "docker",
             &["inspect", name, "--format", "{{json .}}"],
             Duration::from_secs(10),
-        )?;
+        )
+        .map_err(|e| DockerUnavailableError(format!("docker inspect failed: {e}")))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
             if !stderr.contains("no such object") && !stderr.contains("no such container") {
-                return Err(anyhow!(
-                    "docker unavailable: docker inspect failed: {}",
+                return Err(DockerUnavailableError(format!(
+                    "docker inspect failed: {}",
                     String::from_utf8_lossy(&output.stderr).trim()
-                ));
+                ))
+                .into());
             }
             return Ok(None);
         }
@@ -868,12 +901,14 @@ impl DockerInspect for CliDockerInspect {
             "docker",
             &["ps", "-a", "--filter", &filter, "--format", "{{.Names}}"],
             Duration::from_secs(10),
-        )?;
+        )
+        .map_err(|e| DockerUnavailableError(format!("docker ps failed: {e}")))?;
         if !output.status.success() {
-            return Err(anyhow!(
-                "docker unavailable: docker ps failed: {}",
+            return Err(DockerUnavailableError(format!(
+                "docker ps failed: {}",
                 String::from_utf8_lossy(&output.stderr).trim()
-            ));
+            ))
+            .into());
         }
         let names = String::from_utf8_lossy(&output.stdout);
         let mut found = Vec::new();
@@ -892,14 +927,11 @@ impl DockerInspect for CliDockerInspect {
             "systemctl",
             &["--user", "is-active", unit],
             Duration::from_secs(3),
-        );
-        match output {
-            Ok(output) => Ok(Some(SystemdStatus {
-                unit: unit.into(),
-                active: output.status.success(),
-            })),
-            Err(_) => Ok(None),
-        }
+        )?;
+        Ok(Some(SystemdStatus {
+            unit: unit.into(),
+            active: output.status.success(),
+        }))
     }
 
     fn listeners(&self, ports: &[u16]) -> Result<Vec<ListenerInfo>> {
@@ -910,15 +942,19 @@ impl DockerInspect for CliDockerInspect {
                 "ss",
                 &["-ltnup", "sport", "=", &port_arg],
                 Duration::from_secs(3),
-            );
-            if let Ok(output) = output {
-                if output.status.success() && !output.stdout.is_empty() {
-                    listeners.push(ListenerInfo {
-                        port: *port,
-                        process: Some(String::from_utf8_lossy(&output.stdout).to_string()),
-                        belongs_to_target: false,
-                    });
-                }
+            )?;
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "ss listener check failed for port {port}: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
+            if !output.stdout.is_empty() {
+                listeners.push(ListenerInfo {
+                    port: *port,
+                    process: Some(String::from_utf8_lossy(&output.stdout).to_string()),
+                    belongs_to_target: false,
+                });
             }
         }
         Ok(listeners)

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -1,0 +1,1077 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposeDefaults {
+    pub service: String,
+    pub container_name: String,
+    pub timeout: Duration,
+    pub output_limit_bytes: usize,
+}
+
+impl Default for ComposeDefaults {
+    fn default() -> Self {
+        Self {
+            service: "syslog-mcp".into(),
+            container_name: "syslog-mcp".into(),
+            timeout: Duration::from_secs(120),
+            output_limit_bytes: 64 * 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ComposeTarget {
+    pub project_dir: Option<PathBuf>,
+    pub compose_file: Option<PathBuf>,
+    pub project_name: Option<String>,
+    pub service: Option<String>,
+    pub container_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetSource {
+    Explicit,
+    LiveContainerLabels,
+    CurrentWorkingDirectory,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetConfidence {
+    Confirmed,
+    Ambiguous,
+    Unsafe,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticSeverity {
+    Info,
+    Warning,
+    Unsafe,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ComposeDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedComposeTarget {
+    pub target: ComposeTargetSummary,
+    pub source: TargetSource,
+    pub confidence: TargetConfidence,
+    pub diagnostics: Vec<ComposeDiagnostic>,
+    pub compose_files: Vec<PathBuf>,
+    pub compose_working_dir: Option<PathBuf>,
+    pub compose_project: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ComposeTargetSummary {
+    pub project_dir: Option<PathBuf>,
+    pub compose_file: Option<PathBuf>,
+    pub project_name: Option<String>,
+    pub service: String,
+    pub container_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MountInfo {
+    pub source: Option<PathBuf>,
+    pub target: String,
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PortInfo {
+    pub private_port: u16,
+    pub public_port: Option<u16>,
+    pub protocol: String,
+    pub host_ip: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SystemdStatus {
+    pub unit: String,
+    pub active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ComposeStatus {
+    pub container_name: String,
+    pub container_id: Option<String>,
+    pub status: Option<String>,
+    pub health: Option<String>,
+    pub image: Option<String>,
+    pub image_id: Option<String>,
+    pub compose_project: Option<String>,
+    pub compose_working_dir: Option<PathBuf>,
+    pub compose_files: Vec<PathBuf>,
+    pub service: Option<String>,
+    pub data_mounts: Vec<MountInfo>,
+    pub ports: Vec<PortInfo>,
+    pub systemd: Option<SystemdStatus>,
+    pub diagnostics: Vec<ComposeDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PublicPortSummary {
+    pub port: u16,
+    pub protocol: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComposeOwnershipState {
+    ComposeOwned,
+    OwnerMismatch,
+    SystemdOwned,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComposeRuntimeState {
+    Healthy,
+    Degraded,
+    Stopped,
+    DockerUnavailable,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ComposeMcpDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub code: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ComposeMcpStatus {
+    pub container_name: String,
+    pub ownership: ComposeOwnershipState,
+    pub runtime_state: ComposeRuntimeState,
+    pub health: Option<String>,
+    pub published_ports: Vec<PublicPortSummary>,
+    pub diagnostics: Vec<ComposeMcpDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerInfo {
+    pub id: String,
+    pub name: String,
+    pub status: Option<String>,
+    pub health: Option<String>,
+    pub image: Option<String>,
+    pub image_id: Option<String>,
+    pub labels: BTreeMap<String, String>,
+    pub mounts: Vec<MountInfo>,
+    pub ports: Vec<PortInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ListenerInfo {
+    pub port: u16,
+    pub process: Option<String>,
+    pub belongs_to_target: bool,
+}
+
+pub trait DockerInspect {
+    fn inspect_container(&self, name: &str) -> Result<Option<ContainerInfo>>;
+    fn find_candidates(&self, service: &str, container_name: &str) -> Result<Vec<ContainerInfo>>;
+    fn systemd_status(&self, unit: &str) -> Result<Option<SystemdStatus>>;
+    fn listeners(&self, ports: &[u16]) -> Result<Vec<ListenerInfo>>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComposeMutation {
+    Up,
+    Down,
+    Restart,
+    Pull,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct MutationOptions {
+    pub dry_run: bool,
+    pub allow_cwd_target: bool,
+    pub allow_foreign_project: bool,
+    pub yes: bool,
+    pub non_interactive: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposeInvocation {
+    pub program: String,
+    pub args: Vec<String>,
+    pub current_dir: Option<PathBuf>,
+    pub timeout: Duration,
+    pub output_limit_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TimeoutCleanupStatus {
+    pub terminate_sent: bool,
+    pub kill_sent: bool,
+    pub reaped: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CommandOutput {
+    pub exit_status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+    pub timed_out: bool,
+    pub timeout_cleanup: Option<TimeoutCleanupStatus>,
+}
+
+pub trait CommandRunner {
+    fn run(&self, invocation: &ComposeInvocation) -> Result<CommandOutput>;
+}
+
+pub struct ComposeService<I, R> {
+    inspector: I,
+    runner: R,
+    defaults: ComposeDefaults,
+}
+
+impl<I, R> ComposeService<I, R> {
+    pub fn new(inspector: I, runner: R, defaults: ComposeDefaults) -> Self {
+        Self {
+            inspector,
+            runner,
+            defaults,
+        }
+    }
+
+    pub fn compose_invocation(
+        &self,
+        target: &ResolvedComposeTarget,
+        mutation: ComposeMutation,
+    ) -> ComposeInvocation {
+        let mut args = Vec::new();
+        if let Some(project_dir) = &target.compose_working_dir {
+            args.push("--project-directory".into());
+            args.push(project_dir.display().to_string());
+        }
+        for file in &target.compose_files {
+            args.push("-f".into());
+            args.push(file.display().to_string());
+        }
+        if let Some(project_name) = &target.compose_project {
+            args.push("--project-name".into());
+            args.push(project_name.clone());
+        }
+        match mutation {
+            ComposeMutation::Up => {
+                args.push("up".into());
+                args.push("-d".into());
+                args.push(target.target.service.clone());
+            }
+            ComposeMutation::Restart => {
+                args.push("restart".into());
+                args.push(target.target.service.clone());
+            }
+            ComposeMutation::Pull => {
+                args.push("pull".into());
+                args.push(target.target.service.clone());
+            }
+            ComposeMutation::Down => {
+                args.push("down".into());
+            }
+        }
+        ComposeInvocation {
+            program: "docker".into(),
+            args: {
+                let mut all = vec!["compose".into()];
+                all.extend(args);
+                all
+            },
+            current_dir: target.compose_working_dir.clone(),
+            timeout: self.defaults.timeout,
+            output_limit_bytes: self.defaults.output_limit_bytes,
+        }
+    }
+
+    pub fn logs_invocation(&self, target: &ResolvedComposeTarget, tail: u32) -> ComposeInvocation {
+        let mut invocation = self.compose_invocation(target, ComposeMutation::Pull);
+        invocation
+            .args
+            .truncate(invocation.args.len().saturating_sub(2));
+        invocation.args.push("logs".into());
+        invocation.args.push("--tail".into());
+        invocation.args.push(tail.to_string());
+        invocation.args.push(target.target.service.clone());
+        invocation
+    }
+}
+
+impl<I: DockerInspect, R> ComposeService<I, R> {
+    pub fn resolve_target(&self, requested: &ComposeTarget) -> Result<ResolvedComposeTarget> {
+        let service = requested
+            .service
+            .clone()
+            .unwrap_or_else(|| self.defaults.service.clone());
+        let container_name = requested
+            .container_name
+            .clone()
+            .unwrap_or_else(|| self.defaults.container_name.clone());
+
+        if requested.compose_file.is_some() || requested.project_dir.is_some() {
+            return Ok(ResolvedComposeTarget {
+                target: ComposeTargetSummary {
+                    project_dir: requested.project_dir.clone(),
+                    compose_file: requested.compose_file.clone(),
+                    project_name: requested.project_name.clone(),
+                    service,
+                    container_name,
+                },
+                source: TargetSource::Explicit,
+                confidence: TargetConfidence::Confirmed,
+                diagnostics: Vec::new(),
+                compose_files: requested.compose_file.clone().into_iter().collect(),
+                compose_working_dir: requested.project_dir.clone(),
+                compose_project: requested.project_name.clone(),
+            });
+        }
+
+        if let Some(info) = self.inspector.inspect_container(&container_name)? {
+            return Ok(target_from_container(&info, &self.defaults));
+        }
+
+        let candidates = self.inspector.find_candidates(&service, &container_name)?;
+        if candidates.len() == 1 {
+            return Ok(target_from_container(&candidates[0], &self.defaults));
+        }
+        if candidates.len() > 1 {
+            return Ok(ResolvedComposeTarget {
+                target: ComposeTargetSummary {
+                    project_dir: None,
+                    compose_file: None,
+                    project_name: requested.project_name.clone(),
+                    service,
+                    container_name,
+                },
+                source: TargetSource::LiveContainerLabels,
+                confidence: TargetConfidence::Ambiguous,
+                diagnostics: vec![ComposeDiagnostic {
+                    severity: DiagnosticSeverity::Unsafe,
+                    code: "multiple_compose_candidates".into(),
+                    message: format!("found {} candidate syslog-mcp containers", candidates.len()),
+                }],
+                compose_files: Vec::new(),
+                compose_working_dir: None,
+                compose_project: requested.project_name.clone(),
+            });
+        }
+
+        let cwd = std::env::current_dir()?;
+        let cwd_file = cwd.join("docker-compose.yml");
+        if cwd_file.exists() {
+            return Ok(ResolvedComposeTarget {
+                target: ComposeTargetSummary {
+                    project_dir: Some(cwd.clone()),
+                    compose_file: Some(cwd_file.clone()),
+                    project_name: requested.project_name.clone(),
+                    service,
+                    container_name,
+                },
+                source: TargetSource::CurrentWorkingDirectory,
+                confidence: TargetConfidence::Unsafe,
+                diagnostics: vec![ComposeDiagnostic {
+                    severity: DiagnosticSeverity::Unsafe,
+                    code: "cwd_fallback_requires_confirmation".into(),
+                    message:
+                        "cwd docker-compose.yml is not enough for mutation without --allow-cwd-target"
+                            .into(),
+                }],
+                compose_files: vec![cwd_file],
+                compose_working_dir: Some(cwd),
+                compose_project: requested.project_name.clone(),
+            });
+        }
+
+        Err(anyhow!("could not resolve syslog-mcp compose target"))
+    }
+
+    pub fn preflight_mutation(
+        &self,
+        mutation: ComposeMutation,
+        target: &ResolvedComposeTarget,
+        options: &MutationOptions,
+    ) -> Result<()> {
+        if target.confidence == TargetConfidence::Ambiguous {
+            return Err(anyhow!("refusing mutation: target is ambiguous"));
+        }
+        if target.source == TargetSource::CurrentWorkingDirectory && !options.allow_cwd_target {
+            return Err(anyhow!(
+                "refusing mutation: cwd target requires --allow-cwd-target"
+            ));
+        }
+        if target.target.project_name.is_some()
+            && target.target.project_dir.is_none()
+            && target.target.compose_file.is_none()
+            && target.source != TargetSource::LiveContainerLabels
+        {
+            return Err(anyhow!(
+                "refusing mutation: --project-name alone is not a safe target"
+            ));
+        }
+        for file in &target.compose_files {
+            if !file.exists() {
+                return Err(anyhow!(
+                    "refusing mutation: compose file does not exist: {}",
+                    file.display()
+                ));
+            }
+        }
+
+        let published_ports = if target.source == TargetSource::LiveContainerLabels {
+            self.inspector
+                .inspect_container(&target.target.container_name)?
+                .map(|info| {
+                    info.ports
+                        .into_iter()
+                        .filter_map(|port| port.public_port)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let systemd = self.inspector.systemd_status("syslog-mcp.service")?;
+        let listeners = self.inspector.listeners(&[1514, 3100])?;
+        let systemd_active = systemd.as_ref().is_some_and(|s| s.active);
+        let non_target_listener = listeners
+            .iter()
+            .any(|l| !l.belongs_to_target && !published_ports.contains(&l.port));
+
+        match mutation {
+            ComposeMutation::Up | ComposeMutation::Restart
+                if systemd_active || non_target_listener =>
+            {
+                return Err(anyhow!(
+                    "refusing mutation: systemd or non-target listener owns syslog ports"
+                ));
+            }
+            ComposeMutation::Down if target.source != TargetSource::LiveContainerLabels => {
+                return Err(anyhow!(
+                    "refusing down: target must be confirmed compose-owned"
+                ));
+            }
+            ComposeMutation::Down if options.non_interactive && !options.yes => {
+                return Err(anyhow!(
+                    "refusing down: --yes is required in non-interactive mode"
+                ));
+            }
+            ComposeMutation::Pull
+            | ComposeMutation::Up
+            | ComposeMutation::Restart
+            | ComposeMutation::Down => {}
+        }
+
+        Ok(())
+    }
+
+    pub fn status(&self, requested: &ComposeTarget) -> Result<ComposeStatus> {
+        let target = match self.resolve_target(requested) {
+            Ok(target) => target,
+            Err(error) => {
+                return Ok(unresolved_status(
+                    requested,
+                    &self.defaults,
+                    format!("could not resolve syslog-mcp compose target: {error}"),
+                ));
+            }
+        };
+        let container_name = target.target.container_name.clone();
+        let info = match self.inspector.inspect_container(&container_name) {
+            Ok(info) => info,
+            Err(error) => {
+                let mut status = status_from_target(target, None, None);
+                status.diagnostics.push(ComposeDiagnostic {
+                    severity: DiagnosticSeverity::Error,
+                    code: "docker_inspect_failed".into(),
+                    message: error.to_string(),
+                });
+                return Ok(status);
+            }
+        };
+        let systemd = self.inspector.systemd_status("syslog-mcp.service")?;
+        let mut status = status_from_target(target, info, systemd);
+        if status.systemd.as_ref().is_some_and(|s| s.active) {
+            let code = if status.compose_project.is_some() {
+                "owner_mismatch"
+            } else {
+                "systemd_active"
+            };
+            status.diagnostics.push(ComposeDiagnostic {
+                severity: DiagnosticSeverity::Warning,
+                code: code.into(),
+                message: "syslog-mcp.service is active".into(),
+            });
+        }
+        Ok(status)
+    }
+}
+
+impl<I: DockerInspect, R: CommandRunner> ComposeService<I, R> {
+    pub fn run_mutation(
+        &self,
+        mutation: ComposeMutation,
+        requested: &ComposeTarget,
+        options: &MutationOptions,
+    ) -> Result<Option<CommandOutput>> {
+        let target = self.resolve_target(requested)?;
+        self.preflight_mutation(mutation, &target, options)?;
+        if options.dry_run {
+            return Ok(None);
+        }
+        let invocation = self.compose_invocation(&target, mutation);
+        self.runner.run(&invocation).map(Some)
+    }
+
+    pub fn logs(&self, requested: &ComposeTarget, tail: Option<u32>) -> Result<CommandOutput> {
+        let target = self.resolve_target(requested)?;
+        let invocation = self.logs_invocation(&target, tail.unwrap_or(100));
+        self.runner.run(&invocation)
+    }
+}
+
+fn unresolved_status(
+    requested: &ComposeTarget,
+    defaults: &ComposeDefaults,
+    message: String,
+) -> ComposeStatus {
+    ComposeStatus {
+        container_name: requested
+            .container_name
+            .clone()
+            .unwrap_or_else(|| defaults.container_name.clone()),
+        container_id: None,
+        status: None,
+        health: None,
+        image: None,
+        image_id: None,
+        compose_project: requested.project_name.clone(),
+        compose_working_dir: requested.project_dir.clone(),
+        compose_files: requested.compose_file.clone().into_iter().collect(),
+        service: Some(
+            requested
+                .service
+                .clone()
+                .unwrap_or_else(|| defaults.service.clone()),
+        ),
+        data_mounts: Vec::new(),
+        ports: Vec::new(),
+        systemd: None,
+        diagnostics: vec![ComposeDiagnostic {
+            severity: DiagnosticSeverity::Error,
+            code: "target_unresolved".into(),
+            message,
+        }],
+    }
+}
+
+fn status_from_target(
+    target: ResolvedComposeTarget,
+    info: Option<ContainerInfo>,
+    systemd: Option<SystemdStatus>,
+) -> ComposeStatus {
+    let mut diagnostics = target.diagnostics.clone();
+    if target.source == TargetSource::CurrentWorkingDirectory {
+        diagnostics.push(ComposeDiagnostic {
+            severity: DiagnosticSeverity::Warning,
+            code: "cwd_target".into(),
+            message: "resolved from current working directory".into(),
+        });
+    }
+    ComposeStatus {
+        container_name: target.target.container_name,
+        container_id: info.as_ref().map(|i| i.id.clone()),
+        status: info.as_ref().and_then(|i| i.status.clone()),
+        health: info.as_ref().and_then(|i| i.health.clone()),
+        image: info.as_ref().and_then(|i| i.image.clone()),
+        image_id: info.as_ref().and_then(|i| i.image_id.clone()),
+        compose_project: target.compose_project,
+        compose_working_dir: target.compose_working_dir,
+        compose_files: target.compose_files,
+        service: Some(target.target.service),
+        data_mounts: info.as_ref().map(|i| i.mounts.clone()).unwrap_or_default(),
+        ports: info.as_ref().map(|i| i.ports.clone()).unwrap_or_default(),
+        systemd,
+        diagnostics,
+    }
+}
+
+fn label<'a>(info: &'a ContainerInfo, key: &str) -> Option<&'a str> {
+    info.labels.get(key).map(String::as_str)
+}
+
+fn split_compose_files(value: Option<&str>) -> Vec<PathBuf> {
+    value
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn target_from_container(
+    info: &ContainerInfo,
+    defaults: &ComposeDefaults,
+) -> ResolvedComposeTarget {
+    let service = label(info, "com.docker.compose.service")
+        .unwrap_or(defaults.service.as_str())
+        .to_string();
+    let container_name = info.name.trim_start_matches('/').to_string();
+    let compose_working_dir =
+        label(info, "com.docker.compose.project.working_dir").map(PathBuf::from);
+    let compose_files = split_compose_files(label(info, "com.docker.compose.project.config_files"));
+    ResolvedComposeTarget {
+        target: ComposeTargetSummary {
+            project_dir: compose_working_dir.clone(),
+            compose_file: compose_files.first().cloned(),
+            project_name: label(info, "com.docker.compose.project").map(str::to_string),
+            service,
+            container_name,
+        },
+        source: TargetSource::LiveContainerLabels,
+        confidence: TargetConfidence::Confirmed,
+        diagnostics: Vec::new(),
+        compose_files,
+        compose_working_dir,
+        compose_project: label(info, "com.docker.compose.project").map(str::to_string),
+    }
+}
+
+pub fn redact_sensitive(input: &str) -> String {
+    let sensitive = [
+        "token",
+        "secret",
+        "key",
+        "password",
+        "client_secret",
+        "authorization",
+    ];
+    input
+        .lines()
+        .map(|line| {
+            let lower = line.to_ascii_lowercase();
+            if sensitive.iter().any(|term| lower.contains(term)) {
+                "[REDACTED]".to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn mcp_projection(status: &ComposeStatus) -> ComposeMcpStatus {
+    let ownership = if status
+        .diagnostics
+        .iter()
+        .any(|d| d.code == "owner_mismatch")
+    {
+        ComposeOwnershipState::OwnerMismatch
+    } else if status.systemd.as_ref().is_some_and(|s| s.active) {
+        ComposeOwnershipState::SystemdOwned
+    } else if status.compose_project.is_some() {
+        ComposeOwnershipState::ComposeOwned
+    } else {
+        ComposeOwnershipState::Unknown
+    };
+
+    let runtime_state = match status.health.as_deref() {
+        Some("healthy") => ComposeRuntimeState::Healthy,
+        Some("unhealthy") => ComposeRuntimeState::Degraded,
+        _ if status
+            .status
+            .as_deref()
+            .is_some_and(|s| s.contains("Exited")) =>
+        {
+            ComposeRuntimeState::Stopped
+        }
+        _ if status
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "docker_inspect_failed" || d.code == "target_unresolved") =>
+        {
+            ComposeRuntimeState::DockerUnavailable
+        }
+        _ => ComposeRuntimeState::Unknown,
+    };
+
+    ComposeMcpStatus {
+        container_name: status.container_name.clone(),
+        ownership,
+        runtime_state,
+        health: status.health.clone(),
+        published_ports: status
+            .ports
+            .iter()
+            .filter_map(|port| {
+                port.public_port.map(|public| PublicPortSummary {
+                    port: public,
+                    protocol: port.protocol.clone(),
+                })
+            })
+            .collect(),
+        diagnostics: status
+            .diagnostics
+            .iter()
+            .map(|d| ComposeMcpDiagnostic {
+                severity: d.severity.clone(),
+                code: d.code.clone(),
+            })
+            .collect(),
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CliDockerInspect;
+
+impl DockerInspect for CliDockerInspect {
+    fn inspect_container(&self, name: &str) -> Result<Option<ContainerInfo>> {
+        let output = std::process::Command::new("docker")
+            .args(["inspect", name, "--format", "{{json .}}"])
+            .output()
+            .map_err(|e| anyhow!("failed to run docker inspect: {e}"))?;
+        if !output.status.success() {
+            return Ok(None);
+        }
+        let value: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+        container_info_from_inspect(value).map(Some)
+    }
+
+    fn find_candidates(&self, service: &str, container_name: &str) -> Result<Vec<ContainerInfo>> {
+        let filter = format!("label=com.docker.compose.service={service}");
+        let output = std::process::Command::new("docker")
+            .args(["ps", "-a", "--filter", &filter, "--format", "{{.Names}}"])
+            .output()
+            .map_err(|e| anyhow!("failed to run docker ps: {e}"))?;
+        if !output.status.success() {
+            return Ok(Vec::new());
+        }
+        let names = String::from_utf8_lossy(&output.stdout);
+        let mut found = Vec::new();
+        for name in names.lines().take(10) {
+            if name == container_name || name.contains(service) {
+                if let Some(info) = self.inspect_container(name)? {
+                    found.push(info);
+                }
+            }
+        }
+        Ok(found)
+    }
+
+    fn systemd_status(&self, unit: &str) -> Result<Option<SystemdStatus>> {
+        let output = std::process::Command::new("systemctl")
+            .args(["--user", "is-active", unit])
+            .output();
+        match output {
+            Ok(output) => Ok(Some(SystemdStatus {
+                unit: unit.into(),
+                active: output.status.success(),
+            })),
+            Err(_) => Ok(None),
+        }
+    }
+
+    fn listeners(&self, ports: &[u16]) -> Result<Vec<ListenerInfo>> {
+        let mut listeners = Vec::new();
+        for port in ports {
+            let port_arg = format!(":{port}");
+            let output = std::process::Command::new("ss")
+                .args(["-ltnup", "sport", "=", &port_arg])
+                .output();
+            if let Ok(output) = output {
+                if output.status.success() && !output.stdout.is_empty() {
+                    listeners.push(ListenerInfo {
+                        port: *port,
+                        process: Some(String::from_utf8_lossy(&output.stdout).to_string()),
+                        belongs_to_target: false,
+                    });
+                }
+            }
+        }
+        Ok(listeners)
+    }
+}
+
+fn container_info_from_inspect(value: serde_json::Value) -> Result<ContainerInfo> {
+    let labels = value
+        .pointer("/Config/Labels")
+        .and_then(|v| v.as_object())
+        .map(|map| {
+            map.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+    let name = value
+        .get("Name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("syslog-mcp")
+        .trim_start_matches('/')
+        .to_string();
+    let mounts = value
+        .get("Mounts")
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .map(|m| MountInfo {
+                    source: m.get("Source").and_then(|v| v.as_str()).map(PathBuf::from),
+                    target: m
+                        .get("Destination")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    kind: m
+                        .get("Type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(ContainerInfo {
+        id: value
+            .get("Id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        name,
+        status: value
+            .pointer("/State/Status")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        health: value
+            .pointer("/State/Health/Status")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        image: value
+            .pointer("/Config/Image")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        image_id: value
+            .get("Image")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        labels,
+        mounts,
+        ports: ports_from_inspect(&value),
+    })
+}
+
+fn ports_from_inspect(value: &serde_json::Value) -> Vec<PortInfo> {
+    let Some(map) = value
+        .pointer("/NetworkSettings/Ports")
+        .and_then(|v| v.as_object())
+    else {
+        return Vec::new();
+    };
+    let mut ports = Vec::new();
+    for (private, bindings) in map {
+        let Some((port, protocol)) = private.split_once('/') else {
+            continue;
+        };
+        let Ok(private_port) = port.parse::<u16>() else {
+            continue;
+        };
+        match bindings {
+            serde_json::Value::Array(items) if !items.is_empty() => {
+                for item in items {
+                    ports.push(PortInfo {
+                        private_port,
+                        public_port: item
+                            .get("HostPort")
+                            .and_then(|v| v.as_str())
+                            .and_then(|s| s.parse::<u16>().ok()),
+                        protocol: protocol.to_string(),
+                        host_ip: item
+                            .get("HostIp")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string),
+                    });
+                }
+            }
+            _ => ports.push(PortInfo {
+                private_port,
+                public_port: None,
+                protocol: protocol.to_string(),
+                host_ip: None,
+            }),
+        }
+    }
+    ports
+}
+
+pub struct ProcessRunner;
+
+impl CommandRunner for ProcessRunner {
+    fn run(&self, invocation: &ComposeInvocation) -> Result<CommandOutput> {
+        #[cfg(unix)]
+        use std::os::unix::process::CommandExt;
+        use std::process::{Command, Stdio};
+        use std::sync::{Arc, Mutex};
+        use std::thread;
+        use std::time::Instant;
+
+        let mut command = Command::new(&invocation.program);
+        command.args(&invocation.args);
+        if let Some(dir) = &invocation.current_dir {
+            command.current_dir(dir);
+        }
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        #[cfg(unix)]
+        unsafe {
+            command.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+
+        let mut child = command.spawn().map_err(|e| {
+            anyhow!(
+                "failed to spawn {} {}: {e}",
+                invocation.program,
+                invocation.args.join(" ")
+            )
+        })?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("missing stdout pipe"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("missing stderr pipe"))?;
+        let stdout_buf = Arc::new(Mutex::new((Vec::new(), false)));
+        let stderr_buf = Arc::new(Mutex::new((Vec::new(), false)));
+
+        let out_handle = drain_pipe(
+            stdout,
+            Arc::clone(&stdout_buf),
+            invocation.output_limit_bytes,
+        );
+        let err_handle = drain_pipe(
+            stderr,
+            Arc::clone(&stderr_buf),
+            invocation.output_limit_bytes,
+        );
+
+        let started = Instant::now();
+        let mut timed_out = false;
+        let mut timeout_cleanup = None;
+        let status = loop {
+            if let Some(status) = child.try_wait()? {
+                break status;
+            }
+            if started.elapsed() >= invocation.timeout {
+                timed_out = true;
+                let terminate_sent = terminate_child(&mut child);
+                thread::sleep(Duration::from_millis(500));
+                let mut kill_sent = false;
+                let status = if let Some(status) = child.try_wait()? {
+                    status
+                } else {
+                    kill_sent = child.kill().is_ok();
+                    child.wait()?
+                };
+                timeout_cleanup = Some(TimeoutCleanupStatus {
+                    terminate_sent,
+                    kill_sent,
+                    reaped: true,
+                });
+                break status;
+            }
+            thread::sleep(Duration::from_millis(25));
+        };
+
+        let _ = out_handle.join();
+        let _ = err_handle.join();
+
+        let (stdout, stdout_truncated) = take_buffer(stdout_buf)?;
+        let (stderr, stderr_truncated) = take_buffer(stderr_buf)?;
+
+        Ok(CommandOutput {
+            exit_status: status.code(),
+            stdout: redact_sensitive(&String::from_utf8_lossy(&stdout)),
+            stderr: redact_sensitive(&String::from_utf8_lossy(&stderr)),
+            stdout_truncated,
+            stderr_truncated,
+            timed_out,
+            timeout_cleanup,
+        })
+    }
+}
+
+fn drain_pipe<R: std::io::Read + Send + 'static>(
+    mut reader: R,
+    target: std::sync::Arc<std::sync::Mutex<(Vec<u8>, bool)>>,
+    limit: usize,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut chunk = [0u8; 8192];
+        while let Ok(n) = reader.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            let mut guard = target.lock().expect("pipe buffer mutex poisoned");
+            let remaining = limit.saturating_sub(guard.0.len());
+            if remaining > 0 {
+                let keep = remaining.min(n);
+                guard.0.extend_from_slice(&chunk[..keep]);
+                if keep < n {
+                    guard.1 = true;
+                }
+            } else {
+                guard.1 = true;
+            }
+        }
+    })
+}
+
+fn take_buffer(
+    buffer: std::sync::Arc<std::sync::Mutex<(Vec<u8>, bool)>>,
+) -> Result<(Vec<u8>, bool)> {
+    let guard = buffer
+        .lock()
+        .map_err(|_| anyhow!("pipe buffer mutex poisoned"))?;
+    Ok((guard.0.clone(), guard.1))
+}
+
+#[cfg(unix)]
+fn terminate_child(child: &mut std::process::Child) -> bool {
+    let pid = child.id() as i32;
+    unsafe { libc::kill(-pid, libc::SIGTERM) == 0 }
+}
+
+#[cfg(not(unix))]
+fn terminate_child(child: &mut std::process::Child) -> bool {
+    child.kill().is_ok()
+}
+
+#[cfg(test)]
+#[path = "compose_tests.rs"]
+mod tests;

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -172,6 +172,21 @@ pub struct ComposeMcpStatus {
     pub diagnostics: Vec<ComposeMcpDiagnostic>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ComposeDryRun {
+    pub dry_run: bool,
+    pub command: Vec<String>,
+    pub target: ComposeTargetSummary,
+    pub preflight: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ComposeCommandResult {
+    Executed(CommandOutput),
+    DryRun(ComposeDryRun),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContainerInfo {
     pub id: String,
@@ -197,6 +212,9 @@ pub trait DockerInspect {
     fn find_candidates(&self, service: &str, container_name: &str) -> Result<Vec<ContainerInfo>>;
     fn systemd_status(&self, unit: &str) -> Result<Option<SystemdStatus>>;
     fn listeners(&self, ports: &[u16]) -> Result<Vec<ListenerInfo>>;
+    fn published_port_owner(&self, _port: u16) -> Result<Option<String>> {
+        Ok(None)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -462,19 +480,19 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
         }
 
         let ownership = if mutation_requires_ownership_probe(mutation) {
-            let published_ports = if target.source == TargetSource::LiveContainerLabels {
-                self.inspector
-                    .inspect_container(&target.target.container_name)?
-                    .map(|info| {
-                        info.ports
-                            .into_iter()
-                            .filter_map(|port| port.public_port)
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            };
+            let target_container = self
+                .inspector
+                .inspect_container(&target.target.container_name)?;
+            let target_container_id = target_container.as_ref().map(|info| info.id.as_str());
+            let published_ports = target_container
+                .as_ref()
+                .map(|info| {
+                    info.ports
+                        .iter()
+                        .filter_map(|port| port.public_port)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
             let systemd = self
                 .inspector
                 .systemd_status("syslog-mcp.service")
@@ -484,15 +502,22 @@ impl<I: DockerInspect, R> ComposeService<I, R> {
             let listeners = self.inspector.listeners(&[1514, 3100]).map_err(|error| {
                 anyhow!("refusing mutation: could not verify port listeners: {error}")
             })?;
+            let mut non_target_listener = false;
+            for listener in &listeners {
+                if !listener_belongs_to_target(
+                    &self.inspector,
+                    listener,
+                    &target.target.container_name,
+                    target_container_id,
+                    &published_ports,
+                )? {
+                    non_target_listener = true;
+                    break;
+                }
+            }
             Some((
                 systemd.as_ref().is_some_and(|s| s.active),
-                listeners.iter().any(|listener| {
-                    !listener_belongs_to_target(
-                        listener,
-                        &target.target.container_name,
-                        &published_ports,
-                    )
-                }),
+                non_target_listener,
             ))
         } else {
             None
@@ -590,21 +615,64 @@ impl<I: DockerInspect, R: CommandRunner> ComposeService<I, R> {
         mutation: ComposeMutation,
         requested: &ComposeTarget,
         options: &MutationOptions,
-    ) -> Result<Option<CommandOutput>> {
+    ) -> Result<ComposeCommandResult> {
         let target = self.resolve_target(requested)?;
         self.preflight_mutation(mutation, &target, options)?;
-        if options.dry_run {
-            return Ok(None);
-        }
         let invocation = self.compose_invocation(&target, mutation);
-        self.runner.run(&invocation).map(Some)
+        if options.dry_run {
+            return Ok(ComposeCommandResult::DryRun(ComposeDryRun {
+                dry_run: true,
+                command: std::iter::once(invocation.program.clone())
+                    .chain(invocation.args.clone())
+                    .collect(),
+                target: target.target,
+                preflight: "passed".into(),
+            }));
+        }
+        self.runner
+            .run(&invocation)
+            .map(ComposeCommandResult::Executed)
     }
 
     pub fn logs(&self, requested: &ComposeTarget, tail: Option<u32>) -> Result<CommandOutput> {
         let target = self.resolve_target(requested)?;
+        if target.source == TargetSource::CurrentWorkingDirectory {
+            return Err(anyhow!(
+                "refusing logs: cwd target requires explicit compose target"
+            ));
+        }
+        if target.confidence != TargetConfidence::Confirmed {
+            return Err(anyhow!("refusing logs: target is not confirmed"));
+        }
         let invocation = self.logs_invocation(&target, tail.unwrap_or(100));
         self.runner.run(&invocation)
     }
+}
+
+fn listener_belongs_to_target<I: DockerInspect>(
+    inspector: &I,
+    listener: &ListenerInfo,
+    container_name: &str,
+    container_id: Option<&str>,
+    published_ports: &[u16],
+) -> Result<bool> {
+    if listener.belongs_to_target {
+        return Ok(true);
+    }
+    if !published_ports.contains(&listener.port) {
+        return Ok(false);
+    }
+    let Some(process) = listener.process.as_deref() else {
+        return Ok(false);
+    };
+    if !process.contains("users:") || !process.contains("docker-proxy") {
+        return Ok(false);
+    }
+    let Some(owner) = inspector.published_port_owner(listener.port)? else {
+        return Ok(false);
+    };
+    Ok(owner == container_name
+        || container_id.is_some_and(|id| id == owner || id.starts_with(&owner)))
 }
 
 fn unresolved_status(
@@ -775,22 +843,6 @@ fn mutation_requires_ownership_probe(mutation: ComposeMutation) -> bool {
     )
 }
 
-fn listener_belongs_to_target(
-    listener: &ListenerInfo,
-    _container_name: &str,
-    published_ports: &[u16],
-) -> bool {
-    if listener.belongs_to_target {
-        return true;
-    }
-    let published_by_target = published_ports.contains(&listener.port);
-    published_by_target
-        && listener
-            .process
-            .as_deref()
-            .is_some_and(|process| process.contains("users:") && process.contains("docker-proxy"))
-}
-
 fn validate_requested_selectors(
     requested: &ComposeTarget,
     target: &ResolvedComposeTarget,
@@ -838,6 +890,12 @@ pub fn redact_sensitive(input: &str) -> String {
 }
 
 pub fn mcp_projection(status: &ComposeStatus) -> ComposeMcpStatus {
+    let has_hard_diagnostic = status.diagnostics.iter().any(|d| {
+        matches!(
+            d.severity,
+            DiagnosticSeverity::Error | DiagnosticSeverity::Unsafe
+        )
+    });
     let ownership = if status
         .diagnostics
         .iter()
@@ -846,26 +904,31 @@ pub fn mcp_projection(status: &ComposeStatus) -> ComposeMcpStatus {
         ComposeOwnershipState::OwnerMismatch
     } else if status.systemd.as_ref().is_some_and(|s| s.active) {
         ComposeOwnershipState::SystemdOwned
+    } else if has_hard_diagnostic {
+        ComposeOwnershipState::Unknown
     } else if status.compose_project.is_some() {
         ComposeOwnershipState::ComposeOwned
     } else {
         ComposeOwnershipState::Unknown
     };
 
-    let runtime_state = match status.health.as_deref() {
-        Some("healthy") => ComposeRuntimeState::Healthy,
-        Some("unhealthy") => ComposeRuntimeState::Degraded,
-        _ if status.status.as_deref().is_some_and(is_stopped_status) => {
-            ComposeRuntimeState::Stopped
+    let runtime_state = if status
+        .diagnostics
+        .iter()
+        .any(|d| d.code == DIAG_DOCKER_UNAVAILABLE)
+    {
+        ComposeRuntimeState::DockerUnavailable
+    } else if has_hard_diagnostic {
+        ComposeRuntimeState::Degraded
+    } else {
+        match status.health.as_deref() {
+            Some("healthy") => ComposeRuntimeState::Healthy,
+            Some("unhealthy") => ComposeRuntimeState::Degraded,
+            _ if status.status.as_deref().is_some_and(is_stopped_status) => {
+                ComposeRuntimeState::Stopped
+            }
+            _ => ComposeRuntimeState::Unknown,
         }
-        _ if status
-            .diagnostics
-            .iter()
-            .any(|d| d.code == "docker_unavailable") =>
-        {
-            ComposeRuntimeState::DockerUnavailable
-        }
-        _ => ComposeRuntimeState::Unknown,
     };
 
     ComposeMcpStatus {
@@ -892,6 +955,27 @@ pub fn mcp_projection(status: &ComposeStatus) -> ComposeMcpStatus {
             })
             .collect(),
     }
+}
+
+pub fn ensure_doctor_ready(status: &ComposeStatus) -> Result<()> {
+    let projected = mcp_projection(status);
+    if projected.ownership != ComposeOwnershipState::ComposeOwned
+        || projected.runtime_state != ComposeRuntimeState::Healthy
+        || status.diagnostics.iter().any(|d| {
+            matches!(
+                d.severity,
+                DiagnosticSeverity::Error | DiagnosticSeverity::Unsafe
+            )
+        })
+    {
+        return Err(anyhow!(
+            "compose doctor failed: ownership={:?} runtime_state={:?} diagnostics={:?}",
+            projected.ownership,
+            projected.runtime_state,
+            status.diagnostics
+        ));
+    }
+    Ok(())
 }
 
 fn is_stopped_status(status: &str) -> bool {
@@ -967,7 +1051,7 @@ impl DockerInspect for CliDockerInspect {
             let port_arg = format!(":{port}");
             let output = run_inspector_command(
                 "ss",
-                &["-ltnup", "sport", "=", &port_arg],
+                &["-H", "-ltnup", "sport", "=", &port_arg],
                 Duration::from_secs(3),
             )?;
             if !output.status.success() {
@@ -976,7 +1060,7 @@ impl DockerInspect for CliDockerInspect {
                     String::from_utf8_lossy(&output.stderr).trim()
                 ));
             }
-            if !output.stdout.is_empty() {
+            if ss_output_has_listener(&output.stdout) {
                 listeners.push(ListenerInfo {
                     port: *port,
                     process: Some(String::from_utf8_lossy(&output.stdout).to_string()),
@@ -986,6 +1070,53 @@ impl DockerInspect for CliDockerInspect {
         }
         Ok(listeners)
     }
+
+    fn published_port_owner(&self, port: u16) -> Result<Option<String>> {
+        let publish_filter = format!("publish={port}");
+        let output = run_inspector_command(
+            "docker",
+            &[
+                "ps",
+                "--filter",
+                &publish_filter,
+                "--format",
+                "{{.ID}}\t{{.Names}}",
+            ],
+            Duration::from_secs(10),
+        )
+        .map_err(|e| DockerUnavailableError(format!("docker ps failed: {e}")))?;
+        if !output.status.success() {
+            return Err(DockerUnavailableError(format!(
+                "docker ps failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ))
+            .into());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut lines = stdout.lines();
+        let Some(first) = lines.next() else {
+            return Ok(None);
+        };
+        if lines.next().is_some() {
+            return Ok(None);
+        }
+        let mut fields = first.split('\t');
+        let id = fields.next().unwrap_or_default().trim();
+        let name = fields.next().unwrap_or_default().trim();
+        if !id.is_empty() {
+            Ok(Some(id.into()))
+        } else if !name.is_empty() {
+            Ok(Some(name.into()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn ss_output_has_listener(stdout: &[u8]) -> bool {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .any(|line| !line.trim().is_empty() && !line.trim_start().starts_with("Netid "))
 }
 
 fn systemd_status_from_output(
@@ -1171,7 +1302,9 @@ impl CommandRunner for ProcessRunner {
         #[cfg(unix)]
         unsafe {
             command.pre_exec(|| {
-                libc::setsid();
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
                 Ok(())
             });
         }
@@ -1279,23 +1412,31 @@ fn drain_pipe<R: std::io::Read + Send + 'static>(
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let mut chunk = [0u8; 8192];
-        while let Ok(n) = reader.read(&mut chunk) {
-            if n == 0 {
-                break;
-            }
-            let mut guard = target.lock().expect("pipe buffer mutex poisoned");
-            let remaining = limit.saturating_sub(guard.0.len());
-            if remaining > 0 {
-                let keep = remaining.min(n);
-                guard.0.extend_from_slice(&chunk[..keep]);
-                if keep < n {
-                    guard.1 = true;
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let mut guard = target.lock().expect("pipe buffer mutex poisoned");
+                    append_pipe_chunk(&mut guard, &chunk, n, limit);
                 }
-            } else {
-                guard.1 = true;
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
             }
         }
     })
+}
+
+fn append_pipe_chunk(target: &mut (Vec<u8>, bool), chunk: &[u8], n: usize, limit: usize) {
+    let remaining = limit.saturating_sub(target.0.len());
+    if remaining > 0 {
+        let keep = remaining.min(n);
+        target.0.extend_from_slice(&chunk[..keep]);
+        if keep < n {
+            target.1 = true;
+        }
+    } else {
+        target.1 = true;
+    }
 }
 
 fn take_buffer(

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -934,10 +934,7 @@ impl DockerInspect for CliDockerInspect {
             &["--user", "is-active", unit],
             Duration::from_secs(3),
         )?;
-        Ok(Some(SystemdStatus {
-            unit: unit.into(),
-            active: output.status.success(),
-        }))
+        systemd_status_from_output(unit, &output)
     }
 
     fn listeners(&self, ports: &[u16]) -> Result<Vec<ListenerInfo>> {
@@ -965,6 +962,36 @@ impl DockerInspect for CliDockerInspect {
         }
         Ok(listeners)
     }
+}
+
+fn systemd_status_from_output(
+    unit: &str,
+    output: &std::process::Output,
+) -> Result<Option<SystemdStatus>> {
+    if output.status.success() {
+        return Ok(Some(SystemdStatus {
+            unit: unit.into(),
+            active: true,
+        }));
+    }
+
+    let code = output.status.code();
+    let stdout = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .to_ascii_lowercase();
+    if matches!(code, Some(3) | Some(4))
+        || matches!(stdout.as_str(), "inactive" | "failed" | "unknown")
+    {
+        return Ok(Some(SystemdStatus {
+            unit: unit.into(),
+            active: false,
+        }));
+    }
+
+    Err(anyhow!(
+        "systemctl --user is-active {unit} failed (code={code:?}): {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    ))
 }
 
 fn run_inspector_command(

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -210,6 +210,33 @@ fn matching_requested_selectors_are_accepted() {
 }
 
 #[test]
+fn docker_unavailable_code_uses_typed_error() {
+    let err: anyhow::Error = DockerUnavailableError("daemon is down".into()).into();
+    assert_eq!(unresolved_code(&err), DIAG_DOCKER_UNAVAILABLE);
+
+    let plain_err = anyhow::anyhow!("docker unavailable: text only");
+    assert_eq!(unresolved_code(&plain_err), DIAG_TARGET_UNRESOLVED);
+}
+
+#[test]
+fn status_reports_systemd_check_failures_as_diagnostics() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            systemd_error: Some("systemctl unavailable".into()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+
+    let status = service.status(&ComposeTarget::default()).unwrap();
+
+    assert_eq!(status.diagnostics[0].code, DIAG_SYSTEMD_CHECK_FAILED);
+    assert_eq!(status.diagnostics[0].severity, DiagnosticSeverity::Error);
+}
+
+#[test]
 fn containers_without_required_compose_labels_are_unsafe_for_mutation() {
     let service = ComposeService::new(
         FakeInspector {

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -4,9 +4,15 @@ use std::os::unix::process::ExitStatusExt;
 use std::path::PathBuf;
 #[cfg(unix)]
 use std::process::Output;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use super::*;
+
+fn cwd_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+}
 
 #[derive(Default)]
 struct FakeInspector {
@@ -16,6 +22,7 @@ struct FakeInspector {
     listeners: Vec<ListenerInfo>,
     systemd_error: Option<String>,
     listeners_error: Option<String>,
+    published_port_owners: BTreeMap<u16, String>,
 }
 
 impl DockerInspect for FakeInspector {
@@ -39,6 +46,10 @@ impl DockerInspect for FakeInspector {
             anyhow::bail!("{error}");
         }
         Ok(self.listeners.clone())
+    }
+
+    fn published_port_owner(&self, port: u16) -> Result<Option<String>> {
+        Ok(self.published_port_owners.get(&port).cloned())
     }
 }
 
@@ -175,6 +186,49 @@ fn mcp_projection_treats_lowercase_docker_exited_as_stopped() {
 }
 
 #[test]
+fn mcp_projection_degrades_hard_diagnostics() {
+    let mut status = ComposeStatus {
+        container_name: "syslog-mcp".into(),
+        container_id: Some("container-id".into()),
+        status: Some("running".into()),
+        health: Some("healthy".into()),
+        image: Some("ghcr.io/jmagar/syslog-mcp:latest".into()),
+        image_id: None,
+        compose_project: Some("syslog-jmagar-lab".into()),
+        compose_working_dir: None,
+        compose_files: Vec::new(),
+        service: Some("syslog-mcp".into()),
+        data_mounts: Vec::new(),
+        ports: Vec::new(),
+        systemd: None,
+        diagnostics: vec![ComposeDiagnostic {
+            severity: DiagnosticSeverity::Unsafe,
+            code: "incomplete_compose_labels".into(),
+            message: "missing labels".into(),
+        }],
+    };
+
+    let projected = mcp_projection(&status);
+    assert_eq!(projected.ownership, ComposeOwnershipState::Unknown);
+    assert_eq!(projected.runtime_state, ComposeRuntimeState::Degraded);
+    assert!(ensure_doctor_ready(&status).is_err());
+
+    status.diagnostics.clear();
+    assert!(ensure_doctor_ready(&status).is_ok());
+}
+
+#[test]
+fn ss_header_only_output_is_not_listener() {
+    assert!(!ss_output_has_listener(
+        b"Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port Process\n"
+    ));
+    assert!(!ss_output_has_listener(b"\n"));
+    assert!(ss_output_has_listener(
+        b"tcp LISTEN 0 4096 0.0.0.0:3100 0.0.0.0:* users:((\"docker-proxy\",pid=123,fd=4))\n"
+    ));
+}
+
+#[test]
 fn resolves_live_container_labels() {
     let service = ComposeService::new(
         FakeInspector {
@@ -188,6 +242,82 @@ fn resolves_live_container_labels() {
     assert_eq!(target.source, TargetSource::LiveContainerLabels);
     assert_eq!(target.confidence, TargetConfidence::Confirmed);
     assert_eq!(target.compose_project.as_deref(), Some("syslog-jmagar-lab"));
+}
+
+#[test]
+fn inspect_json_extracts_compose_fields_ports_and_mounts() {
+    let info = container_info_from_inspect(serde_json::json!({
+        "Id": "abcdef123456",
+        "Name": "/syslog-mcp",
+        "Image": "sha256:image-id",
+        "State": {
+            "Status": "running",
+            "Health": {"Status": "healthy"}
+        },
+        "Config": {
+            "Image": "ghcr.io/jmagar/syslog-mcp:latest",
+            "Labels": {
+                "com.docker.compose.project": "syslog-jmagar-lab",
+                "com.docker.compose.service": "syslog-mcp",
+                "com.docker.compose.project.working_dir": "/srv/syslog",
+                "com.docker.compose.project.config_files": "/srv/syslog/docker-compose.yml"
+            }
+        },
+        "Mounts": [
+            {"Type": "bind", "Source": "/srv/syslog/data", "Destination": "/data"}
+        ],
+        "NetworkSettings": {
+            "Ports": {
+                "3100/tcp": [{"HostIp": "0.0.0.0", "HostPort": "3100"}],
+                "1514/udp": null
+            }
+        }
+    }))
+    .unwrap();
+
+    assert_eq!(info.id, "abcdef123456");
+    assert_eq!(info.name, "syslog-mcp");
+    assert_eq!(info.status.as_deref(), Some("running"));
+    assert_eq!(info.health.as_deref(), Some("healthy"));
+    assert_eq!(
+        info.image.as_deref(),
+        Some("ghcr.io/jmagar/syslog-mcp:latest")
+    );
+    assert_eq!(info.image_id.as_deref(), Some("sha256:image-id"));
+    assert_eq!(info.mounts[0].target, "/data");
+    assert_eq!(info.ports.len(), 2);
+    assert!(info
+        .ports
+        .iter()
+        .any(|port| port.private_port == 3100 && port.public_port == Some(3100)));
+    assert!(info
+        .ports
+        .iter()
+        .any(|port| port.private_port == 1514 && port.public_port.is_none()));
+}
+
+#[test]
+fn cwd_fallback_is_unsafe_and_refused_for_mutation() {
+    let _guard = cwd_lock();
+    let old_cwd = std::env::current_dir().unwrap();
+    let tempdir = tempfile::tempdir().unwrap();
+    std::fs::write(tempdir.path().join("docker-compose.yml"), "services: {}\n").unwrap();
+    std::env::set_current_dir(tempdir.path()).unwrap();
+
+    let service = ComposeService::new(
+        FakeInspector::default(),
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = service.resolve_target(&ComposeTarget::default()).unwrap();
+    assert_eq!(target.source, TargetSource::CurrentWorkingDirectory);
+    assert_eq!(target.confidence, TargetConfidence::Unsafe);
+    let err = service
+        .preflight_mutation(ComposeMutation::Pull, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("cwd target"));
+
+    std::env::set_current_dir(old_cwd).unwrap();
 }
 
 #[test]
@@ -511,6 +641,8 @@ fn up_refuses_non_target_listener() {
 
 #[test]
 fn live_target_allows_listener_on_published_target_port() {
+    let mut owners = BTreeMap::new();
+    owners.insert(3100, "abc".into());
     let service = ComposeService::new(
         FakeInspector {
             container: Some(labelled_container()),
@@ -519,6 +651,7 @@ fn live_target_allows_listener_on_published_target_port() {
                 process: Some("users:((\"docker-proxy\",pid=123,fd=7))".into()),
                 belongs_to_target: false,
             }],
+            published_port_owners: owners,
             ..Default::default()
         },
         FakeRunner,
@@ -528,6 +661,31 @@ fn live_target_allows_listener_on_published_target_port() {
     service
         .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
         .unwrap();
+}
+
+#[test]
+fn live_target_refuses_foreign_docker_proxy_on_published_port() {
+    let mut owners = BTreeMap::new();
+    owners.insert(3100, "foreign-container".into());
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            listeners: vec![ListenerInfo {
+                port: 3100,
+                process: Some("users:((\"docker-proxy\",pid=123,fd=7))".into()),
+                belongs_to_target: false,
+            }],
+            published_port_owners: owners,
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    let err = service
+        .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("non-target listener"));
 }
 
 #[test]
@@ -678,7 +836,7 @@ fn dry_run_does_not_invoke_runner() {
         FakeRunner,
         ComposeDefaults::default(),
     );
-    let output = service
+    let result = service
         .run_mutation(
             ComposeMutation::Pull,
             &ComposeTarget::default(),
@@ -688,7 +846,14 @@ fn dry_run_does_not_invoke_runner() {
             },
         )
         .unwrap();
-    assert!(output.is_none());
+    let ComposeCommandResult::DryRun(dry_run) = result else {
+        panic!("expected dry-run result");
+    };
+    assert!(dry_run.dry_run);
+    assert!(dry_run
+        .command
+        .ends_with(&["pull".into(), "syslog-mcp".into()]));
+    assert_eq!(dry_run.preflight, "passed");
 }
 
 #[test]
@@ -709,6 +874,23 @@ fn logs_invocation_is_bounded_tail() {
 }
 
 #[test]
+fn logs_refuses_unsafe_target() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(unlabelled_container()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let err = service
+        .logs(&ComposeTarget::default(), Some(20))
+        .unwrap_err();
+    assert!(err.to_string().contains("target is not confirmed"));
+}
+
+#[cfg(unix)]
+#[test]
 fn process_runner_truncates_and_redacts_output() {
     let runner = ProcessRunner;
     let invocation = ComposeInvocation {
@@ -728,6 +910,7 @@ fn process_runner_truncates_and_redacts_output() {
     assert!(output.stdout_truncated);
 }
 
+#[cfg(unix)]
 #[test]
 fn process_runner_times_out_and_reports_cleanup() {
     let runner = ProcessRunner;

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -82,6 +82,13 @@ fn labelled_container() -> ContainerInfo {
     }
 }
 
+fn unlabelled_container() -> ContainerInfo {
+    ContainerInfo {
+        labels: BTreeMap::new(),
+        ..labelled_container()
+    }
+}
+
 #[test]
 fn redacts_sensitive_lines() {
     let input = "ok=true\nSYSLOG_MCP_TOKEN=abc\nclient_secret = \"secret\"\nport=3100";
@@ -148,6 +155,52 @@ fn resolves_live_container_labels() {
 }
 
 #[test]
+fn containers_without_required_compose_labels_are_unsafe_for_mutation() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(unlabelled_container()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = service.resolve_target(&ComposeTarget::default()).unwrap();
+    assert_eq!(target.source, TargetSource::LiveContainerLabels);
+    assert_eq!(target.confidence, TargetConfidence::Unsafe);
+    assert_eq!(target.diagnostics[0].code, "incomplete_compose_labels");
+    let err = service
+        .preflight_mutation(ComposeMutation::Down, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("required compose labels"));
+}
+
+#[test]
+fn partial_compose_labels_are_unsafe_for_mutation() {
+    let mut container = labelled_container();
+    container
+        .labels
+        .remove("com.docker.compose.project.config_files");
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(container),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = service.resolve_target(&ComposeTarget::default()).unwrap();
+    assert_eq!(target.confidence, TargetConfidence::Unsafe);
+    let err = service
+        .preflight_mutation(
+            ComposeMutation::Restart,
+            &target,
+            &MutationOptions::default(),
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("required compose labels"));
+}
+
+#[test]
 fn project_name_alone_is_rejected_for_mutation() {
     let service = ComposeService::new(
         FakeInspector::default(),
@@ -181,7 +234,7 @@ fn up_refuses_non_target_listener() {
         FakeInspector {
             listeners: vec![ListenerInfo {
                 port: 3100,
-                process: Some("other".into()),
+                process: Some("users:((\"other\",pid=123,fd=7))".into()),
                 belongs_to_target: false,
             }],
             ..Default::default()
@@ -204,7 +257,7 @@ fn live_target_allows_listener_on_published_target_port() {
             container: Some(labelled_container()),
             listeners: vec![ListenerInfo {
                 port: 3100,
-                process: Some("docker-proxy".into()),
+                process: Some("users:((\"docker-proxy\",pid=123,fd=7))".into()),
                 belongs_to_target: false,
             }],
             ..Default::default()
@@ -226,6 +279,28 @@ fn live_target_refuses_listener_on_unpublished_target_port() {
             listeners: vec![ListenerInfo {
                 port: 1514,
                 process: Some("other".into()),
+                belongs_to_target: false,
+            }],
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    let err = service
+        .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("non-target listener"));
+}
+
+#[test]
+fn live_target_refuses_foreign_listener_even_on_published_port() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            listeners: vec![ListenerInfo {
+                port: 3100,
+                process: Some("users:((\"other\",pid=123,fd=7))".into()),
                 belongs_to_target: false,
             }],
             ..Default::default()
@@ -361,4 +436,26 @@ fn process_runner_times_out_and_reports_cleanup() {
     let output = runner.run(&invocation).unwrap();
     assert!(output.timed_out);
     assert!(output.timeout_cleanup.as_ref().is_some_and(|c| c.reaped));
+}
+
+#[cfg(unix)]
+#[test]
+fn process_runner_kills_term_ignoring_process_group() {
+    let runner = ProcessRunner;
+    let invocation = ComposeInvocation {
+        program: "sh".into(),
+        args: vec![
+            "-c".into(),
+            "trap '' TERM; sh -c 'trap \"\" TERM; while true; do sleep 1; done' & wait".into(),
+        ],
+        current_dir: None,
+        timeout: Duration::from_millis(100),
+        output_limit_bytes: 1024,
+    };
+    let output = runner.run(&invocation).unwrap();
+    assert!(output.timed_out);
+    let cleanup = output.timeout_cleanup.unwrap();
+    assert!(cleanup.terminate_sent);
+    assert!(cleanup.kill_sent);
+    assert!(cleanup.reaped);
 }

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -147,6 +147,30 @@ fn mcp_projection_omits_host_paths_and_image_ids() {
 }
 
 #[test]
+fn mcp_projection_treats_lowercase_docker_exited_as_stopped() {
+    let status = ComposeStatus {
+        container_name: "syslog-mcp".into(),
+        container_id: Some("container-id".into()),
+        status: Some("exited".into()),
+        health: None,
+        image: Some("ghcr.io/jmagar/syslog-mcp:latest".into()),
+        image_id: Some("sha256:secret-image-id".into()),
+        compose_project: Some("syslog-jmagar-lab".into()),
+        compose_working_dir: None,
+        compose_files: Vec::new(),
+        service: Some("syslog-mcp".into()),
+        data_mounts: Vec::new(),
+        ports: Vec::new(),
+        systemd: None,
+        diagnostics: vec![],
+    };
+
+    let projected = mcp_projection(&status);
+
+    assert_eq!(projected.runtime_state, ComposeRuntimeState::Stopped);
+}
+
+#[test]
 fn resolves_live_container_labels() {
     let service = ComposeService::new(
         FakeInspector {

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -10,6 +10,8 @@ struct FakeInspector {
     candidates: Vec<ContainerInfo>,
     systemd: Option<SystemdStatus>,
     listeners: Vec<ListenerInfo>,
+    systemd_error: Option<String>,
+    listeners_error: Option<String>,
 }
 
 impl DockerInspect for FakeInspector {
@@ -22,10 +24,16 @@ impl DockerInspect for FakeInspector {
     }
 
     fn systemd_status(&self, _unit: &str) -> Result<Option<SystemdStatus>> {
+        if let Some(error) = &self.systemd_error {
+            anyhow::bail!("{error}");
+        }
         Ok(self.systemd.clone())
     }
 
     fn listeners(&self, _ports: &[u16]) -> Result<Vec<ListenerInfo>> {
+        if let Some(error) = &self.listeners_error {
+            anyhow::bail!("{error}");
+        }
         Ok(self.listeners.clone())
     }
 }
@@ -155,6 +163,53 @@ fn resolves_live_container_labels() {
 }
 
 #[test]
+fn requested_project_or_service_must_match_live_labels() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let err = service
+        .resolve_target(&ComposeTarget {
+            project_name: Some("staging".into()),
+            ..Default::default()
+        })
+        .unwrap_err();
+    assert!(err.to_string().contains("project_name"));
+
+    let err = service
+        .resolve_target(&ComposeTarget {
+            service: Some("other".into()),
+            ..Default::default()
+        })
+        .unwrap_err();
+    assert!(err.to_string().contains("service"));
+}
+
+#[test]
+fn matching_requested_selectors_are_accepted() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = service
+        .resolve_target(&ComposeTarget {
+            project_name: Some("syslog-jmagar-lab".into()),
+            service: Some("syslog-mcp".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(target.confidence, TargetConfidence::Confirmed);
+}
+
+#[test]
 fn containers_without_required_compose_labels_are_unsafe_for_mutation() {
     let service = ComposeService::new(
         FakeInspector {
@@ -226,6 +281,104 @@ fn project_name_alone_is_rejected_for_mutation() {
         .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
         .unwrap_err();
     assert!(err.to_string().contains("--project-name alone"));
+}
+
+#[test]
+fn up_refuses_active_systemd_owner() {
+    let service = ComposeService::new(
+        FakeInspector {
+            systemd: Some(SystemdStatus {
+                unit: "syslog-mcp.service".into(),
+                active: true,
+            }),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    let err = service
+        .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("systemd"));
+}
+
+#[test]
+fn mutation_refuses_unverified_systemd_or_listener_state() {
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    let systemd_service = ComposeService::new(
+        FakeInspector {
+            systemd_error: Some("systemctl unavailable".into()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let err = systemd_service
+        .preflight_mutation(
+            ComposeMutation::Restart,
+            &target,
+            &MutationOptions::default(),
+        )
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("could not verify systemd ownership"));
+
+    let listener_service = ComposeService::new(
+        FakeInspector {
+            listeners_error: Some("ss unavailable".into()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let err = listener_service
+        .preflight_mutation(
+            ComposeMutation::Restart,
+            &target,
+            &MutationOptions::default(),
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("could not verify port listeners"));
+}
+
+#[test]
+fn down_requires_yes_and_stops_only_target_service() {
+    let service = ComposeService::new(
+        FakeInspector::default(),
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    let err = service
+        .preflight_mutation(
+            ComposeMutation::Down,
+            &target,
+            &MutationOptions {
+                non_interactive: true,
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+    assert!(err.to_string().contains("--yes"));
+
+    service
+        .preflight_mutation(
+            ComposeMutation::Down,
+            &target,
+            &MutationOptions {
+                non_interactive: true,
+                yes: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let invocation = service.compose_invocation(&target, ComposeMutation::Down);
+    assert!(invocation
+        .args
+        .ends_with(&["stop".into(), "syslog-mcp".into()]));
+    assert!(!invocation.args.iter().any(|arg| arg == "down"));
 }
 
 #[test]
@@ -361,6 +514,30 @@ fn up_invocation_is_detached_and_uses_project_directory_and_all_files() {
             "syslog-mcp",
         ]
     );
+}
+
+#[test]
+fn mutation_invocations_scope_service_where_supported() {
+    let service = ComposeService::new(
+        FakeInspector::default(),
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    for (mutation, expected) in [
+        (ComposeMutation::Pull, vec!["pull", "syslog-mcp"]),
+        (ComposeMutation::Restart, vec!["restart", "syslog-mcp"]),
+        (ComposeMutation::Down, vec!["stop", "syslog-mcp"]),
+    ] {
+        let invocation = service.compose_invocation(&target, mutation);
+        assert!(
+            invocation
+                .args
+                .ends_with(&expected.iter().map(|s| s.to_string()).collect::<Vec<_>>()),
+            "unexpected args for {mutation:?}: {:?}",
+            invocation.args
+        );
+    }
 }
 
 #[test]

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -1,0 +1,364 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::*;
+
+#[derive(Default)]
+struct FakeInspector {
+    container: Option<ContainerInfo>,
+    candidates: Vec<ContainerInfo>,
+    systemd: Option<SystemdStatus>,
+    listeners: Vec<ListenerInfo>,
+}
+
+impl DockerInspect for FakeInspector {
+    fn inspect_container(&self, _name: &str) -> Result<Option<ContainerInfo>> {
+        Ok(self.container.clone())
+    }
+
+    fn find_candidates(&self, _service: &str, _container_name: &str) -> Result<Vec<ContainerInfo>> {
+        Ok(self.candidates.clone())
+    }
+
+    fn systemd_status(&self, _unit: &str) -> Result<Option<SystemdStatus>> {
+        Ok(self.systemd.clone())
+    }
+
+    fn listeners(&self, _ports: &[u16]) -> Result<Vec<ListenerInfo>> {
+        Ok(self.listeners.clone())
+    }
+}
+
+#[derive(Default)]
+struct FakeRunner;
+
+impl CommandRunner for FakeRunner {
+    fn run(&self, _invocation: &ComposeInvocation) -> Result<CommandOutput> {
+        Ok(CommandOutput {
+            exit_status: Some(0),
+            stdout: String::new(),
+            stderr: String::new(),
+            stdout_truncated: false,
+            stderr_truncated: false,
+            timed_out: false,
+            timeout_cleanup: None,
+        })
+    }
+}
+
+fn labelled_container() -> ContainerInfo {
+    let compose_file = std::env::current_dir().unwrap().join("docker-compose.yml");
+    let project_dir = compose_file.parent().unwrap().to_path_buf();
+    let mut labels = BTreeMap::new();
+    labels.insert(
+        "com.docker.compose.project".into(),
+        "syslog-jmagar-lab".into(),
+    );
+    labels.insert(
+        "com.docker.compose.project.working_dir".into(),
+        project_dir.display().to_string(),
+    );
+    labels.insert(
+        "com.docker.compose.project.config_files".into(),
+        compose_file.display().to_string(),
+    );
+    labels.insert("com.docker.compose.service".into(), "syslog-mcp".into());
+    ContainerInfo {
+        id: "abc".into(),
+        name: "syslog-mcp".into(),
+        status: Some("Up".into()),
+        health: Some("healthy".into()),
+        image: Some("ghcr.io/jmagar/syslog-mcp:latest".into()),
+        image_id: Some("sha256:abc".into()),
+        labels,
+        mounts: Vec::new(),
+        ports: vec![PortInfo {
+            private_port: 3100,
+            public_port: Some(3100),
+            protocol: "tcp".into(),
+            host_ip: Some("0.0.0.0".into()),
+        }],
+    }
+}
+
+#[test]
+fn redacts_sensitive_lines() {
+    let input = "ok=true\nSYSLOG_MCP_TOKEN=abc\nclient_secret = \"secret\"\nport=3100";
+    let redacted = redact_sensitive(input);
+    assert!(redacted.contains("ok=true"));
+    assert!(redacted.contains("port=3100"));
+    assert!(!redacted.contains("abc"));
+    assert!(!redacted.contains("client_secret"));
+    assert_eq!(redacted.matches("[REDACTED]").count(), 2);
+}
+
+#[test]
+fn mcp_projection_omits_host_paths_and_image_ids() {
+    let status = ComposeStatus {
+        container_name: "syslog-mcp".into(),
+        container_id: Some("container-id".into()),
+        status: Some("Up 1 minute".into()),
+        health: Some("healthy".into()),
+        image: Some("ghcr.io/jmagar/syslog-mcp:latest".into()),
+        image_id: Some("sha256:secret-image-id".into()),
+        compose_project: Some("syslog-jmagar-lab".into()),
+        compose_working_dir: Some(PathBuf::from("/home/jmagar/private")),
+        compose_files: vec![PathBuf::from("/home/jmagar/private/docker-compose.yml")],
+        service: Some("syslog-mcp".into()),
+        data_mounts: vec![MountInfo {
+            source: Some(PathBuf::from("/home/jmagar/private/data")),
+            target: "/data".into(),
+            kind: "bind".into(),
+        }],
+        ports: vec![PortInfo {
+            private_port: 3100,
+            public_port: Some(3100),
+            protocol: "tcp".into(),
+            host_ip: Some("0.0.0.0".into()),
+        }],
+        systemd: None,
+        diagnostics: vec![],
+    };
+
+    let projected = mcp_projection(&status);
+    let json = serde_json::to_string(&projected).unwrap();
+    assert_eq!(projected.ownership, ComposeOwnershipState::ComposeOwned);
+    assert_eq!(projected.runtime_state, ComposeRuntimeState::Healthy);
+    assert!(json.contains("3100"));
+    assert!(!json.contains("/home/jmagar"));
+    assert!(!json.contains("secret-image-id"));
+    assert!(!json.contains("/data"));
+}
+
+#[test]
+fn resolves_live_container_labels() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = service.resolve_target(&ComposeTarget::default()).unwrap();
+    assert_eq!(target.source, TargetSource::LiveContainerLabels);
+    assert_eq!(target.confidence, TargetConfidence::Confirmed);
+    assert_eq!(target.compose_project.as_deref(), Some("syslog-jmagar-lab"));
+}
+
+#[test]
+fn project_name_alone_is_rejected_for_mutation() {
+    let service = ComposeService::new(
+        FakeInspector::default(),
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = ResolvedComposeTarget {
+        target: ComposeTargetSummary {
+            project_dir: None,
+            compose_file: None,
+            project_name: Some("syslog".into()),
+            service: "syslog-mcp".into(),
+            container_name: "syslog-mcp".into(),
+        },
+        source: TargetSource::Explicit,
+        confidence: TargetConfidence::Confirmed,
+        diagnostics: Vec::new(),
+        compose_files: Vec::new(),
+        compose_working_dir: None,
+        compose_project: Some("syslog".into()),
+    };
+    let err = service
+        .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("--project-name alone"));
+}
+
+#[test]
+fn up_refuses_non_target_listener() {
+    let service = ComposeService::new(
+        FakeInspector {
+            listeners: vec![ListenerInfo {
+                port: 3100,
+                process: Some("other".into()),
+                belongs_to_target: false,
+            }],
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let mut target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    target.source = TargetSource::Explicit;
+    let err = service
+        .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("non-target listener"));
+}
+
+#[test]
+fn live_target_allows_listener_on_published_target_port() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            listeners: vec![ListenerInfo {
+                port: 3100,
+                process: Some("docker-proxy".into()),
+                belongs_to_target: false,
+            }],
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    service
+        .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
+        .unwrap();
+}
+
+#[test]
+fn live_target_refuses_listener_on_unpublished_target_port() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            listeners: vec![ListenerInfo {
+                port: 1514,
+                process: Some("other".into()),
+                belongs_to_target: false,
+            }],
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    let err = service
+        .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("non-target listener"));
+}
+
+#[test]
+fn up_invocation_is_detached_and_uses_project_directory_and_all_files() {
+    let service = ComposeService::new(
+        FakeInspector::default(),
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = ResolvedComposeTarget {
+        target: ComposeTargetSummary {
+            project_dir: Some(PathBuf::from("/tmp/project")),
+            compose_file: Some(PathBuf::from("/tmp/project/base.yml")),
+            project_name: Some("syslog-jmagar-lab".into()),
+            service: "syslog-mcp".into(),
+            container_name: "syslog-mcp".into(),
+        },
+        source: TargetSource::LiveContainerLabels,
+        confidence: TargetConfidence::Confirmed,
+        diagnostics: Vec::new(),
+        compose_files: vec![
+            PathBuf::from("/tmp/project/base.yml"),
+            PathBuf::from("/tmp/project/override.yml"),
+        ],
+        compose_working_dir: Some(PathBuf::from("/tmp/project")),
+        compose_project: Some("syslog-jmagar-lab".into()),
+    };
+
+    let invocation = service.compose_invocation(&target, ComposeMutation::Up);
+    assert_eq!(invocation.program, "docker");
+    assert_eq!(invocation.current_dir, Some(PathBuf::from("/tmp/project")));
+    assert_eq!(
+        invocation.args,
+        vec![
+            "compose",
+            "--project-directory",
+            "/tmp/project",
+            "-f",
+            "/tmp/project/base.yml",
+            "-f",
+            "/tmp/project/override.yml",
+            "--project-name",
+            "syslog-jmagar-lab",
+            "up",
+            "-d",
+            "syslog-mcp",
+        ]
+    );
+}
+
+#[test]
+fn dry_run_does_not_invoke_runner() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let output = service
+        .run_mutation(
+            ComposeMutation::Pull,
+            &ComposeTarget::default(),
+            &MutationOptions {
+                dry_run: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert!(output.is_none());
+}
+
+#[test]
+fn logs_invocation_is_bounded_tail() {
+    let service = ComposeService::new(
+        FakeInspector::default(),
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    let invocation = service.logs_invocation(&target, 20);
+    assert!(invocation.args.ends_with(&[
+        "logs".into(),
+        "--tail".into(),
+        "20".into(),
+        "syslog-mcp".into(),
+    ]));
+}
+
+#[test]
+fn process_runner_truncates_and_redacts_output() {
+    let runner = ProcessRunner;
+    let invocation = ComposeInvocation {
+        program: "sh".into(),
+        args: vec![
+            "-c".into(),
+            "printf 'token=secret-value\\nvisible-line\\nmore-output\\n'".into(),
+        ],
+        current_dir: None,
+        timeout: Duration::from_secs(5),
+        output_limit_bytes: 32,
+    };
+    let output = runner.run(&invocation).unwrap();
+    assert_eq!(output.exit_status, Some(0));
+    assert!(output.stdout.contains("[REDACTED]"));
+    assert!(!output.stdout.contains("secret-value"));
+    assert!(output.stdout_truncated);
+}
+
+#[test]
+fn process_runner_times_out_and_reports_cleanup() {
+    let runner = ProcessRunner;
+    let invocation = ComposeInvocation {
+        program: "sh".into(),
+        args: vec!["-c".into(), "sleep 5".into()],
+        current_dir: None,
+        timeout: Duration::from_millis(100),
+        output_limit_bytes: 1024,
+    };
+    let output = runner.run(&invocation).unwrap();
+    assert!(output.timed_out);
+    assert!(output.timeout_cleanup.as_ref().is_some_and(|c| c.reaped));
+}

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -1,5 +1,9 @@
 use std::collections::BTreeMap;
+#[cfg(unix)]
+use std::os::unix::process::ExitStatusExt;
 use std::path::PathBuf;
+#[cfg(unix)]
+use std::process::Output;
 use std::time::Duration;
 
 use super::*;
@@ -231,6 +235,39 @@ fn matching_requested_selectors_are_accepted() {
         })
         .unwrap();
     assert_eq!(target.confidence, TargetConfidence::Confirmed);
+}
+
+#[cfg(unix)]
+fn output_with_status(code: i32, stdout: &str, stderr: &str) -> Output {
+    Output {
+        status: std::process::ExitStatus::from_raw(code << 8),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: stderr.as_bytes().to_vec(),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn systemd_status_distinguishes_inactive_from_probe_failure() {
+    let active = systemd_status_from_output("syslog-mcp.service", &output_with_status(0, "", ""))
+        .unwrap()
+        .unwrap();
+    assert!(active.active);
+
+    let inactive = systemd_status_from_output(
+        "syslog-mcp.service",
+        &output_with_status(3, "inactive\n", ""),
+    )
+    .unwrap()
+    .unwrap();
+    assert!(!inactive.active);
+
+    let failed = systemd_status_from_output(
+        "syslog-mcp.service",
+        &output_with_status(1, "", "dbus unavailable"),
+    )
+    .unwrap_err();
+    assert!(failed.to_string().contains("probe failure") || failed.to_string().contains("failed"));
 }
 
 #[test]

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -60,7 +60,7 @@ impl CommandRunner for FakeRunner {
 }
 
 fn labelled_container() -> ContainerInfo {
-    let compose_file = std::env::current_dir().unwrap().join("docker-compose.yml");
+    let compose_file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("docker-compose.yml");
     let project_dir = compose_file.parent().unwrap().to_path_buf();
     let mut labels = BTreeMap::new();
     labels.insert(
@@ -432,6 +432,24 @@ fn mutation_refuses_unverified_systemd_or_listener_state() {
 }
 
 #[test]
+fn pull_does_not_require_systemd_or_listener_probes() {
+    let service = ComposeService::new(
+        FakeInspector {
+            systemd_error: Some("systemctl unavailable".into()),
+            listeners_error: Some("ss unavailable".into()),
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+
+    service
+        .preflight_mutation(ComposeMutation::Pull, &target, &MutationOptions::default())
+        .unwrap();
+}
+
+#[test]
 fn down_requires_yes_and_stops_only_target_service() {
     let service = ComposeService::new(
         FakeInspector::default(),
@@ -542,6 +560,28 @@ fn live_target_refuses_foreign_listener_even_on_published_port() {
             listeners: vec![ListenerInfo {
                 port: 3100,
                 process: Some("users:((\"other\",pid=123,fd=7))".into()),
+                belongs_to_target: false,
+            }],
+            ..Default::default()
+        },
+        FakeRunner,
+        ComposeDefaults::default(),
+    );
+    let target = target_from_container(&labelled_container(), &ComposeDefaults::default());
+    let err = service
+        .preflight_mutation(ComposeMutation::Up, &target, &MutationOptions::default())
+        .unwrap_err();
+    assert!(err.to_string().contains("non-target listener"));
+}
+
+#[test]
+fn live_target_refuses_published_listener_with_unknown_owner() {
+    let service = ComposeService::new(
+        FakeInspector {
+            container: Some(labelled_container()),
+            listeners: vec![ListenerInfo {
+                port: 3100,
+                process: Some("LISTEN 0 4096 0.0.0.0:3100 0.0.0.0:*".into()),
                 belongs_to_target: false,
             }],
             ..Default::default()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod api;
 pub mod app;
+pub mod compose;
 pub mod config;
 pub mod mcp;
 pub mod observability;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,9 @@ async fn serve_stdio_mcp() -> Result<()> {
 }
 
 async fn run_cli(command: cli::CliCommand) -> Result<()> {
+    if matches!(command, cli::CliCommand::Compose(_)) {
+        return cli::run_compose(command);
+    }
     let runtime = RuntimeCore::load_query_only().await?;
     cli::run(runtime.service(), command).await
 }
@@ -140,6 +143,7 @@ impl Mode {
                         | "ai"
                         | "correlate"
                         | "stats"
+                        | "compose"
                 ) =>
             {
                 let mut cli_args = Vec::with_capacity(rest.len() + 1);
@@ -183,6 +187,11 @@ fn print_usage() {
   syslog ai projects [--tool TOOL] [--from TIME] [--to TIME] [--json]
   syslog ai index [--path PATH] [--json]
   syslog ai add --file FILE [--json]
+  syslog compose doctor [--json]
+  syslog compose status [--compose-file FILE] [--project-dir DIR] [--project-name NAME] [--json]
+  syslog compose pull|up|restart [--dry-run] [--allow-cwd-target] [--json]
+  syslog compose down --yes [--dry-run] [--allow-cwd-target] [--json]
+  syslog compose logs [--tail N] [--json]
   syslog correlate --reference-time TIME [--window-minutes N] [--severity-min LEVEL] [--hostname HOST] [--source-ip SOURCE] [--query FTS] [--limit N] [--json]
   syslog stats [--json]
 

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -38,3 +38,11 @@ fn mode_parse_accepts_ai_namespace() {
         Mode::Cli(_)
     ));
 }
+
+#[test]
+fn mode_parse_accepts_compose_namespace() {
+    assert!(matches!(
+        Mode::parse(vec!["compose".into(), "status".into(), "--json".into()]).unwrap(),
+        Mode::Cli(_)
+    ));
+}

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -55,6 +55,8 @@ const READ_ONLY_ACTIONS: &[&str] = &[
     "clock_skew",
     "anomalies",
     "compare",
+    "compose_status",
+    "compose_doctor",
 ];
 
 impl SyslogRmcpServer {
@@ -273,6 +275,7 @@ fn is_validation_error(error: &anyhow::Error) -> bool {
     ) || error.to_string().contains(" is required")
         || error.to_string().contains("must be an unsigned integer")
         || error.to_string().contains(" must be <=")
+        || error.to_string().contains("target override")
         || error.to_string().contains("unknown syslog action")
 }
 

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -680,6 +680,12 @@ fn sessions_action_requires_read_scope() {
     assert_eq!(required_scope_for("sessions"), Some("syslog:read"));
 }
 
+#[test]
+fn compose_actions_require_read_scope() {
+    assert_eq!(required_scope_for("compose_status"), Some("syslog:read"));
+    assert_eq!(required_scope_for("compose_doctor"), Some("syslog:read"));
+}
+
 /// `AuthPolicy::Mounted` + AuthContext with `syslog:admin` (superset) → read
 /// actions permitted because `syslog:admin` implies `syslog:read`.
 #[tokio::test]

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -26,6 +26,8 @@ pub(super) const SYSLOG_ACTIONS: &[&str] = &[
     "clock_skew",
     "anomalies",
     "compare",
+    "compose_status",
+    "compose_doctor",
     "help",
 ];
 
@@ -33,7 +35,7 @@ pub(super) const SYSLOG_ACTIONS: &[&str] = &[
 pub(super) fn tool_definitions() -> Vec<Value> {
     vec![json!({
         "name": "syslog",
-        "description": "Query syslog-mcp logs with action-based subcommands: syslog search, syslog tail, syslog errors, syslog hosts, syslog correlate, syslog stats, syslog status, syslog apps, syslog sessions, syslog search_sessions, syslog usage_blocks, syslog project_context, syslog list_ai_tools, syslog list_ai_projects, syslog source_ips, syslog timeline, syslog patterns, syslog context, syslog get, syslog ingest_rate, syslog silent_hosts, syslog clock_skew, syslog anomalies, syslog compare, and syslog help.",
+        "description": "Query syslog-mcp logs with action-based subcommands: syslog search, syslog tail, syslog errors, syslog hosts, syslog correlate, syslog stats, syslog status, syslog apps, syslog sessions, syslog search_sessions, syslog usage_blocks, syslog project_context, syslog list_ai_tools, syslog list_ai_projects, syslog source_ips, syslog timeline, syslog patterns, syslog context, syslog get, syslog ingest_rate, syslog silent_hosts, syslog clock_skew, syslog anomalies, syslog compare, syslog compose_status, syslog compose_doctor, and syslog help.",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -771,8 +771,10 @@ output are omitted.
 ---
 
 ## syslog compose_doctor
-Alias of `compose_status` intended for deployment-health checks. Lifecycle
-mutations remain CLI-only.
+Strict deployment-health check for the canonical syslog-mcp Compose deployment.
+Returns the same redacted diagnostic shape as `compose_status` when healthy, and
+returns a tool error when Docker/Compose ownership or runtime checks are not
+ready for lifecycle work. Lifecycle mutations remain CLI-only.
 
 **Parameters:** none. Target override fields are rejected.
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -232,12 +232,21 @@ fn reject_compose_target_overrides(args: &Value) -> anyhow::Result<()> {
 
 async fn tool_compose_status(args: Value) -> anyhow::Result<Value> {
     reject_compose_target_overrides(&args)?;
+    static COMPOSE_DIAGNOSTICS: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
+        std::sync::OnceLock::new();
+    let permit = COMPOSE_DIAGNOSTICS
+        .get_or_init(|| std::sync::Arc::new(tokio::sync::Semaphore::new(2)))
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|e| anyhow::anyhow!("compose diagnostics limiter closed: {e}"))?;
     let service = crate::compose::ComposeService::new(
         crate::compose::CliDockerInspect,
         crate::compose::ProcessRunner,
         crate::compose::ComposeDefaults::default(),
     );
     let status = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
         service.status(&crate::compose::ComposeTarget::default())
     })
     .await

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -52,7 +52,7 @@ async fn tool_syslog(state: &AppState, args: Value) -> anyhow::Result<Value> {
         "anomalies" => tool_anomalies(state, args).await,
         "compare" => tool_compare(state, args).await,
         "compose_status" => tool_compose_status(args).await,
-        "compose_doctor" => tool_compose_status(args).await,
+        "compose_doctor" => tool_compose_doctor(args).await,
         "help" => tool_syslog_help().await,
         _ => Err(anyhow::anyhow!(
             "unknown syslog action: {action}; expected one of {}",
@@ -233,6 +233,22 @@ fn reject_compose_target_overrides(args: &Value) -> anyhow::Result<()> {
 
 async fn tool_compose_status(args: Value) -> anyhow::Result<Value> {
     reject_compose_target_overrides(&args)?;
+    let status = compose_status().await?;
+    Ok(serde_json::to_value(crate::compose::mcp_projection(
+        &status,
+    ))?)
+}
+
+async fn tool_compose_doctor(args: Value) -> anyhow::Result<Value> {
+    reject_compose_target_overrides(&args)?;
+    let status = compose_status().await?;
+    crate::compose::ensure_doctor_ready(&status)?;
+    Ok(serde_json::to_value(crate::compose::mcp_projection(
+        &status,
+    ))?)
+}
+
+async fn compose_status() -> anyhow::Result<crate::compose::ComposeStatus> {
     static COMPOSE_DIAGNOSTICS: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
         std::sync::OnceLock::new();
     let permit = COMPOSE_DIAGNOSTICS
@@ -252,9 +268,7 @@ async fn tool_compose_status(args: Value) -> anyhow::Result<Value> {
     })
     .await
     .map_err(|e| anyhow::anyhow!("compose status task failed: {e}"))??;
-    Ok(serde_json::to_value(crate::compose::mcp_projection(
-        &status,
-    ))?)
+    Ok(status)
 }
 
 async fn tool_timeline(state: &AppState, args: Value) -> anyhow::Result<Value> {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -222,6 +222,7 @@ fn reject_compose_target_overrides(args: &Value) -> anyhow::Result<()> {
         "project_dir",
         "compose_file",
         "project_name",
+        "service",
     ] {
         if args.get(key).is_some() {
             anyhow::bail!("compose MCP actions do not accept target override: {key}");

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -51,6 +51,8 @@ async fn tool_syslog(state: &AppState, args: Value) -> anyhow::Result<Value> {
         "clock_skew" => tool_clock_skew(state, args).await,
         "anomalies" => tool_anomalies(state, args).await,
         "compare" => tool_compare(state, args).await,
+        "compose_status" => tool_compose_status(args).await,
+        "compose_doctor" => tool_compose_status(args).await,
         "help" => tool_syslog_help().await,
         _ => Err(anyhow::anyhow!(
             "unknown syslog action: {action}; expected one of {}",
@@ -211,6 +213,38 @@ async fn tool_list_source_ips(state: &AppState, _args: Value) -> anyhow::Result<
         "list_source_ips completed"
     );
     Ok(serde_json::to_value(response)?)
+}
+
+fn reject_compose_target_overrides(args: &Value) -> anyhow::Result<()> {
+    for key in [
+        "container",
+        "container_name",
+        "project_dir",
+        "compose_file",
+        "project_name",
+    ] {
+        if args.get(key).is_some() {
+            anyhow::bail!("compose MCP actions do not accept target override: {key}");
+        }
+    }
+    Ok(())
+}
+
+async fn tool_compose_status(args: Value) -> anyhow::Result<Value> {
+    reject_compose_target_overrides(&args)?;
+    let service = crate::compose::ComposeService::new(
+        crate::compose::CliDockerInspect,
+        crate::compose::ProcessRunner,
+        crate::compose::ComposeDefaults::default(),
+    );
+    let status = tokio::task::spawn_blocking(move || {
+        service.status(&crate::compose::ComposeTarget::default())
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("compose status task failed: {e}"))??;
+    Ok(serde_json::to_value(crate::compose::mcp_projection(
+        &status,
+    ))?)
 }
 
 async fn tool_timeline(state: &AppState, args: Value) -> anyhow::Result<Value> {
@@ -700,6 +734,23 @@ Get lightweight runtime status without full DB statistics. Use this for dashboar
 doctor checks that need queue/backpressure/writer state quickly.
 
 **Parameters:** none
+
+---
+
+## syslog compose_status
+Read-only Docker Compose diagnostics for the canonical syslog-mcp deployment.
+The response is MCP-safe: host paths, image ids, mount sources, and raw command
+output are omitted.
+
+**Parameters:** none. Target override fields are rejected.
+
+---
+
+## syslog compose_doctor
+Alias of `compose_status` intended for deployment-health checks. Lifecycle
+mutations remain CLI-only.
+
+**Parameters:** none. Target override fields are rejected.
 
 ---
 

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -211,6 +211,19 @@ async fn syslog_tool_requires_known_action() {
     assert!(unknown.to_string().contains("unknown syslog action"));
 }
 
+#[tokio::test]
+async fn compose_action_rejects_target_override() {
+    let h = TestHarness::new();
+    let err = execute_tool(
+        &h.state,
+        "syslog",
+        json!({"action": "compose_status", "project_dir": "/home/jmagar"}),
+    )
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("target override"));
+}
+
 #[test]
 fn parse_optional_timestamp_normalizes_offsets_to_utc() {
     let parsed = crate::app::parse_optional_timestamp(Some("2026-01-01T01:00:00+01:00"), "from")

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -138,9 +138,18 @@ async fn schema_actions_are_dispatchable() {
             }
             _ => json!({"action": action}),
         };
-        execute_tool(&h.state, "syslog", args)
-            .await
-            .unwrap_or_else(|error| panic!("schema action {action} did not dispatch: {error}"));
+        let result = execute_tool(&h.state, "syslog", args).await;
+        if *action == "compose_doctor" {
+            if let Err(error) = result {
+                assert!(
+                    error.to_string().contains("compose doctor failed"),
+                    "compose_doctor failed before dispatching: {error}"
+                );
+            }
+        } else {
+            result
+                .unwrap_or_else(|error| panic!("schema action {action} did not dispatch: {error}"));
+        }
     }
 }
 
@@ -215,7 +224,14 @@ async fn syslog_tool_requires_known_action() {
 async fn compose_action_rejects_target_override() {
     let h = TestHarness::new();
     for action in ["compose_status", "compose_doctor"] {
-        for key in ["project_dir", "service"] {
+        for key in [
+            "container",
+            "container_name",
+            "project_dir",
+            "compose_file",
+            "project_name",
+            "service",
+        ] {
             let mut args = json!({"action": action});
             args.as_object_mut()
                 .unwrap()

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -214,14 +214,19 @@ async fn syslog_tool_requires_known_action() {
 #[tokio::test]
 async fn compose_action_rejects_target_override() {
     let h = TestHarness::new();
-    let err = execute_tool(
-        &h.state,
-        "syslog",
-        json!({"action": "compose_status", "project_dir": "/home/jmagar"}),
-    )
-    .await
-    .unwrap_err();
-    assert!(err.to_string().contains("target override"));
+    for action in ["compose_status", "compose_doctor"] {
+        for key in ["project_dir", "service"] {
+            let mut args = json!({"action": action});
+            args.as_object_mut()
+                .unwrap()
+                .insert(key.into(), json!("override-value"));
+            let err = execute_tool(&h.state, "syslog", args).await.unwrap_err();
+            assert!(
+                err.to_string().contains("target override"),
+                "expected target override rejection for {action}.{key}, got: {err}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -466,6 +466,7 @@ suite_meta() {
   run_test "syslog stats: free_disk_mb field present"  syslog stats   '{}' "free_disk_mb"
   run_test "syslog compose_status: redacted diagnostics" syslog compose_status '{}' "runtime_state"
   run_test "syslog compose_doctor: redacted diagnostics" syslog compose_doctor '{}' "ownership"
+  run_test "syslog compose_doctor: published ports present" syslog compose_doctor '{}' "published_ports"
 }
 
 suite_hosts() {

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -465,8 +465,18 @@ suite_meta() {
   run_test "syslog stats: write_blocked field present" syslog stats   '{}' "write_blocked"
   run_test "syslog stats: free_disk_mb field present"  syslog stats   '{}' "free_disk_mb"
   run_test "syslog compose_status: redacted diagnostics" syslog compose_status '{}' "runtime_state"
-  run_test "syslog compose_doctor: redacted diagnostics" syslog compose_doctor '{}' "ownership"
-  run_test "syslog compose_doctor: published ports present" syslog compose_doctor '{}' "published_ports"
+
+  local compose_status compose_runtime compose_ownership
+  compose_status="$(mcporter_call syslog compose_status '{}')" || compose_status=""
+  compose_runtime="$(printf '%s' "${compose_status}" | jq -r '.runtime_state // "unknown"' 2>/dev/null)" || compose_runtime="unknown"
+  compose_ownership="$(printf '%s' "${compose_status}" | jq -r '.ownership // "unknown"' 2>/dev/null)" || compose_ownership="unknown"
+  if [[ "${compose_runtime}" != "docker_unavailable" && "${compose_ownership}" == "compose_owned" ]]; then
+    run_test "syslog compose_doctor: redacted diagnostics" syslog compose_doctor '{}' "ownership"
+    run_test "syslog compose_doctor: published ports present" syslog compose_doctor '{}' "published_ports"
+  else
+    skip_test "syslog compose_doctor: redacted diagnostics" "runtime=${compose_runtime}, ownership=${compose_ownership}"
+    skip_test "syslog compose_doctor: published ports present" "runtime=${compose_runtime}, ownership=${compose_ownership}"
+  fi
 }
 
 suite_hosts() {

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -9,7 +9,8 @@
 #   syslog list_ai_tools, syslog list_ai_projects, syslog correlate, syslog stats, syslog status, syslog apps,
 #   syslog source_ips, syslog timeline, syslog patterns, syslog context,
 #   syslog get, syslog ingest_rate, syslog silent_hosts, syslog clock_skew,
-#   syslog anomalies, syslog compare, syslog help
+#   syslog anomalies, syslog compare, syslog compose_status,
+#   syslog compose_doctor, syslog help
 #
 # The server runs as a Docker container over HTTP. No stdio launch needed.
 # Credentials are sourced from ~/.claude-homelab/.env:

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -464,6 +464,8 @@ suite_meta() {
   run_test "syslog stats: returns database statistics" syslog stats   '{}' "total_logs"
   run_test "syslog stats: write_blocked field present" syslog stats   '{}' "write_blocked"
   run_test "syslog stats: free_disk_mb field present"  syslog stats   '{}' "free_disk_mb"
+  run_test "syslog compose_status: redacted diagnostics" syslog compose_status '{}' "runtime_state"
+  run_test "syslog compose_doctor: redacted diagnostics" syslog compose_doctor '{}' "ownership"
 }
 
 suite_hosts() {

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -454,19 +454,14 @@ phase_tools() {
   if [[ "${compose_runtime}" != "docker_unavailable" && "${compose_ownership}" == "compose_owned" ]]; then
     assert_jq "syslog compose_status — ownership known" "${compose_status_result}" '.ownership != "unknown"'
     assert_jq "syslog compose_status — no unsafe diagnostics" "${compose_status_result}" '[.diagnostics[]?.severity] | all(. != "error" and . != "unsafe")'
-  else
-    _skip "syslog compose_status strict diagnostics" "runtime=${compose_runtime}, ownership=${compose_ownership}"
-  fi
 
-  local compose_doctor_result
-  compose_doctor_result="$(call_tool syslog '{"action":"compose_doctor"}')" || compose_doctor_result=""
-  assert_jq "syslog compose_doctor — ownership present" "${compose_doctor_result}" '.ownership'
-  assert_jq "syslog compose_doctor — runtime_state present" "${compose_doctor_result}" '.runtime_state'
-  compose_runtime="$(printf '%s' "${compose_doctor_result}" | jq -r '.runtime_state // "unknown"' 2>/dev/null)" || compose_runtime="unknown"
-  compose_ownership="$(printf '%s' "${compose_doctor_result}" | jq -r '.ownership // "unknown"' 2>/dev/null)" || compose_ownership="unknown"
-  if [[ "${compose_runtime}" != "docker_unavailable" && "${compose_ownership}" == "compose_owned" ]]; then
+    local compose_doctor_result
+    compose_doctor_result="$(call_tool syslog '{"action":"compose_doctor"}')" || compose_doctor_result=""
+    assert_jq "syslog compose_doctor — ownership present" "${compose_doctor_result}" '.ownership'
+    assert_jq "syslog compose_doctor — runtime_state present" "${compose_doctor_result}" '.runtime_state'
     assert_jq "syslog compose_doctor — no unsafe diagnostics" "${compose_doctor_result}" '[.diagnostics[]?.severity] | all(. != "error" and . != "unsafe")'
   else
+    _skip "syslog compose_status strict diagnostics" "runtime=${compose_runtime}, ownership=${compose_ownership}"
     _skip "syslog compose_doctor strict diagnostics" "runtime=${compose_runtime}, ownership=${compose_ownership}"
   fi
 

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -448,15 +448,27 @@ phase_tools() {
   assert_jq "syslog compose_status — runtime_state present" "${compose_status_result}" '.runtime_state'
   assert_jq "syslog compose_status — no host working dir leaks" "${compose_status_result}" 'has("compose_working_dir") | not'
   assert_jq "syslog compose_status — no image id leaks" "${compose_status_result}" 'has("image_id") | not'
-  assert_jq "syslog compose_status — docker is available" "${compose_status_result}" '.runtime_state != "docker_unavailable"'
-  assert_jq "syslog compose_status — ownership known" "${compose_status_result}" '.ownership != "unknown"'
-  assert_jq "syslog compose_status — no unsafe diagnostics" "${compose_status_result}" '[.diagnostics[]?.severity] | all(. != "error" and . != "unsafe")'
+  local compose_runtime compose_ownership
+  compose_runtime="$(printf '%s' "${compose_status_result}" | jq -r '.runtime_state // "unknown"' 2>/dev/null)" || compose_runtime="unknown"
+  compose_ownership="$(printf '%s' "${compose_status_result}" | jq -r '.ownership // "unknown"' 2>/dev/null)" || compose_ownership="unknown"
+  if [[ "${compose_runtime}" != "docker_unavailable" && "${compose_ownership}" == "compose_owned" ]]; then
+    assert_jq "syslog compose_status — ownership known" "${compose_status_result}" '.ownership != "unknown"'
+    assert_jq "syslog compose_status — no unsafe diagnostics" "${compose_status_result}" '[.diagnostics[]?.severity] | all(. != "error" and . != "unsafe")'
+  else
+    _skip "syslog compose_status strict diagnostics" "runtime=${compose_runtime}, ownership=${compose_ownership}"
+  fi
 
   local compose_doctor_result
   compose_doctor_result="$(call_tool syslog '{"action":"compose_doctor"}')" || compose_doctor_result=""
-  assert_jq "syslog compose_doctor — compose-owned" "${compose_doctor_result}" '.ownership' "compose_owned"
-  assert_jq "syslog compose_doctor — docker is available" "${compose_doctor_result}" '.runtime_state != "docker_unavailable"'
-  assert_jq "syslog compose_doctor — no unsafe diagnostics" "${compose_doctor_result}" '[.diagnostics[]?.severity] | all(. != "error" and . != "unsafe")'
+  assert_jq "syslog compose_doctor — ownership present" "${compose_doctor_result}" '.ownership'
+  assert_jq "syslog compose_doctor — runtime_state present" "${compose_doctor_result}" '.runtime_state'
+  compose_runtime="$(printf '%s' "${compose_doctor_result}" | jq -r '.runtime_state // "unknown"' 2>/dev/null)" || compose_runtime="unknown"
+  compose_ownership="$(printf '%s' "${compose_doctor_result}" | jq -r '.ownership // "unknown"' 2>/dev/null)" || compose_ownership="unknown"
+  if [[ "${compose_runtime}" != "docker_unavailable" && "${compose_ownership}" == "compose_owned" ]]; then
+    assert_jq "syslog compose_doctor — no unsafe diagnostics" "${compose_doctor_result}" '[.diagnostics[]?.severity] | all(. != "error" and . != "unsafe")'
+  else
+    _skip "syslog compose_doctor strict diagnostics" "runtime=${compose_runtime}, ownership=${compose_ownership}"
+  fi
 
   # --- syslog hosts ---
   section "  syslog hosts"

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -23,7 +23,8 @@
 #   syslog list_ai_tools, syslog list_ai_projects, syslog correlate, syslog stats, syslog status, syslog apps,
 #   syslog source_ips, syslog timeline, syslog patterns, syslog context,
 #   syslog get, syslog ingest_rate, syslog silent_hosts, syslog clock_skew,
-#   syslog anomalies, syslog compare, syslog help
+#   syslog anomalies, syslog compare, syslog compose_status,
+#   syslog compose_doctor, syslog help
 #
 # Exit codes:
 #   0 — all tests passed (SKIPs do not count as failures)

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -441,6 +441,23 @@ phase_tools() {
   assert_jq "syslog stats — total_logs is a number >= 0"      "${stats_result}" '.total_logs >= 0'
   assert_jq "syslog stats — total_hosts is a number >= 0"     "${stats_result}" '.total_hosts >= 0'
 
+  # --- compose diagnostics ---
+  section "  syslog compose diagnostics"
+  local compose_status_result
+  compose_status_result="$(call_tool syslog '{"action":"compose_status"}')" || compose_status_result=""
+  assert_jq "syslog compose_status — runtime_state present" "${compose_status_result}" '.runtime_state'
+  assert_jq "syslog compose_status — no host working dir leaks" "${compose_status_result}" 'has("compose_working_dir") | not'
+  assert_jq "syslog compose_status — no image id leaks" "${compose_status_result}" 'has("image_id") | not'
+  assert_jq "syslog compose_status — docker is available" "${compose_status_result}" '.runtime_state != "docker_unavailable"'
+  assert_jq "syslog compose_status — ownership known" "${compose_status_result}" '.ownership != "unknown"'
+  assert_jq "syslog compose_status — no unsafe diagnostics" "${compose_status_result}" '[.diagnostics[]?.severity] | all(. != "error" and . != "unsafe")'
+
+  local compose_doctor_result
+  compose_doctor_result="$(call_tool syslog '{"action":"compose_doctor"}')" || compose_doctor_result=""
+  assert_jq "syslog compose_doctor — compose-owned" "${compose_doctor_result}" '.ownership' "compose_owned"
+  assert_jq "syslog compose_doctor — docker is available" "${compose_doctor_result}" '.runtime_state != "docker_unavailable"'
+  assert_jq "syslog compose_doctor — no unsafe diagnostics" "${compose_doctor_result}" '[.diagnostics[]?.severity] | all(. != "error" and . != "unsafe")'
+
   # --- syslog hosts ---
   section "  syslog hosts"
   local hosts_result


### PR DESCRIPTION
## Summary
- add `syslog compose` lifecycle commands for status, doctor, pull, up, restart, down, and logs
- add safe Compose target resolution, mutation preflight checks, bounded/redacted subprocess output, and live Docker diagnostics
- expose read-only MCP `compose_status` / `compose_doctor` diagnostics under existing read scope
- bump release surfaces to 0.20.0 and update CLI/MCP/deployment docs and smoke coverage

## Verification
- `bash scripts/check-version-sync.sh`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo run -- compose status --json`
- `cargo run -- compose doctor`
- `cargo run -- compose pull --dry-run --json`
- `cargo run -- compose up --dry-run --json`
- `cargo run -- compose logs --tail 5`

## Notes
- Work was implemented in `.worktrees/compose-lifecycle-cli`.
- Pre-push hook also ran the full test suite successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guarded Docker Compose lifecycle to the `syslog` CLI (status, doctor, pull, up, restart, down, logs) with safe target resolution and strict preflight checks. Exposes redacted, read-only Compose diagnostics via MCP, updates docs/tests, hardens smoke/live tests to handle strict `compose doctor` on non-Docker hosts, and bumps to 0.20.0.

- **New Features**
  - `syslog compose {status,doctor,pull,up,restart,down,logs}` with JSON output and `--tail N`.
  - Safe target discovery (explicit file/dir, live labels); blocks cwd fallback without `--allow-cwd-target`; rejects stale labels and MCP target overrides.
  - Preflight guards for systemd/listener conflicts; fail closed on systemd probe errors; `down` requires `--yes`; bounded, redacted output with timeouts.
  - MCP `compose_status`/`compose_doctor` under `syslog:read`; diagnostics include published port summaries; mutations remain CLI-only.

- **Migration**
  - Upgrade to 0.20.0; use `syslog compose pull && syslog compose up` for deploys and `logs --tail N` for bounded logs.
  - Add `--yes` for destructive `down`; pass `--allow-cwd-target` to use cwd as target; use MCP compose actions for diagnostics only.

<sup>Written for commit 6a75caaad0be2d964d6df0cf4e28849731d49afa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `syslog compose` CLI lifecycle: `status`, `doctor`, `pull`, `up`, `restart`, `down`, `logs` (bounded tail), preflight checks, target discovery, `--dry-run`/`--yes`, and JSON output.

* **MCP**
  * Added redacted, read-only compose diagnostics as `compose_status`/`compose_doctor` (require `syslog:read`); lifecycle mutations remain CLI-only.

* **Documentation**
  * Updated docs, README, changelog, and runbooks with compose usage and examples.

* **Tests**
  * Added unit, integration, and smoke tests covering CLI parsing, compose diagnostics, preflight, and runner behavior.

* **Chore**
  * Bumped release version to 0.20.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/22)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->