### PR TITLE
fix: propagate MCP admin request identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +571,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1055,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1778,6 +1812,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2844,6 +2888,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d525c8ff68aa99e5818302259bdd02d86d0303710616f39c0f44846ff6d332"
+dependencies = [
+ "axum",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.25.4"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3193,6 +3250,8 @@ dependencies = [
  "scheduled-thread-pool",
  "serde",
  "serde_json",
+ "serde_path_to_error",
+ "serde_qs",
  "serial_test",
  "sha2 0.10.9",
  "syslog-mcp",
@@ -3206,6 +3265,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -4194,6 +4254,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,16 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,24 +561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "deadpool"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
-dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,12 +1027,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1812,16 +1778,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2888,19 +2844,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d525c8ff68aa99e5818302259bdd02d86d0303710616f39c0f44846ff6d332"
-dependencies = [
- "axum",
- "itoa",
- "percent-encoding",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3223,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.26.0"
+version = "0.25.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -3250,8 +3193,6 @@ dependencies = [
  "scheduled-thread-pool",
  "serde",
  "serde_json",
- "serde_path_to_error",
- "serde_qs",
  "serial_test",
  "sha2 0.10.9",
  "syslog-mcp",
@@ -3265,7 +3206,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "wiremock",
 ]
 
 [[package]]
@@ -4254,29 +4194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wiremock"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
-dependencies = [
- "assert-json-diff",
- "base64",
- "deadpool",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "hyper-util",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "tokio",
- "url",
 ]
 
 [[package]]

--- a/docs/sessions/2026-05-18-cfr-mcp-identity.md
+++ b/docs/sessions/2026-05-18-cfr-mcp-identity.md
@@ -69,6 +69,7 @@ Implement Agent 2's assignment from `06-all-issues.md`: CFR-004, CFR-010, and CF
 - `git push -u origin HEAD`: passed; pre-push hook reran `cargo test` successfully.
 - `gh pr create --base main --head work/cfr-mcp-identity`: created PR #32.
 - `gh pr view 32 --json comments,reviews,reviewDecision,statusCheckRollup`: CodeRabbit was rate-limited; no reviews were present; some CI checks were still queued or in progress immediately after PR creation.
+- Final PR status check: cubic and Copilot posted no-issue reviews; CodeRabbit remained rate-limited; GitHub CI was queued after the final note push.
 
 ## Errors Encountered
 
@@ -76,6 +77,7 @@ Implement Agent 2's assignment from `06-all-issues.md`: CFR-004, CFR-010, and CF
 - Initial focused tests without `RUSTC_WRAPPER=` failed in dependency compilation due to `sccache` allocation errors while zipping cache entries.
 - Lab `Agent` review substitutions were attempted for review waves, but the runtime reported `Agent type 'general-purpose' not found. Available agents:` with no usable types listed.
 - CodeRabbit posted a non-actionable rate-limit comment instead of a review; no actionable review findings were available to resolve during the session.
+- cubic and Copilot produced no actionable findings.
 
 ## Behavior Changes
 
@@ -115,5 +117,5 @@ Implement Agent 2's assignment from `06-all-issues.md`: CFR-004, CFR-010, and CF
 ## Next Steps
 
 - Fetch and address external PR comments if reviewers post actionable findings.
-- Wait for queued GitHub CI checks and cubic review to complete.
+- Wait for queued GitHub CI checks to complete.
 - Broader CFR-016 follow-up remains open for a future central action descriptor/schema/help refactor.

--- a/docs/sessions/2026-05-18-cfr-mcp-identity.md
+++ b/docs/sessions/2026-05-18-cfr-mcp-identity.md
@@ -1,0 +1,119 @@
+---
+date: 2026-05-18 00:45:03 EDT
+repo: https://github.com/jmagar/syslog-mcp
+branch: work/cfr-mcp-identity
+head: d71fa90
+plan: /home/jmagar/workspace/syslog-mcp/06-all-issues.md
+working directory: /home/jmagar/workspace/syslog-mcp/.worktrees/cfr-mcp-identity
+worktree: /home/jmagar/workspace/syslog-mcp/.worktrees/cfr-mcp-identity
+pr: "#32 fix: propagate MCP admin request identity https://github.com/jmagar/syslog-mcp/pull/32"
+---
+
+# CFR MCP Identity Session
+
+## User Request
+
+Implement Agent 2's assignment from `06-all-issues.md`: CFR-004, CFR-010, and CFR-016 for per-request MCP identity on mutating admin actions, plus practical action/help metadata drift reduction in the touched MCP surface.
+
+## Session Overview
+
+- Created isolated worktree `.worktrees/cfr-mcp-identity` on branch `work/cfr-mcp-identity`.
+- Threaded `AuthContext` from RMCP request handling into syslog tool execution.
+- Updated admin actor extraction to prefer authenticated email and fall back to subject.
+- Added RMCP coverage proving distinct request identities are recorded in admin audit rows.
+- Opened PR #32: https://github.com/jmagar/syslog-mcp/pull/32.
+
+## Sequence of Events
+
+- Inspected main checkout state and confirmed only `06-all-issues.md` was untracked in the main worktree.
+- Read `06-all-issues.md` and scoped work to CFR-004, CFR-010, and CFR-016.
+- Created `.worktrees/cfr-mcp-identity` from `main`.
+- Updated `src/mcp/rmcp_server.rs` to pass the request `AuthContext` into `execute_tool`.
+- Updated `src/mcp/tools.rs` to pass identity through `tool_syslog` to `ack_error`, `unack_error`, and `notifications_test`.
+- Added `mounted_admin_actions_record_per_request_subject_actor` in `src/mcp/rmcp_server_tests.rs`.
+- Centralized admin help text for the touched mutating actions in `src/mcp/tools.rs`.
+- Bumped version metadata to `0.25.4` in `Cargo.toml`, `Cargo.lock`, and `server.json`, and added a `CHANGELOG.md` entry.
+
+## Key Findings
+
+- `src/mcp/rmcp_server.rs:118` already extracted `AuthContext` for scope checks, but `src/mcp/rmcp_server.rs:130` previously dropped it before tool execution.
+- `src/mcp/tools.rs:536` now uses the request identity instead of only the app auth mode.
+- `src/mcp/rmcp_server_tests.rs:807` verifies `ack_error` and `unack_error` persist distinct actors in `error_signature_ack_events`.
+- The first Cargo test attempt failed before project compilation because `sccache` ran out of memory while caching dependency outputs; rerunning with `RUSTC_WRAPPER=` resolved it.
+
+## Technical Decisions
+
+- Actor extraction prefers `AuthContext.email` when present because it is the human-readable verified caller identity, then falls back to `AuthContext.sub`.
+- Loopback/no-context calls retain the previous stable fallback labels (`mcp:loopback`, `mcp:oauth`, `mcp:bearer`) for direct tool tests and stdio/local trust-boundary paths.
+- `notifications_test` shares the same actor helper as `ack_error` and `unack_error`, so its per-actor rate limiter no longer collapses all mounted callers to the auth mode.
+- The help drift reduction was kept local: only the touched admin action sections were moved into a small metadata table, avoiding broad schema/dispatcher refactors owned by other agents.
+
+## Files Modified
+
+- `src/mcp/rmcp_server.rs`: forwards `AuthContext` into tool execution.
+- `src/mcp/tools.rs`: accepts per-request identity, derives admin actors from email/subject, and generates admin help sections.
+- `src/mcp/rmcp_server_tests.rs`: adds RMCP-level request identity/audit persistence coverage.
+- `src/mcp/tools_tests.rs`: updates direct `execute_tool` call sites for the new optional auth parameter.
+- `Cargo.toml`, `Cargo.lock`, `server.json`: bump version to `0.25.4`.
+- `CHANGELOG.md`: documents the identity and help metadata fixes.
+
+## Commands Executed
+
+- `git worktree add -b work/cfr-mcp-identity .worktrees/cfr-mcp-identity HEAD`: created the isolated worktree.
+- `RUSTC_WRAPPER= cargo test mounted_admin_actions_record_per_request_subject_actor`: passed.
+- `RUSTC_WRAPPER= cargo test public_action_references_cover_schema_registry`: passed.
+- `RUSTC_WRAPPER= cargo test schema_actions_are_dispatchable`: passed.
+- `RUSTC_WRAPPER= cargo test`: passed on the final tree.
+- `RUSTC_WRAPPER= cargo clippy`: passed.
+- `bash scripts/check-version-sync.sh`: passed, all checked files at `v0.25.4`.
+- `git push -u origin HEAD`: passed; pre-push hook reran `cargo test` successfully.
+- `gh pr create --base main --head work/cfr-mcp-identity`: created PR #32.
+- `gh pr view 32 --json comments,reviews,reviewDecision,statusCheckRollup`: CodeRabbit was rate-limited; no reviews were present; some CI checks were still queued or in progress immediately after PR creation.
+
+## Errors Encountered
+
+- Running three focused `cargo test` commands in parallel caused Cargo lock contention.
+- Initial focused tests without `RUSTC_WRAPPER=` failed in dependency compilation due to `sccache` allocation errors while zipping cache entries.
+- Lab `Agent` review substitutions were attempted for review waves, but the runtime reported `Agent type 'general-purpose' not found. Available agents:` with no usable types listed.
+- CodeRabbit posted a non-actionable rate-limit comment instead of a review; no actionable review findings were available to resolve during the session.
+
+## Behavior Changes
+
+- Before: mounted MCP admin actions recorded actors like `mcp:oauth` or `mcp:bearer`, losing per-request caller identity.
+- After: mounted MCP admin actions record the authenticated email when present, otherwise the authenticated subject.
+- Before: `notifications_test` rate limiting grouped mounted callers by auth mode.
+- After: `notifications_test` rate limiting is keyed by the same per-request actor identity.
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---|---|---|---|
+| `RUSTC_WRAPPER= cargo test mounted_admin_actions_record_per_request_subject_actor` | Identity/audit test passes | 1 passed | Pass |
+| `RUSTC_WRAPPER= cargo test public_action_references_cover_schema_registry` | Help/schema reference coverage passes | 1 passed | Pass |
+| `RUSTC_WRAPPER= cargo test schema_actions_are_dispatchable` | MCP schema actions still dispatch | 1 passed | Pass |
+| `RUSTC_WRAPPER= cargo test` | Full test suite passes | 580 lib, 48 binary, all integration/doc-test groups passed | Pass |
+| `RUSTC_WRAPPER= cargo clippy` | Lint passes | Finished successfully | Pass |
+| `bash scripts/check-version-sync.sh` | Version metadata aligned | `OK - all 2 files at v0.25.4` | Pass |
+| pre-commit hook | format and lint pass | `cargo fmt` and `cargo clippy -- -D warnings` passed | Pass |
+| pre-push hook | full tests pass | `cargo test` passed | Pass |
+
+## Risks and Rollback
+
+- Risk: Downstream audit consumers that expected auth-mode actor labels for mounted HTTP admin actions will now see email/subject values. This is the intended auditability fix.
+- Rollback: revert commit `d71fa90` and the follow-up session-note commit if needed.
+
+## Decisions Not Taken
+
+- Did not refactor all MCP action dispatch/schema/help metadata; CFR-016 was addressed only for the touched admin action surface to avoid conflicting with broader parallel work.
+- Did not add a live Apprise delivery test for `notifications_test`; the actor path is shared with the tested ack/unack admin actions and existing notification delivery tests cover Apprise behavior.
+
+## References
+
+- Issue register: `/home/jmagar/workspace/syslog-mcp/06-all-issues.md`.
+- PR: https://github.com/jmagar/syslog-mcp/pull/32.
+
+## Next Steps
+
+- Fetch and address external PR comments if reviewers post actionable findings.
+- Wait for queued GitHub CI checks and cubic review to complete.
+- Broader CFR-016 follow-up remains open for a future central action descriptor/schema/help refactor.

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -127,7 +127,7 @@ impl ServerHandler for SyslogRmcpServer {
         let started = Instant::now();
         tracing::info!(tool = %tool_name, "MCP tool execution started");
 
-        match execute_tool(&self.state, &tool_name, arguments).await {
+        match execute_tool(&self.state, &tool_name, arguments, auth).await {
             Ok(result) => {
                 let result_count = safe_result_count(&result);
                 tracing::info!(

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -99,16 +99,40 @@ fn rmcp_router_no_auth_middleware(state: AppState) -> Router {
     Router::new().nest_service("/mcp", streamable_http_service(state, config))
 }
 
-fn auth_ctx_with_scopes(scopes: Vec<&str>) -> AuthContext {
+fn auth_ctx(subject: &str, scopes: Vec<&str>, email: Option<&str>) -> AuthContext {
     AuthContext {
-        sub: "test-user@example.com".to_string(),
+        sub: subject.to_string(),
         actor_key: None,
         scopes: scopes.into_iter().map(String::from).collect(),
         issuer: "local".to_string(),
         via_session: false,
         csrf_token: None,
-        email: None,
+        email: email.map(String::from),
     }
+}
+
+fn auth_ctx_with_scopes(scopes: Vec<&str>) -> AuthContext {
+    auth_ctx("test-user@example.com", scopes, None)
+}
+
+fn seed_error_signature(pool: &DbPool, hash: &str) {
+    let conn = pool.get().unwrap();
+    crate::db::error_signatures::upsert_signature(
+        &conn,
+        crate::db::error_signatures::UpsertSignatureParams {
+            hash,
+            normalizer_version: crate::app::error_detection::NORMALIZER_VERSION,
+            template: "mounted auth coverage",
+            sample_message: "mounted auth coverage",
+            sample_hostname: "auth-test-host",
+            sample_app_name: Some("schema-test"),
+            severity: "err",
+            first_seen_at: "2026-01-01T00:00:00.000Z",
+            last_seen_at: "2026-01-01T00:00:00.000Z",
+            delta: 1,
+        },
+    )
+    .unwrap();
 }
 
 fn entry(ts: &str, host: &str, severity: &str, msg: &str, source_ip: &str) -> LogBatchEntry {
@@ -778,6 +802,84 @@ async fn mounted_policy_with_both_scopes_permits_all_actions() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert!(response["result"].is_object(), "response: {response}");
+}
+
+#[tokio::test]
+async fn mounted_admin_actions_record_per_request_subject_actor() {
+    let (state, pool, _dir) = mounted_state();
+    let signature_hash = "1111111111111111111111111111111111111111111111111111111111111111";
+    seed_error_signature(&pool, signature_hash);
+
+    let alice_router = rmcp_router_with_auth(
+        state.clone(),
+        auth_ctx("alice-subject", vec!["syslog:admin"], None),
+    );
+    let (status, response) = post_rmcp(
+        alice_router,
+        jsonrpc_request(
+            41,
+            "tools/call",
+            Some(json!({
+                "name": "syslog",
+                "arguments": {
+                    "action": "ack_error",
+                    "signature_hash": signature_hash,
+                    "notes": "alice ack"
+                }
+            })),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let ack = content_json(&response);
+    assert_eq!(ack["actor"], "alice-subject", "response: {response}");
+
+    let bob_router = rmcp_router_with_auth(
+        state,
+        auth_ctx("bob-subject", vec!["syslog:admin"], Some("bob@example.com")),
+    );
+    let (status, response) = post_rmcp(
+        bob_router,
+        jsonrpc_request(
+            42,
+            "tools/call",
+            Some(json!({
+                "name": "syslog",
+                "arguments": {
+                    "action": "unack_error",
+                    "signature_hash": signature_hash,
+                    "reason": "bob unack"
+                }
+            })),
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let unack = content_json(&response);
+    assert_eq!(unack["actor"], "bob@example.com", "response: {response}");
+
+    let conn = pool.get().unwrap();
+    let events = conn
+        .prepare(
+            "SELECT event_type, actor FROM error_signature_ack_events
+             WHERE signature_hash = ?1
+             ORDER BY id",
+        )
+        .unwrap()
+        .query_map([signature_hash], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    assert_eq!(
+        events,
+        vec![
+            ("ack".to_string(), "alice-subject".to_string()),
+            ("unack".to_string(), "bob@example.com".to_string()),
+        ]
+    );
 }
 
 /// `AuthPolicy::Mounted` + AuthContext with EMPTY scopes + any action → denied.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,3 +1,4 @@
+use lab_auth::AuthContext;
 use serde_json::{json, Value};
 
 use crate::app::{
@@ -16,14 +17,19 @@ pub(super) async fn execute_tool(
     state: &AppState,
     name: &str,
     args: Value,
+    auth: Option<&AuthContext>,
 ) -> anyhow::Result<Value> {
     match name {
-        "syslog" => tool_syslog(state, args).await,
+        "syslog" => tool_syslog(state, args, auth).await,
         _ => Err(anyhow::anyhow!("Unknown tool: {name}")),
     }
 }
 
-async fn tool_syslog(state: &AppState, args: Value) -> anyhow::Result<Value> {
+async fn tool_syslog(
+    state: &AppState,
+    args: Value,
+    auth: Option<&AuthContext>,
+) -> anyhow::Result<Value> {
     let action =
         string_arg(&args, "action").ok_or_else(|| anyhow::anyhow!("action is required"))?;
     match action.as_str() {
@@ -56,10 +62,10 @@ async fn tool_syslog(state: &AppState, args: Value) -> anyhow::Result<Value> {
         "compose_status" => tool_compose_status(args).await,
         "compose_doctor" => tool_compose_doctor(args).await,
         "unaddressed_errors" => tool_unaddressed_errors(state, args).await,
-        "ack_error" => tool_ack_error(state, args).await,
-        "unack_error" => tool_unack_error(state, args).await,
+        "ack_error" => tool_ack_error(state, args, auth).await,
+        "unack_error" => tool_unack_error(state, args, auth).await,
         "notifications_recent" => tool_notifications_recent(state, args).await,
-        "notifications_test" => tool_notifications_test(state, args).await,
+        "notifications_test" => tool_notifications_test(state, args, auth).await,
         "help" => tool_syslog_help().await,
         _ => Err(anyhow::anyhow!(
             "unknown syslog action: {action}; expected one of {}",
@@ -522,22 +528,27 @@ fn string_arg(args: &Value, name: &str) -> Option<String> {
     args.get(name).and_then(|v| v.as_str()).map(String::from)
 }
 
-/// Return a stable actor identifier from the app state's auth policy.
+/// Return a stable actor identifier for mutating/admin actions.
 ///
-/// Full per-request OAuth claim extraction requires threading the `AuthContext`
-/// extension through the tool dispatch call chain. Until that plumbing is in
-/// place, this helper at least distinguishes between the three auth modes so
-/// audit logs aren't uniformly `"mcp:bearer"`.
-///
-/// TODO: thread `AuthContext` from routes/rmcp_server into tool handlers and
-/// use `auth_ctx.subject()` here instead.
-fn extract_actor(state: &AppState) -> &'static str {
+/// Mounted MCP requests carry caller identity in `AuthContext`. Prefer the
+/// verified email when available, then the subject. Loopback mode has no
+/// per-request credential, so it falls back to the local trust-boundary actor.
+fn extract_actor(state: &AppState, auth: Option<&AuthContext>) -> String {
+    if let Some(auth) = auth {
+        if let Some(email) = auth.email.as_deref().filter(|email| !email.is_empty()) {
+            return email.to_string();
+        }
+        if !auth.sub.is_empty() {
+            return auth.sub.clone();
+        }
+    }
+
     match &state.auth_policy {
-        super::AuthPolicy::LoopbackDev => "mcp:loopback",
+        super::AuthPolicy::LoopbackDev => "mcp:loopback".to_string(),
         super::AuthPolicy::Mounted {
             auth_state: Some(_),
-        } => "mcp:oauth",
-        super::AuthPolicy::Mounted { auth_state: None } => "mcp:bearer",
+        } => "mcp:oauth".to_string(),
+        super::AuthPolicy::Mounted { auth_state: None } => "mcp:bearer".to_string(),
     }
 }
 
@@ -585,7 +596,11 @@ async fn tool_unaddressed_errors(state: &AppState, args: Value) -> anyhow::Resul
     Ok(serde_json::to_value(resp)?)
 }
 
-async fn tool_ack_error(state: &AppState, args: Value) -> anyhow::Result<Value> {
+async fn tool_ack_error(
+    state: &AppState,
+    args: Value,
+    auth: Option<&AuthContext>,
+) -> anyhow::Result<Value> {
     use crate::app::AckErrorRequest;
     let hash = string_arg(&args, "signature_hash")
         .ok_or_else(|| anyhow::anyhow!("signature_hash is required"))?;
@@ -593,12 +608,16 @@ async fn tool_ack_error(state: &AppState, args: Value) -> anyhow::Result<Value> 
         signature_hash: hash,
         notes: string_arg(&args, "notes"),
     };
-    let actor = extract_actor(state);
-    let resp = state.service.ack_error(req, actor).await?;
+    let actor = extract_actor(state, auth);
+    let resp = state.service.ack_error(req, &actor).await?;
     Ok(serde_json::to_value(resp)?)
 }
 
-async fn tool_unack_error(state: &AppState, args: Value) -> anyhow::Result<Value> {
+async fn tool_unack_error(
+    state: &AppState,
+    args: Value,
+    auth: Option<&AuthContext>,
+) -> anyhow::Result<Value> {
     use crate::app::UnackErrorRequest;
     let hash = string_arg(&args, "signature_hash")
         .ok_or_else(|| anyhow::anyhow!("signature_hash is required"))?;
@@ -606,8 +625,8 @@ async fn tool_unack_error(state: &AppState, args: Value) -> anyhow::Result<Value
         signature_hash: hash,
         reason: string_arg(&args, "reason"),
     };
-    let actor = extract_actor(state);
-    let resp = state.service.unack_error(req, actor).await?;
+    let actor = extract_actor(state, auth);
+    let resp = state.service.unack_error(req, &actor).await?;
     Ok(serde_json::to_value(resp)?)
 }
 
@@ -626,11 +645,15 @@ async fn tool_notifications_recent(state: &AppState, args: Value) -> anyhow::Res
     Ok(serde_json::to_value(firings)?)
 }
 
-async fn tool_notifications_test(state: &AppState, args: Value) -> anyhow::Result<Value> {
+async fn tool_notifications_test(
+    state: &AppState,
+    args: Value,
+    auth: Option<&AuthContext>,
+) -> anyhow::Result<Value> {
     let body = string_arg(&args, "body")
         .unwrap_or_else(|| "Test notification from syslog-mcp".to_string());
-    // Actor is derived from the auth policy, not from caller-supplied args.
-    let actor = extract_actor(state).to_string();
+    // Actor is derived from request auth context, not caller-supplied args.
+    let actor = extract_actor(state, auth);
     // Apprise URLs come exclusively from server config to prevent SSRF.
     // Caller-supplied apprise_url / apprise_urls are intentionally ignored.
     let apprise_url = state.notifications_config.apprise_url.clone();
@@ -641,6 +664,57 @@ async fn tool_notifications_test(state: &AppState, args: Value) -> anyhow::Resul
         .notifications_test(body, actor, apprise_url, apprise_urls)
         .await?;
     Ok(serde_json::json!({ "result": result }))
+}
+
+struct AdminActionHelp {
+    action: &'static str,
+    description: &'static str,
+    parameters: &'static [&'static str],
+}
+
+const ADMIN_ACTION_HELP: &[AdminActionHelp] = &[
+    AdminActionHelp {
+        action: "ack_error",
+        description: "Acknowledge an error signature so it is suppressed from future `unaddressed_errors`\nresults. Writes an audit event and updates the acknowledgement projection. Use\n`unack_error` to revoke.",
+        parameters: &[
+            "`signature_hash` (string, **required**) — the SHA-256 hash from `unaddressed_errors`",
+            "`notes` (string, optional) — acknowledgement notes (max 4096 chars)",
+        ],
+    },
+    AdminActionHelp {
+        action: "unack_error",
+        description: "Revoke an existing acknowledgement on an error signature so it reappears in\n`unaddressed_errors`. Writes an unack audit event; does NOT delete the ack history.",
+        parameters: &[
+            "`signature_hash` (string, **required**) — the SHA-256 hash of the signature",
+            "`reason` (string, optional) — reason for removing the acknowledgement (max 4096 chars)",
+        ],
+    },
+    AdminActionHelp {
+        action: "notifications_test",
+        description: "Send a test notification via the server-configured Apprise URLs. Rate-limited to 10 per minute per actor.\nCaller-supplied Apprise URLs are ignored for security; the server uses its own configured URLs.",
+        parameters: &[
+            "`body` (string, optional) — notification body text (default: test message)",
+        ],
+    },
+];
+
+fn admin_action_help() -> String {
+    let mut help = String::new();
+    for action in ADMIN_ACTION_HELP {
+        help.push_str("---\n\n");
+        help.push_str("## syslog ");
+        help.push_str(action.action);
+        help.push('\n');
+        help.push_str(action.description);
+        help.push_str("\n\n**Parameters:**\n");
+        for parameter in action.parameters {
+            help.push_str("- ");
+            help.push_str(parameter);
+            help.push('\n');
+        }
+        help.push('\n');
+    }
+    help
 }
 
 async fn tool_syslog_help() -> anyhow::Result<Value> {
@@ -982,27 +1056,6 @@ normalized template, sample message, severity, counts, and acknowledgement state
 
 ---
 
-## syslog ack_error
-Acknowledge an error signature so it is suppressed from future `unaddressed_errors`
-results. Writes an audit event and updates the acknowledgement projection. Use
-`unack_error` to revoke.
-
-**Parameters:**
-- `signature_hash` (string, **required**) — the SHA-256 hash from `unaddressed_errors`
-- `notes` (string, optional) — acknowledgement notes (max 4096 chars)
-
----
-
-## syslog unack_error
-Revoke an existing acknowledgement on an error signature so it reappears in
-`unaddressed_errors`. Writes an unack audit event; does NOT delete the ack history.
-
-**Parameters:**
-- `signature_hash` (string, **required**) — the SHA-256 hash of the signature
-- `reason` (string, optional) — reason for removing the acknowledgement (max 4096 chars)
-
----
-
 ## syslog notifications_recent
 List recent notification firings from the `notification_firings` table.
 
@@ -1011,22 +1064,18 @@ List recent notification firings from the `notification_firings` table.
 - `rule_id` (string, optional) — filter by rule ID (e.g. `oom_kill`, `daily_digest`)
 - `since` (string, optional) — ISO8601 lower bound for `fired_at`
 
----
-
-## syslog notifications_test
-Send a test notification via the server-configured Apprise URLs. Rate-limited to 10 per minute per actor.
-Caller-supplied Apprise URLs are ignored for security; the server uses its own configured URLs.
-
-**Parameters:**
-- `body` (string, optional) — notification body text (default: test message)
-
----
+"#;
+    let help = format!(
+        "{help}{}{}",
+        admin_action_help(),
+        r#"---
 
 ## syslog help
 Returns this markdown documentation.
 
 **Parameters:** none
-"#;
+"#
+    );
     Ok(json!({ "help": help }))
 }
 

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -80,6 +80,7 @@ async fn numeric_args_reject_out_of_range_values() {
         &h.state,
         "syslog",
         json!({"action": "tail", "n": u64::from(u32::MAX) + 1}),
+        None,
     )
     .await
     .unwrap_err();
@@ -95,7 +96,9 @@ async fn numeric_args_reject_wrong_type_values() {
         json!({"action": "correlate", "reference_time": "2026-01-01T00:00:00Z", "window_minutes": "5"}),
         json!({"action": "correlate", "reference_time": "2026-01-01T00:00:00Z", "limit": null}),
     ] {
-        let err = execute_tool(&h.state, "syslog", args).await.unwrap_err();
+        let err = execute_tool(&h.state, "syslog", args, None)
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("must be an unsigned integer"));
     }
 }
@@ -151,7 +154,7 @@ async fn schema_actions_are_dispatchable() {
             }
             _ => json!({"action": action}),
         };
-        let result = execute_tool(&h.state, "syslog", args).await;
+        let result = execute_tool(&h.state, "syslog", args, None).await;
         if *action == "compose_doctor" {
             if let Err(error) = result {
                 assert!(
@@ -249,12 +252,12 @@ async fn public_action_references_cover_schema_registry() {
 #[tokio::test]
 async fn syslog_tool_requires_known_action() {
     let h = TestHarness::new();
-    let missing = execute_tool(&h.state, "syslog", json!({}))
+    let missing = execute_tool(&h.state, "syslog", json!({}), None)
         .await
         .unwrap_err();
     assert!(missing.to_string().contains("action is required"));
 
-    let unknown = execute_tool(&h.state, "syslog", json!({"action": "reboot"}))
+    let unknown = execute_tool(&h.state, "syslog", json!({"action": "reboot"}), None)
         .await
         .unwrap_err();
     assert!(unknown.to_string().contains("unknown syslog action"));
@@ -276,7 +279,9 @@ async fn compose_action_rejects_target_override() {
             args.as_object_mut()
                 .unwrap()
                 .insert(key.into(), json!("override-value"));
-            let err = execute_tool(&h.state, "syslog", args).await.unwrap_err();
+            let err = execute_tool(&h.state, "syslog", args, None)
+                .await
+                .unwrap_err();
             assert!(
                 err.to_string().contains("target override"),
                 "expected target override rejection for {action}.{key}, got: {err}"


### PR DESCRIPTION
## Summary
- Thread per-request AuthContext from RMCP call handling into syslog tool execution.
- Use authenticated email, falling back to subject, for ack_error, unack_error, and notifications_test actors.
- Add RMCP coverage proving distinct request identities are persisted in admin/audit events.
- Generate admin help sections for the touched mutating action surface from shared metadata.
- Bump version metadata to 0.25.4 with changelog entry.

## Verification
- RUSTC_WRAPPER= cargo test mounted_admin_actions_record_per_request_subject_actor
- RUSTC_WRAPPER= cargo test public_action_references_cover_schema_registry
- RUSTC_WRAPPER= cargo test schema_actions_are_dispatchable
- RUSTC_WRAPPER= cargo test
- RUSTC_WRAPPER= cargo clippy
- bash scripts/check-version-sync.sh
- pre-commit hook: cargo fmt, cargo clippy -- -D warnings
- pre-push hook: cargo test

## Review tooling
- Attempted Lab Agent substitutions for lavra/code_simplifier/pr-review-toolkit, but this runtime reported no available subagent types. Manual review was performed against touched files after the failed tool dispatch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates per-request MCP auth into syslog tool execution so admin actions and test notifications record the real caller and rate-limit per actor. Also generates admin help from shared metadata and refreshes dependencies (regenerated `Cargo.lock` for 0.26.0).

- **Bug Fixes**
  - Threaded `AuthContext` from RMCP server to tools; `ack_error`, `unack_error`, and `notifications_test` now use authenticated email, then subject. Loopback/bearer modes still use `mcp:loopback`/`mcp:oauth`/`mcp:bearer`.
  - Persisted actor in admin/audit events with RMCP tests proving distinct per-request identities for `ack_error` and `unack_error`; `notifications_test` keys rate limits by the same actor.

- **Refactors**
  - Generated admin help for acknowledgements and test notifications from shared action metadata to prevent drift.
  - Updated tool and test call sites to accept optional auth context; regenerated `Cargo.lock` for 0.26.0.

<sup>Written for commit 790b75141c51d67cf0b9eeb276fa006c404a1668. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/32?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

