### PR TITLE
fix: enforce release and CI version gates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  version-sync:
+    name: Version Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check version sync
+        run: bash scripts/check-version-sync.sh
+
   fmt:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
 
@@ -27,13 +36,13 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Clippy
         run: cargo clippy -- -D warnings
@@ -42,11 +51,11 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run tests
         run: cargo test
@@ -58,9 +67,9 @@ jobs:
       contents: read
       checks: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: rustsec/audit-check@v2.0.0
+      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -70,7 +79,7 @@ jobs:
     needs: [test]
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run integration tests
         env:
           SYSLOG_MCP_TOKEN: ci-integration-token
@@ -80,9 +89,9 @@ jobs:
     name: Secret Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -12,9 +12,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Check version sync and changelog
+        run: bash scripts/check-version-sync.sh --require-changelog
 
       - name: Verify tag matches Cargo.toml version
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release enforcement**: Pinned CI and crates publish GitHub Actions to full
+  commit SHAs, added version-sync checks to CI/publish, made release
+  changelog checks fail closed, and routed `just publish` through the repo
+  release scripts plus test/clippy gates.
+
 ## [0.26.0] - 2026-05-18
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,9 +85,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -85,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -97,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -188,9 +198,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -256,6 +266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,9 +288,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -299,7 +318,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -440,7 +459,7 @@ dependencies = [
  "cpubits",
  "ctutils",
  "num-traits",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "serdect",
  "zeroize",
 ]
@@ -472,7 +491,7 @@ checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
 dependencies = [
  "crypto-bigint 0.7.3",
  "libm",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -550,6 +569,24 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -724,9 +761,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -937,7 +974,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -965,7 +1002,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -999,6 +1036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1055,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1084,18 +1133,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1108,7 +1157,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1305,12 +1353,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1340,16 +1388,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -1427,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1439,9 +1477,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -1458,6 +1496,7 @@ dependencies = [
  "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -1521,9 +1560,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1657,9 +1696,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1741,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1773,6 +1812,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1911,18 +1960,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1934,12 +1983,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -1984,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -2047,7 +2090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "nix",
  "tokio",
  "tracing",
@@ -2205,7 +2248,7 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2248,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -2416,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2447,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2490,7 +2533,7 @@ dependencies = [
  "digest 0.11.3",
  "pkcs1 0.8.0-rc.4",
  "pkcs8 0.11.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "signature 3.0.0",
  "spki 0.8.0",
  "zeroize",
@@ -2775,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2845,6 +2888,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d525c8ff68aa99e5818302259bdd02d86d0303710616f39c0f44846ff6d332"
+dependencies = [
+ "axum",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,15 +2934,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -3005,7 +3062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
  "digest 0.11.3",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3166,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3193,6 +3250,8 @@ dependencies = [
  "scheduled-thread-pool",
  "serde",
  "serde_json",
+ "serde_path_to_error",
+ "serde_qs",
  "serial_test",
  "sha2 0.10.9",
  "syslog-mcp",
@@ -3206,6 +3265,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -3338,9 +3398,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3387,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -3437,7 +3497,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3501,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -3513,7 +3573,6 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -3521,6 +3580,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3605,9 +3665,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -3617,7 +3677,6 @@ dependencies = [
  "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -3664,12 +3723,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3677,9 +3730,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3732,11 +3785,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3745,14 +3798,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3763,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3773,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3783,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3796,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3820,7 +3873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3846,15 +3899,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4204,6 +4257,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4211,6 +4287,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -4231,7 +4313,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4262,7 +4344,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4281,7 +4363,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4322,18 +4404,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4342,9 +4424,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -4366,6 +4448,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,16 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,24 +552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "deadpool"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
-dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,12 +1012,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1807,16 +1773,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2889,19 +2845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d525c8ff68aa99e5818302259bdd02d86d0303710616f39c0f44846ff6d332"
-dependencies = [
- "axum",
- "itoa",
- "percent-encoding",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3223,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.26.0"
+version = "0.25.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3250,8 +3193,6 @@ dependencies = [
  "scheduled-thread-pool",
  "serde",
  "serde_json",
- "serde_path_to_error",
- "serde_qs",
  "serial_test",
  "sha2 0.10.9",
  "syslog-mcp",
@@ -3265,7 +3206,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "wiremock",
 ]
 
 [[package]]
@@ -4261,29 +4201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wiremock"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
-dependencies = [
- "assert-json-diff",
- "base64",
- "deadpool",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "url",
 ]
 
 [[package]]

--- a/Justfile
+++ b/Justfile
@@ -106,17 +106,17 @@ publish bump="patch":
     [ "$(git branch --show-current)" = "main" ] || { echo "Switch to main first"; exit 1; }
     [ -z "$(git status --porcelain)" ] || { echo "Commit or stash changes first"; exit 1; }
     git pull origin main
-    CURRENT=$(grep -m1 "^version" Cargo.toml | sed "s/.*\"\(.*\)\".*/\1/")
-    IFS="." read -r major minor patch <<< "$CURRENT"
     case "{{bump}}" in
-      major) major=$((major+1)); minor=0; patch=0 ;;
-      minor) minor=$((minor+1)); patch=0 ;;
-      patch) patch=$((patch+1)) ;;
+      major|minor|patch) ;;
       *) echo "Usage: just publish [major|minor|patch]"; exit 1 ;;
     esac
-    NEW="${major}.${minor}.${patch}"
-    echo "Version: ${CURRENT} → ${NEW}"
-    sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW}\"/" Cargo.toml
-    cargo check 2>/dev/null || true
-    git add -A && git commit -m "release: v${NEW}" && git tag "v${NEW}" && git push origin main --tags
+    scripts/bump-version.sh "{{bump}}"
+    NEW=$(grep -m1 "^version" Cargo.toml | sed "s/.*\"\(.*\)\".*/\1/")
+    scripts/check-version-sync.sh --require-changelog
+    cargo test
+    cargo clippy -- -D warnings
+    git add -A
+    git commit -m "release: v${NEW}"
+    git tag "v${NEW}"
+    git push origin main --tags
     echo "Tagged v${NEW} — publish workflow will run automatically"

--- a/docs/sessions/2026-05-18-cfr-release-ci.md
+++ b/docs/sessions/2026-05-18-cfr-release-ci.md
@@ -31,13 +31,16 @@ Use the `work-it` skill for Agent 4's assignment from `06-all-issues.md`: resolv
 4. Updated workflows, release scripts, `Justfile`, version metadata, and changelog.
 5. Ran local verification, committed, pushed, and opened PR #29.
 6. Addressed two external review comments about changelog heading matching and resolved both review threads.
+7. Addressed a later cubic review comment about avoiding regex interpolation in the changelog heading check.
 
 ## Key Findings
 
 - `scripts/check-version-sync.sh` warned on missing changelog entries but did not fail release paths.
 - `scripts/bump-version.sh` used `.claude-plugin/plugin.json` as the source version even though the current plugin manifest has no top-level version.
 - `just publish` previously ran `cargo check 2>/dev/null || true`, so release publishing could continue after a failed check.
-- CodeRabbit was rate-limited and did not provide actionable code review; cubic reported no issues; Codex/Copilot both flagged the changelog false-positive matcher.
+- CodeRabbit was rate-limited and did not provide actionable code review.
+- Codex/Copilot both flagged the changelog false-positive matcher.
+- cubic later flagged regex interpolation in the heading check; the final script uses literal shell pattern matching instead.
 
 ## Technical Decisions
 
@@ -91,6 +94,7 @@ Use the `work-it` skill for Agent 4's assignment from `06-all-issues.md`: resolv
 | YAML parse via `python3` | Workflows parse | `OK` | Pass |
 | `./scripts/check-version-sync.sh --require-changelog` | Strict sync passes | `OK -- all 2 files at v0.25.4` | Pass |
 | Temp changelog false-positive test | Version mention without heading fails | Failed first, passed after heading append | Pass |
+| Temp literal heading test | Version is not interpolated into regex | Failed without heading, passed after literal heading append | Pass |
 | `RUSTC_WRAPPER= cargo clippy -- -D warnings` | No warnings | Finished successfully | Pass |
 | `RUSTC_WRAPPER= cargo test` | Full suite passes | 579 lib, 48 bin, all integration/doc tests passed | Pass |
 | Pre-push hook | Test gate passes | `test` hook passed before each push | Pass |
@@ -109,12 +113,12 @@ Use the `work-it` skill for Agent 4's assignment from `06-all-issues.md`: resolv
 
 - PR #29: https://github.com/jmagar/syslog-mcp/pull/29
 - Issue register: `/home/jmagar/workspace/syslog-mcp/06-all-issues.md`
-- External review comments resolved: Codex and Copilot changelog-heading comments on `scripts/check-version-sync.sh`.
+- External review comments resolved: Codex, Copilot, and cubic comments on `scripts/check-version-sync.sh`.
 
 ## Open Questions
 
-- GitHub CI was still running after the final push when this note was written; local gates and pre-push tests were green, and earlier upstream checks had progressed successfully.
+- GitHub CI restarted after the final push when this note was written; local gates and pre-push tests were green, and earlier upstream checks had progressed successfully.
 
 ## Next Steps
 
-- Wait for final GitHub CI rollup on PR #29 to complete after commit `147f4e3`.
+- Wait for final GitHub CI rollup on PR #29 to complete after the final branch push.

--- a/docs/sessions/2026-05-18-cfr-release-ci.md
+++ b/docs/sessions/2026-05-18-cfr-release-ci.md
@@ -1,0 +1,120 @@
+---
+date: 2026-05-18 00:44:40 EDT
+repo: https://github.com/jmagar/syslog-mcp
+branch: work/cfr-release-ci
+head: 147f4e3f213c4356828cd2de4132a3206663347c
+plan: /home/jmagar/workspace/syslog-mcp/06-all-issues.md
+working directory: /home/jmagar/workspace/syslog-mcp/.worktrees/cfr-release-ci
+worktree: /home/jmagar/workspace/syslog-mcp/.worktrees/cfr-release-ci
+pr: "#29 fix: enforce release and CI version gates https://github.com/jmagar/syslog-mcp/pull/29"
+---
+
+# CFR Release CI Session
+
+## User Request
+
+Use the `work-it` skill for Agent 4's assignment from `06-all-issues.md`: resolve CFR-012, CFR-013, and CFR-014 for supply-chain pinning and release/version enforcement in an isolated worktree.
+
+## Session Overview
+
+- Created `.worktrees/cfr-release-ci` on branch `work/cfr-release-ci`.
+- Pinned main CI and crates publish workflow actions to full commit SHAs.
+- Added CI/publish version-sync gates and strict release changelog enforcement.
+- Reworked `just publish` to use repo scripts and fail on test/clippy failures.
+- Bumped release metadata to `0.25.4` and opened PR #29.
+
+## Sequence of Events
+
+1. Inspected main checkout state and read `/home/jmagar/workspace/syslog-mcp/06-all-issues.md`.
+2. Created the requested worktree from `main`.
+3. Resolved current action SHAs with `gh api`.
+4. Updated workflows, release scripts, `Justfile`, version metadata, and changelog.
+5. Ran local verification, committed, pushed, and opened PR #29.
+6. Addressed two external review comments about changelog heading matching and resolved both review threads.
+
+## Key Findings
+
+- `scripts/check-version-sync.sh` warned on missing changelog entries but did not fail release paths.
+- `scripts/bump-version.sh` used `.claude-plugin/plugin.json` as the source version even though the current plugin manifest has no top-level version.
+- `just publish` previously ran `cargo check 2>/dev/null || true`, so release publishing could continue after a failed check.
+- CodeRabbit was rate-limited and did not provide actionable code review; cubic reported no issues; Codex/Copilot both flagged the changelog false-positive matcher.
+
+## Technical Decisions
+
+- Kept normal CI version sync non-strict so current non-release branches do not fail only because a release heading is missing.
+- Used `--require-changelog` for release/publish paths so release checks fail without a proper `## [x.y.z]` heading.
+- Used `Cargo.toml` as the canonical source for `scripts/bump-version.sh` because it is the crate/package release source.
+- Kept `just publish` on `main` only and preserved its clean-worktree precondition before bumping/tagging.
+
+## Files Modified
+
+- `.github/workflows/ci.yml`: pinned actions and added a `Version Sync` job.
+- `.github/workflows/publish-crates.yml`: pinned actions and added strict version/changelog validation.
+- `scripts/check-version-sync.sh`: added `--require-changelog` and heading-based changelog validation.
+- `scripts/bump-version.sh`: switched canonical version detection to `Cargo.toml`, updates `server.json`, and seeds changelog headings.
+- `Justfile`: routes `just publish` through release scripts, `cargo test`, and `cargo clippy`.
+- `Cargo.toml`, `Cargo.lock`, `server.json`, `CHANGELOG.md`: bumped/release-documented `0.25.4`.
+
+## Commands Executed
+
+- `git worktree add -b work/cfr-release-ci .worktrees/cfr-release-ci HEAD`: created isolated worktree.
+- `gh api repos/.../git/ref/...`: resolved action tag/branch SHAs.
+- `bash -n scripts/check-version-sync.sh` and `bash -n scripts/bump-version.sh`: passed.
+- `shellcheck scripts/check-version-sync.sh scripts/bump-version.sh`: passed.
+- `python3` YAML parse of CI/publish workflow files: passed.
+- `./scripts/check-version-sync.sh --require-changelog`: passed after `0.25.4` changelog entry.
+- `RUSTC_WRAPPER= cargo clippy -- -D warnings`: passed.
+- `RUSTC_WRAPPER= cargo test`: passed.
+- `gh pr create`: created PR #29.
+
+## Errors Encountered
+
+- Sandboxed `git status`/`git diff` hit Git LFS temp-file writes under the main checkout `.git/lfs/tmp`; reran those git inspections with escalation.
+- Initial `cargo test` failed in `sccache` with an allocation error; reran with `RUSTC_WRAPPER=` and tests passed.
+- Initial `cargo clippy` via the snap cargo path failed before repo execution; reran with the non-sccache path and it passed.
+- `gh pr checks --watch` hit a transient GitHub API connection error; used `gh pr view --json statusCheckRollup` instead.
+
+## Behavior Changes
+
+- CI now checks version-bearing files are synchronized.
+- Publish workflow now requires synchronized versions and a changelog release heading before publishing.
+- `just publish` no longer silently tolerates a Cargo check failure and now runs full test and clippy gates before tagging.
+- Release bumping now updates the server manifest and OCI image tag alongside Cargo metadata.
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+| --- | --- | --- | --- |
+| `bash -n scripts/check-version-sync.sh` | Shell parses | No output | Pass |
+| `bash -n scripts/bump-version.sh` | Shell parses | No output | Pass |
+| `shellcheck scripts/check-version-sync.sh scripts/bump-version.sh` | No findings | No output | Pass |
+| YAML parse via `python3` | Workflows parse | `OK` | Pass |
+| `./scripts/check-version-sync.sh --require-changelog` | Strict sync passes | `OK -- all 2 files at v0.25.4` | Pass |
+| Temp changelog false-positive test | Version mention without heading fails | Failed first, passed after heading append | Pass |
+| `RUSTC_WRAPPER= cargo clippy -- -D warnings` | No warnings | Finished successfully | Pass |
+| `RUSTC_WRAPPER= cargo test` | Full suite passes | 579 lib, 48 bin, all integration/doc tests passed | Pass |
+| Pre-push hook | Test gate passes | `test` hook passed before each push | Pass |
+
+## Risks and Rollback
+
+- SHA-pinned actions require deliberate future updates instead of floating tag updates; rollback is to restore tag references or update SHAs.
+- `just publish` is now slower because it runs `cargo test` and `cargo clippy`; rollback is to loosen the Justfile recipe, but that would reintroduce CFR-014.
+
+## Decisions Not Taken
+
+- Did not add Dependabot action-update configuration because the assignment only required pinning and release enforcement.
+- Did not make normal CI require a changelog heading because the existing main state already had a current version without a changelog release heading.
+
+## References
+
+- PR #29: https://github.com/jmagar/syslog-mcp/pull/29
+- Issue register: `/home/jmagar/workspace/syslog-mcp/06-all-issues.md`
+- External review comments resolved: Codex and Copilot changelog-heading comments on `scripts/check-version-sync.sh`.
+
+## Open Questions
+
+- GitHub CI was still running after the final push when this note was written; local gates and pre-push tests were green, and earlier upstream checks had progressed successfully.
+
+## Next Steps
+
+- Wait for final GitHub CI rollup on PR #29 to complete after commit `147f4e3`.

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -13,20 +13,17 @@ REPO_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd
 
 VERSION_FILES=(
     "${REPO_ROOT}/Cargo.toml"
+    "${REPO_ROOT}/server.json"
+    "${REPO_ROOT}/package.json"
     "${REPO_ROOT}/pyproject.toml"
     "${REPO_ROOT}/.claude-plugin/plugin.json"
     "${REPO_ROOT}/.codex-plugin/plugin.json"
-    "${REPO_ROOT}/.gemini-extension.json"
+    "${REPO_ROOT}/gemini-extension.json"
 )
 
-# Resolve gemini path (handles both naming conventions)
-if [ -f "${REPO_ROOT}/gemini-extension.json" ]; then
-    VERSION_FILES[3]="${REPO_ROOT}/gemini-extension.json"
-fi
-
 current_version() {
-    grep -m1 '"version"' "${REPO_ROOT}/.claude-plugin/plugin.json" \
-        | sed 's/.*"version": "\(.*\)".*/\1/'
+    grep -m1 '^version' "${REPO_ROOT}/Cargo.toml" \
+        | sed 's/.*"\(.*\)".*/\1/'
 }
 
 bump() {
@@ -56,7 +53,20 @@ for file in "${VERSION_FILES[@]}"; do
     [ -f "$file" ] || { echo "  skip (not found): $file"; continue; }
     sed -i "s/\"version\": \"${CURRENT}\"/\"version\": \"${NEW}\"/" "$file"
     sed -i "s/^version = \"${CURRENT}\"/version = \"${NEW}\"/" "$file"
+    sed -i "s/syslog-mcp:v${CURRENT}/syslog-mcp:v${NEW}/g" "$file"
     echo "  updated: ${file#"${REPO_ROOT}/"}"
 done
 
-echo "Done. Don't forget to add a CHANGELOG.md entry for ${NEW}."
+if [ -f "${REPO_ROOT}/CHANGELOG.md" ]; then
+    if grep -qF "## [${NEW}]" "${REPO_ROOT}/CHANGELOG.md"; then
+        echo "  unchanged: CHANGELOG.md already has ${NEW}"
+    elif grep -q '^## \[Unreleased\]' "${REPO_ROOT}/CHANGELOG.md"; then
+        today="$(date +%F)"
+        sed -i "0,/^## \\[Unreleased\\]/s//## [Unreleased]\\n\\n## [${NEW}] - ${today}/" "${REPO_ROOT}/CHANGELOG.md"
+        echo "  updated: CHANGELOG.md"
+    else
+        echo "  WARN: CHANGELOG.md has no [Unreleased] heading; add an entry for ${NEW}" >&2
+    fi
+fi
+
+echo "Done. Review CHANGELOG.md before committing ${NEW}."

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -32,6 +32,19 @@ cd "$PROJECT_DIR"
 versions=()
 files_checked=()
 
+changelog_has_release_heading() {
+  local version="$1"
+  local line
+
+  while IFS= read -r line; do
+    case "$line" in
+      "## [$version]" | "## [$version] "*) return 0 ;;
+    esac
+  done < CHANGELOG.md
+
+  return 1
+}
+
 # Extract version from each file type
 if [ -f "Cargo.toml" ]; then
   v=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
@@ -104,7 +117,7 @@ fi
 
 # Check CHANGELOG.md has an entry for the current version
 if [ -f "CHANGELOG.md" ]; then
-  if ! grep -qE "^## \\[$canonical\\]([[:space:]]|$)" CHANGELOG.md; then
+  if ! changelog_has_release_heading "$canonical"; then
     if [ "$REQUIRE_CHANGELOG" -eq 1 ]; then
       echo "[version-sync] FAIL — CHANGELOG.md has no release heading for version $canonical"
       echo "  Add a changelog entry before releasing."

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -104,13 +104,13 @@ fi
 
 # Check CHANGELOG.md has an entry for the current version
 if [ -f "CHANGELOG.md" ]; then
-  if ! grep -qF "$canonical" CHANGELOG.md; then
+  if ! grep -qE "^## \\[$canonical\\]([[:space:]]|$)" CHANGELOG.md; then
     if [ "$REQUIRE_CHANGELOG" -eq 1 ]; then
-      echo "[version-sync] FAIL — CHANGELOG.md has no entry for version $canonical"
+      echo "[version-sync] FAIL — CHANGELOG.md has no release heading for version $canonical"
       echo "  Add a changelog entry before releasing."
       exit 1
     else
-      echo "[version-sync] WARN — CHANGELOG.md has no entry for version $canonical"
+      echo "[version-sync] WARN — CHANGELOG.md has no release heading for version $canonical"
       echo "  Add a changelog entry before releasing."
     fi
   fi

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -1,9 +1,32 @@
 #!/usr/bin/env bash
-# check-version-sync.sh — Pre-commit hook to verify all version-bearing files match.
-# Exits non-zero if versions are out of sync or CHANGELOG.md is missing an entry.
+# check-version-sync.sh — verify all version-bearing files match.
+# Exits non-zero if versions are out of sync. With --require-changelog, also
+# exits non-zero if CHANGELOG.md is missing an entry for the canonical version.
 set -euo pipefail
 
-PROJECT_DIR="${1:-.}"
+REQUIRE_CHANGELOG=0
+PROJECT_DIR="."
+
+for arg in "$@"; do
+  case "$arg" in
+    --require-changelog)
+      REQUIRE_CHANGELOG=1
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--require-changelog] [PROJECT_DIR]"
+      exit 0
+      ;;
+    -*)
+      echo "[version-sync] Unknown option: $arg" >&2
+      echo "Usage: $0 [--require-changelog] [PROJECT_DIR]" >&2
+      exit 2
+      ;;
+    *)
+      PROJECT_DIR="$arg"
+      ;;
+  esac
+done
+
 cd "$PROJECT_DIR"
 
 versions=()
@@ -82,10 +105,18 @@ fi
 # Check CHANGELOG.md has an entry for the current version
 if [ -f "CHANGELOG.md" ]; then
   if ! grep -qF "$canonical" CHANGELOG.md; then
-    echo "[version-sync] WARN — CHANGELOG.md has no entry for version $canonical"
-    echo "  Add a changelog entry before pushing."
-    # Warning only, not blocking
+    if [ "$REQUIRE_CHANGELOG" -eq 1 ]; then
+      echo "[version-sync] FAIL — CHANGELOG.md has no entry for version $canonical"
+      echo "  Add a changelog entry before releasing."
+      exit 1
+    else
+      echo "[version-sync] WARN — CHANGELOG.md has no entry for version $canonical"
+      echo "  Add a changelog entry before releasing."
+    fi
   fi
+elif [ "$REQUIRE_CHANGELOG" -eq 1 ]; then
+  echo "[version-sync] FAIL — CHANGELOG.md is required for release checks"
+  exit 1
 fi
 
 echo "[version-sync] OK — all ${#versions[@]} files at v${canonical}"


### PR DESCRIPTION
## Summary
- Pin main CI and crates publish workflow actions to full commit SHAs, matching the Docker workflow style.
- Add version-sync checks to CI and strict version/changelog checks to crates publish.
- Route just publish through scripts/bump-version.sh, scripts/check-version-sync.sh --require-changelog, cargo test, and cargo clippy before commit/tag/push.
- Bump repo release metadata to v0.25.4 with a changelog entry.

## Verification
- bash -n scripts/check-version-sync.sh
- bash -n scripts/bump-version.sh
- shellcheck scripts/check-version-sync.sh scripts/bump-version.sh
- python3 YAML parse check for .github/workflows/ci.yml and publish-crates.yml
- ./scripts/check-version-sync.sh --require-changelog
- temp release bump smoke test for Cargo.toml, server.json, image tag, and changelog
- RUSTC_WRAPPER= cargo clippy -- -D warnings
- RUSTC_WRAPPER= cargo test
- pre-commit hook: diff_check, env_guard, skills, yaml, format, lint
- pre-push hook: cargo test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down CI and releases by pinning GitHub Actions to SHAs and enforcing strict version/changelog gates. Adds a Version Sync job, requires a literal changelog release heading, syncs image tags, routes `just publish` through tests/clippy, and bumps to v0.25.4 (plugin manifest is 0.26.0 to exercise the gate).

- **New Features**
  - CI: add Version Sync job; crates publish runs `scripts/check-version-sync.sh --require-changelog`.
  - Versioning: use `Cargo.toml` as canonical; sync `server.json`, `package.json`, plugin files, and OCI image tags; require `## [x.y.z]` changelog heading (literal match).
  - `just publish`: run bump-version, version sync (with changelog), tests, and clippy before tag/push.

- **Dependencies**
  - Pin `actions/checkout`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, `rustsec/audit-check`, and `gitleaks/gitleaks-action` to commit SHAs.
  - Regenerate `Cargo.lock` to reflect current dependency resolutions.

<sup>Written for commit 41fc1ce22f34d880502a658d5d7a5cd888cf00a3. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/29?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

