### PR TITLE
fix: optimize AI analytics queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   migration indexes/version metadata.
 - **Review artifact preservation**: Copied the consolidated full-review issue
   register into tracked docs.
+- **AI analytics query cost**: `search_ai_sessions` now computes session event
+  counts with a grouped join backed by an AI session/host/time index, avoiding a
+  full-history count per grouped result. `ai_correlate` now batches related-log
+  window lookups into one bounded query instead of issuing one database search
+  per anchor.
 
 ## [0.25.2] - 2026-05-16
 

--- a/docs/sessions/2026-05-18-cfr-ai-analytics-query-performance.md
+++ b/docs/sessions/2026-05-18-cfr-ai-analytics-query-performance.md
@@ -1,0 +1,117 @@
+---
+date: 2026-05-18 00:49:01 EDT
+repo: https://github.com/jmagar/syslog-mcp
+branch: work/cfr-ai-analytics
+head: 94ccc47
+plan: /home/jmagar/workspace/syslog-mcp/06-all-issues.md
+working directory: /home/jmagar/workspace/syslog-mcp/.worktrees/cfr-ai-analytics
+worktree: /home/jmagar/workspace/syslog-mcp/.worktrees/cfr-ai-analytics
+pr: "#33 fix: optimize AI analytics queries https://github.com/jmagar/syslog-mcp/pull/33"
+---
+
+# CFR AI Analytics Query Performance
+
+## User Request
+
+Implement Agent 3's assignment from `06-all-issues.md`: CFR-007, CFR-008, CFR-011, and CFR-015 covering AI analytics query performance, query structure, and query-plan/load regression coverage.
+
+## Session Overview
+
+- Created isolated worktree `.worktrees/cfr-ai-analytics` on branch `work/cfr-ai-analytics`.
+- Replaced `search_ai_sessions` per-group full-history `event_count` correlated count with a grouped `event_counts` CTE.
+- Added a targeted AI session/host/time SQLite index via migration 14.
+- Replaced `ai_correlate` per-anchor related-log DB searches with one batched related-window query.
+- Added focused query-plan/load tests and service-level batched correlation coverage.
+- Opened PR #33 and pushed branch `work/cfr-ai-analytics`.
+
+## Sequence of Events
+
+1. Inspected main checkout state and confirmed only untracked `06-all-issues.md` existed there.
+2. Created `.worktrees/cfr-ai-analytics` from `main` and read the relevant CFR issues from the absolute plan path.
+3. Read `src/db/queries.rs`, `src/db/queries_tests.rs`, `src/app/service.rs`, `src/app/service_tests.rs`, and `src/db/pool.rs`.
+4. Implemented reusable AI SQL filter helpers, grouped session event counting, batched related-log lookup, and migration 14.
+5. Added focused DB and app tests, then ran focused and full verification.
+6. Bumped version metadata to `0.25.4`, added a changelog entry, committed, pushed, and created PR #33.
+7. Attempted work-it review waves. Named review agents and the default/general agent were unavailable through the lab bridge, so direct GitHub comment fetch and local review/verification were used as substitutes.
+
+## Key Findings
+
+- `search_ai_sessions` counted full session history once per grouped result; this was the CFR-007 hot path.
+- `correlate_ai_logs` performed one blocking DB `search_logs` call for every anchor; this was the CFR-008 hot path.
+- Existing AI metadata indexes did not include `hostname` or `timestamp` in the same key order needed for grouped session event-count lookups.
+- Direct GitHub review thread APIs reported no review threads for PR #33 at the time of capture.
+- CodeRabbit posted a rate-limit notice rather than an actionable review.
+
+## Technical Decisions
+
+- Kept `event_count` semantics as full session history, matching prior behavior, by joining grouped matches back to `logs` without applying the search time window to the count.
+- Added `idx_logs_ai_session_host_time` on `(ai_project, ai_tool, ai_session_id, hostname, timestamp)` to support grouped event-count probes.
+- Used a `VALUES` CTE plus `ROW_NUMBER() OVER (PARTITION BY anchor_index ...)` for batched related-log windows, preserving per-anchor truncation behavior.
+- Left the small best-snippet lookup correlated over the bounded `candidates` CTE because CFR-007 targeted the unbounded full-history count.
+
+## Files Modified
+
+- `src/db/queries.rs`: AI SQL helpers, grouped session query, batched related-log query, row mapper offset helper.
+- `src/db/models.rs`: request/response structs for batched AI related-log windows.
+- `src/db.rs`: exports for the new related-log query and model types.
+- `src/app/service.rs`: `correlate_ai_logs` now performs one related-log DB call after anchor discovery.
+- `src/db/pool.rs`: migration 14 and always-on creation for `idx_logs_ai_session_host_time`.
+- `src/db/queries_tests.rs`: query-plan and batched related-log regression tests.
+- `src/app/service_tests.rs`: service-level multi-anchor/per-anchor-cap correlation test.
+- `Cargo.toml`, `Cargo.lock`, `server.json`, `CHANGELOG.md`: patch version bump to `0.25.4`.
+
+## Commands Executed
+
+- `git worktree add -b work/cfr-ai-analytics .worktrees/cfr-ai-analytics HEAD`: created isolated worktree.
+- `RUSTC_WRAPPER= cargo test search_ai`: focused DB AI tests passed.
+- `RUSTC_WRAPPER= cargo test correlate_ai_logs`: focused service AI correlate tests passed.
+- `cargo fmt`: formatting passed.
+- `RUSTC_WRAPPER= cargo test`: full suite passed after version bump.
+- `RUSTC_WRAPPER= cargo clippy -- -D warnings`: clippy passed.
+- `bash scripts/check-version-sync.sh .`: version sync passed.
+- `git push -u origin HEAD`: pushed branch and pre-push `cargo test` passed.
+- `gh pr create --base main --head work/cfr-ai-analytics ...`: created PR #33.
+
+## Errors Encountered
+
+- `git status` in the new worktree initially failed because Git LFS tried to write shared `.git/lfs/tmp` state through the sandbox. Reran status with escalation and confirmed a clean worktree baseline.
+- The first focused test run failed in `sccache` with an allocation error while packaging compiler output. Reran Rust verification with `RUSTC_WRAPPER=` and continued successfully.
+- The first batched related-log SQL used a second `ON` clause after joining `logs_fts`; fixed by moving the timestamp window predicate into the `JOIN logs l ON ...` condition.
+- Named review agents and default/general `Agent` dispatch were unavailable through the lab bridge in this session. Used local review, direct GitHub API comment checks, and verification as substitutes.
+- `gh-fetch-comments` failed its auth preflight even though `gh auth status` and direct `gh api` calls succeeded. Used direct REST/GraphQL comment and review-thread queries.
+
+## Behavior Changes
+
+- Before: `search_ai_sessions` could perform one unbounded `COUNT(*) FROM logs` per grouped session result.
+- After: `search_ai_sessions` materializes grouped matches and joins once to grouped event counts.
+- Before: `ai_correlate` performed up to one anchor query plus one related-log query per anchor.
+- After: `ai_correlate` still performs one anchor query, then one batched related-log query for all anchor windows.
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---|---|---|---|
+| `RUSTC_WRAPPER= cargo test search_ai` | Focused AI DB tests pass | 7 passed | PASS |
+| `RUSTC_WRAPPER= cargo test correlate_ai_logs` | Focused service correlate tests pass | 2 passed | PASS |
+| `RUSTC_WRAPPER= cargo test` | Full suite passes | 582 lib tests, 48 bin tests, integration tests, doc tests passed | PASS |
+| `RUSTC_WRAPPER= cargo clippy -- -D warnings` | No clippy warnings | Finished successfully | PASS |
+| `bash scripts/check-version-sync.sh .` | Version-bearing files aligned | OK, all checked files at v0.25.4 | PASS |
+| `git diff --check` | No whitespace errors | No output | PASS |
+| Pre-commit hook | format and clippy pass | `cargo fmt` and `cargo clippy -- -D warnings` passed | PASS |
+| Pre-push hook | full test suite passes | `cargo test` passed | PASS |
+
+## Risks and Rollback
+
+- Migration 14 creates a new index and may take time on large AI transcript databases; the migration logs start/end timing.
+- The `EXPLAIN QUERY PLAN` regression test asserts use of `idx_logs_ai_session_host_time`; future SQLite planner changes may require revisiting the assertion.
+- Rollback path is to revert PR #33, which removes migration 14 creation code and restores the prior per-anchor/per-group query behavior.
+
+## Open Questions
+
+- GitHub CI was still running for Tests, Security Audit, build-and-push, and cubic review when this note was written. Local equivalents for tests/clippy passed.
+- CodeRabbit was rate-limited and did not provide actionable review findings.
+
+## Next Steps
+
+- Re-check PR #33 after external CI and cubic finish.
+- Trigger CodeRabbit review after the rate-limit window if an external CodeRabbit pass is required.

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -252,42 +252,51 @@ impl SyslogService {
         let anchors_truncated = anchors.len() > anchor_limit as usize;
         anchors.truncate(anchor_limit as usize);
 
-        let mut correlated = Vec::with_capacity(anchors.len());
-        let mut total_related_events = 0usize;
-        for anchor in anchors {
+        let mut anchor_entries = Vec::with_capacity(anchors.len());
+        let mut windows = Vec::with_capacity(anchors.len());
+        for (anchor_index, anchor) in anchors.into_iter().enumerate() {
             let ref_dt = parse_required_timestamp(&anchor.timestamp, "anchor.timestamp")?;
             let delta = TimeDelta::try_minutes(i64::from(window))
                 .ok_or_else(|| ServiceError::InvalidInput("duration overflow".into()))?;
             let window_from = rfc3339_z(ref_dt - delta);
             let window_to = rfc3339_z(ref_dt + delta);
-            let search_params = SearchParams {
-                query: req.log_query.clone(),
-                hostname: req.hostname.clone(),
-                source_ip: req.source_ip.clone(),
-                severity: None,
-                severity_in: Some(severity_levels.clone()),
-                app_name: req.app_name.clone(),
-                facility: None,
-                process_id: None,
-                from: Some(window_from.clone()),
-                to: Some(window_to.clone()),
-                limit: Some(related_limit + 1),
-                ai_tool: None,
-                ai_project: None,
-                ai_session_id: None,
-                exclude_ai: true,
-            };
-            let mut related = self
-                .run_db(move |pool| db::search_logs(pool, &search_params))
-                .await?;
-            let related_truncated = related.len() > related_limit as usize;
-            related.truncate(related_limit as usize);
-            total_related_events += related.len();
+            windows.push(db::AiRelatedWindow {
+                anchor_index,
+                window_from: window_from.clone(),
+                window_to: window_to.clone(),
+            });
+            anchor_entries.push((anchor, window_from, window_to));
+        }
+
+        let related_params = db::AiRelatedLogsParams {
+            windows,
+            query: req.log_query,
+            hostname: req.hostname,
+            source_ip: req.source_ip,
+            severity_in: severity_levels,
+            app_name: req.app_name,
+            limit_per_anchor: related_limit,
+        };
+        let related_by_anchor = self
+            .run_db(move |pool| db::search_ai_related_logs(pool, &related_params))
+            .await?;
+
+        let mut correlated = Vec::with_capacity(anchor_entries.len());
+        let mut total_related_events = 0usize;
+        for (anchor_index, (anchor, window_from, window_to)) in
+            anchor_entries.into_iter().enumerate()
+        {
+            let related = related_by_anchor
+                .iter()
+                .find(|group| group.anchor_index == anchor_index);
+            let related_logs = related.map(|group| group.logs.clone()).unwrap_or_default();
+            let related_truncated = related.map(|group| group.truncated).unwrap_or(false);
+            total_related_events += related_logs.len();
             correlated.push(AiCorrelationAnchor {
                 entry: anchor.into(),
                 window_from,
                 window_to,
-                related: related.into_iter().map(Into::into).collect(),
+                related: related_logs.into_iter().map(Into::into).collect(),
                 related_truncated,
             });
         }

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -281,16 +281,21 @@ impl SyslogService {
             .run_db(move |pool| db::search_ai_related_logs(pool, &related_params))
             .await?;
 
+        let mut by_anchor: std::collections::HashMap<usize, db::AiRelatedLogsForAnchor> =
+            related_by_anchor
+                .into_iter()
+                .map(|group| (group.anchor_index, group))
+                .collect();
+
         let mut correlated = Vec::with_capacity(anchor_entries.len());
         let mut total_related_events = 0usize;
         for (anchor_index, (anchor, window_from, window_to)) in
             anchor_entries.into_iter().enumerate()
         {
-            let related = related_by_anchor
-                .iter()
-                .find(|group| group.anchor_index == anchor_index);
-            let related_logs = related.map(|group| group.logs.clone()).unwrap_or_default();
-            let related_truncated = related.map(|group| group.truncated).unwrap_or(false);
+            let (related_logs, related_truncated) = by_anchor
+                .remove(&anchor_index)
+                .map(|group| (group.logs, group.truncated))
+                .unwrap_or((Vec::new(), false));
             total_related_events += related_logs.len();
             correlated.push(AiCorrelationAnchor {
                 entry: anchor.into(),

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -164,6 +164,69 @@ async fn correlate_ai_logs_cross_references_non_ai_logs_only() {
 }
 
 #[tokio::test]
+async fn correlate_ai_logs_batches_related_windows_with_per_anchor_caps() {
+    let (service, pool, _dir) = test_service();
+    insert_logs_batch(
+        &pool,
+        &[
+            ai_entry("2026-01-01T00:00:00Z", "deploy failure near host-a"),
+            entry(
+                "2026-01-01T00:00:10Z",
+                "host-a",
+                "err",
+                "deploy failed on host-a",
+                "10.0.0.1:514",
+            ),
+            entry(
+                "2026-01-01T00:00:20Z",
+                "host-a",
+                "warning",
+                "deploy warning on host-a",
+                "10.0.0.1:514",
+            ),
+            ai_entry("2026-01-01T00:10:00Z", "deploy failure near host-b"),
+            entry(
+                "2026-01-01T00:10:10Z",
+                "host-b",
+                "err",
+                "deploy failed on host-b",
+                "10.0.0.2:514",
+            ),
+        ],
+    )
+    .unwrap();
+
+    let response = service
+        .correlate_ai_logs(AiCorrelateRequest {
+            project: Some("/tmp/project".into()),
+            tool: Some("codex".into()),
+            ai_query: Some("deploy".into()),
+            log_query: Some("deploy".into()),
+            window_minutes: Some(1),
+            severity_min: Some("warning".into()),
+            limit: Some(2),
+            events_per_anchor: Some(1),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(response.total_anchors, 2);
+    assert_eq!(response.related_limit_per_anchor, 1);
+    assert_eq!(response.total_related_events, 2);
+    let truncated_count = response
+        .anchors
+        .iter()
+        .filter(|anchor| anchor.related_truncated)
+        .count();
+    assert_eq!(truncated_count, 1);
+    assert!(response
+        .anchors
+        .iter()
+        .all(|anchor| anchor.related.len() == 1));
+}
+
+#[tokio::test]
 async fn source_ip_filter_uses_network_sender_identity() {
     let (service, pool, _dir) = test_service();
     insert_logs_batch(

--- a/src/db.rs
+++ b/src/db.rs
@@ -26,16 +26,17 @@ pub use maintenance::{
 pub(crate) use maintenance::{db_pragma_i64, db_pragma_string};
 pub use models::{
     AiAbuseMatch, AiAbuseParams, AiAbuseResult, AiCorrelateParams, AiProjectContext,
-    AiProjectContextParams, AiProjectInventoryEntry, AiSessionEntry, AiToolInventoryEntry,
-    AiUsageBlock, AiUsageBlocksParams, AiUsageBlocksResult, DbStats, DockerCheckpoint,
-    ErrorSummaryEntry, HostEntry, ListAiProjectsParams, ListAiProjectsResult, ListAiSessionsParams,
-    ListAiToolsParams, ListAiToolsResult, LogBatchEntry, LogEntry, SearchAiSessionsParams,
-    SearchAiSessionsResult, SearchParams, SearchedAiSessionEntry,
+    AiProjectContextParams, AiProjectInventoryEntry, AiRelatedLogsForAnchor, AiRelatedLogsParams,
+    AiRelatedWindow, AiSessionEntry, AiToolInventoryEntry, AiUsageBlock, AiUsageBlocksParams,
+    AiUsageBlocksResult, DbStats, DockerCheckpoint, ErrorSummaryEntry, HostEntry,
+    ListAiProjectsParams, ListAiProjectsResult, ListAiSessionsParams, ListAiToolsParams,
+    ListAiToolsResult, LogBatchEntry, LogEntry, SearchAiSessionsParams, SearchAiSessionsResult,
+    SearchParams, SearchedAiSessionEntry,
 };
 pub use models::{StorageBudgetState, StorageEnforcementOutcome, StorageMetrics, StorageRecovery};
 pub use pool::{init_pool, DbPool};
 pub use queries::{
     get_error_summary, get_stats, list_ai_projects, list_ai_sessions, list_ai_tools, list_hosts,
-    search_ai_abuse, search_ai_anchors, search_ai_sessions, search_logs, severity_to_num,
-    tail_logs, validate_fts_query, SEVERITY_LEVELS,
+    search_ai_abuse, search_ai_anchors, search_ai_related_logs, search_ai_sessions, search_logs,
+    severity_to_num, tail_logs, validate_fts_query, SEVERITY_LEVELS,
 };

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -193,6 +193,31 @@ pub struct AiCorrelateParams {
     pub limit: Option<u32>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiRelatedWindow {
+    pub anchor_index: usize,
+    pub window_from: String,
+    pub window_to: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AiRelatedLogsParams {
+    pub windows: Vec<AiRelatedWindow>,
+    pub query: Option<String>,
+    pub hostname: Option<String>,
+    pub source_ip: Option<String>,
+    pub severity_in: Vec<String>,
+    pub app_name: Option<String>,
+    pub limit_per_anchor: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiRelatedLogsForAnchor {
+    pub anchor_index: usize,
+    pub logs: Vec<LogEntry>,
+    pub truncated: bool,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AiUsageBlocksParams {
     pub ai_project: Option<String>,

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -543,6 +543,31 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
         tracing::info!("Migration 13: added enrichment columns + partial indexes");
     }
 
+    let already_applied_14: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM schema_migrations WHERE version = 14",
+        [],
+        |r| r.get(0),
+    )?;
+    if already_applied_14 == 0 {
+        tracing::info!(
+            "Migration 14: starting CREATE INDEX idx_logs_ai_session_host_time \
+             — may take time on large AI transcript databases"
+        );
+        let started = std::time::Instant::now();
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_logs_ai_session_host_time
+                 ON logs(ai_project, ai_tool, ai_session_id, hostname, timestamp)
+                 WHERE ai_project IS NOT NULL
+                   AND ai_tool IS NOT NULL
+                   AND ai_session_id IS NOT NULL;
+             INSERT INTO schema_migrations (version) VALUES (14);",
+        )?;
+        tracing::info!(
+            elapsed_ms = started.elapsed().as_millis(),
+            "Migration 14: AI session host/time index created"
+        );
+    }
+
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_logs_ai_project_time
              ON logs(ai_project, timestamp)
@@ -550,6 +575,11 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
          CREATE INDEX IF NOT EXISTS idx_logs_ai_session
              ON logs(ai_tool, ai_project, ai_session_id)
              WHERE ai_tool IS NOT NULL;
+         CREATE INDEX IF NOT EXISTS idx_logs_ai_session_host_time
+             ON logs(ai_project, ai_tool, ai_session_id, hostname, timestamp)
+             WHERE ai_project IS NOT NULL
+               AND ai_tool IS NOT NULL
+               AND ai_session_id IS NOT NULL;
          CREATE INDEX IF NOT EXISTS idx_logs_ai_transcript_path
              ON logs(ai_transcript_path)
              WHERE ai_transcript_path IS NOT NULL;",

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -6,10 +6,10 @@ use crate::config::StorageConfig;
 use super::maintenance::{exceeds_trigger, get_storage_metrics};
 use super::models::{
     AiAbuseMatch, AiAbuseParams, AiAbuseResult, AiCorrelateParams, AiProjectInventoryEntry,
-    AiSessionEntry, AiToolInventoryEntry, DbStats, ErrorSummaryEntry, HostEntry,
-    ListAiProjectsParams, ListAiProjectsResult, ListAiSessionsParams, ListAiToolsParams,
-    ListAiToolsResult, LogEntry, SearchAiSessionsParams, SearchAiSessionsResult, SearchParams,
-    SearchedAiSessionEntry,
+    AiRelatedLogsForAnchor, AiRelatedLogsParams, AiSessionEntry, AiToolInventoryEntry, DbStats,
+    ErrorSummaryEntry, HostEntry, ListAiProjectsParams, ListAiProjectsResult, ListAiSessionsParams,
+    ListAiToolsParams, ListAiToolsResult, LogEntry, SearchAiSessionsParams, SearchAiSessionsResult,
+    SearchParams, SearchedAiSessionEntry,
 };
 use super::pool::DbPool;
 
@@ -32,6 +32,70 @@ pub fn validate_fts_query(query: &str) -> Result<()> {
         anyhow::bail!("Search query has too many terms ({term_count}); maximum is 16 terms");
     }
     Ok(())
+}
+
+#[derive(Debug, Default)]
+struct SqlParams {
+    bindings: Vec<rusqlite::types::Value>,
+    next_idx: usize,
+}
+
+impl SqlParams {
+    fn new(next_idx: usize) -> Self {
+        Self {
+            bindings: Vec::new(),
+            next_idx,
+        }
+    }
+
+    fn push_text(&mut self, value: String) -> usize {
+        let idx = self.next_idx;
+        self.bindings.push(rusqlite::types::Value::Text(value));
+        self.next_idx += 1;
+        idx
+    }
+
+    fn push_i64(&mut self, value: i64) -> usize {
+        let idx = self.next_idx;
+        self.bindings.push(rusqlite::types::Value::Integer(value));
+        self.next_idx += 1;
+        idx
+    }
+}
+
+fn push_required_ai_filters(sql: &mut String, alias: &str) {
+    sql.push_str(&format!(
+        " AND {alias}.ai_project IS NOT NULL AND {alias}.ai_project != ''
+          AND {alias}.ai_tool IS NOT NULL AND {alias}.ai_tool != ''
+          AND {alias}.ai_session_id IS NOT NULL AND {alias}.ai_session_id != ''"
+    ));
+}
+
+fn push_ai_scope_filters(
+    sql: &mut String,
+    params: &mut SqlParams,
+    alias: &str,
+    project: &Option<String>,
+    tool: &Option<String>,
+    from: &Option<String>,
+    to: &Option<String>,
+) {
+    if let Some(project) = project {
+        let idx = params.push_text(project.clone());
+        sql.push_str(&format!(" AND {alias}.ai_project = ?{idx}"));
+    }
+    if let Some(tool) = tool {
+        let idx = params.push_text(tool.clone());
+        sql.push_str(&format!(" AND {alias}.ai_tool = ?{idx}"));
+    }
+    if let Some(from) = from {
+        let idx = params.push_text(from.clone());
+        sql.push_str(&format!(" AND {alias}.timestamp >= ?{idx}"));
+    }
+    if let Some(to) = to {
+        let idx = params.push_text(to.clone());
+        sql.push_str(&format!(" AND {alias}.timestamp <= ?{idx}"));
+    }
 }
 
 /// Search logs with flexible filtering + FTS
@@ -295,90 +359,7 @@ pub fn search_ai_sessions(
 
     let conn = pool.get()?;
     let limit = params.limit.unwrap_or(20).clamp(1, 100) as usize;
-    const CANDIDATE_CAP: usize = 5_000;
-
-    let mut sql = String::from(
-        "WITH candidates AS (
-            SELECT l.ai_project,
-                   l.ai_tool,
-                   l.ai_session_id,
-                   l.hostname,
-                   l.timestamp,
-                   l.message
-            FROM logs_fts
-            JOIN logs l ON l.id = logs_fts.rowid
-            WHERE logs_fts MATCH ?1
-              AND l.ai_project IS NOT NULL AND l.ai_project != ''
-              AND l.ai_tool IS NOT NULL AND l.ai_tool != ''
-              AND l.ai_session_id IS NOT NULL AND l.ai_session_id != ''",
-    );
-    let mut bindings = vec![rusqlite::types::Value::Text(params.query.clone())];
-    let mut idx = 2usize;
-
-    if let Some(project) = &params.ai_project {
-        sql.push_str(&format!(" AND l.ai_project = ?{idx}"));
-        bindings.push(rusqlite::types::Value::Text(project.clone()));
-        idx += 1;
-    }
-    if let Some(tool) = &params.ai_tool {
-        sql.push_str(&format!(" AND l.ai_tool = ?{idx}"));
-        bindings.push(rusqlite::types::Value::Text(tool.clone()));
-        idx += 1;
-    }
-    if let Some(from) = &params.from {
-        sql.push_str(&format!(" AND l.timestamp >= ?{idx}"));
-        bindings.push(rusqlite::types::Value::Text(from.clone()));
-        idx += 1;
-    }
-    if let Some(to) = &params.to {
-        sql.push_str(&format!(" AND l.timestamp <= ?{idx}"));
-        bindings.push(rusqlite::types::Value::Text(to.clone()));
-    }
-    sql.push_str(&format!(
-        " ORDER BY logs_fts.rowid DESC
-           LIMIT {}
-         ),
-         grouped AS (
-            SELECT ai_project,
-                   ai_tool,
-                   ai_session_id,
-                   hostname,
-                   MIN(timestamp) AS first_seen,
-                   MAX(timestamp) AS last_seen,
-                   COUNT(*) AS match_count,
-                   (
-                       SELECT c2.message
-                       FROM candidates c2
-                       WHERE c2.ai_project = c.ai_project
-                         AND c2.ai_tool = c.ai_tool
-                         AND c2.ai_session_id = c.ai_session_id
-                         AND c2.hostname = c.hostname
-                       ORDER BY c2.timestamp DESC
-                       LIMIT 1
-                   ) AS best_snippet
-            FROM candidates c
-            GROUP BY ai_project, ai_tool, ai_session_id, hostname
-         )
-         SELECT ai_project, ai_tool, ai_session_id, hostname,
-                first_seen,
-                last_seen,
-                (
-                    SELECT COUNT(*)
-                    FROM logs total
-                    WHERE total.ai_project = grouped.ai_project
-                      AND total.ai_tool = grouped.ai_tool
-                      AND total.ai_session_id = grouped.ai_session_id
-                      AND total.hostname = grouped.hostname
-                ) AS event_count,
-                match_count,
-                best_snippet,
-                COUNT(*) OVER() AS total_candidates,
-                (SELECT COUNT(*) FROM candidates) AS raw_candidate_count
-         FROM grouped
-         ORDER BY last_seen DESC
-         LIMIT {limit}",
-        CANDIDATE_CAP + 1
-    ));
+    let (sql, bindings) = search_ai_sessions_sql(params, limit);
 
     let mut stmt = conn.prepare(&sql)?;
     let mut total_candidates = 0usize;
@@ -410,6 +391,98 @@ pub fn search_ai_sessions(
     })
 }
 
+const CANDIDATE_CAP: usize = 5_000;
+
+fn search_ai_sessions_sql(
+    params: &SearchAiSessionsParams,
+    limit: usize,
+) -> (String, Vec<rusqlite::types::Value>) {
+    let mut sql = String::from(
+        "WITH candidates AS (
+            SELECT l.ai_project,
+                   l.ai_tool,
+                   l.ai_session_id,
+                   l.hostname,
+                   l.timestamp,
+                   l.message
+            FROM logs_fts
+            JOIN logs l ON l.id = logs_fts.rowid
+            WHERE logs_fts MATCH ?1",
+    );
+    push_required_ai_filters(&mut sql, "l");
+    let mut query_params = SqlParams::new(2);
+    query_params
+        .bindings
+        .push(rusqlite::types::Value::Text(params.query.clone()));
+    push_ai_scope_filters(
+        &mut sql,
+        &mut query_params,
+        "l",
+        &params.ai_project,
+        &params.ai_tool,
+        &params.from,
+        &params.to,
+    );
+    sql.push_str(&format!(
+        " ORDER BY logs_fts.rowid DESC
+           LIMIT {}
+         ),
+         grouped AS (
+            SELECT ai_project,
+                   ai_tool,
+                   ai_session_id,
+                   hostname,
+                   MIN(timestamp) AS first_seen,
+                   MAX(timestamp) AS last_seen,
+                   COUNT(*) AS match_count,
+                   (
+                       SELECT c2.message
+                       FROM candidates c2
+                       WHERE c2.ai_project = c.ai_project
+                         AND c2.ai_tool = c.ai_tool
+                         AND c2.ai_session_id = c.ai_session_id
+                         AND c2.hostname = c.hostname
+                       ORDER BY c2.timestamp DESC
+                       LIMIT 1
+                   ) AS best_snippet
+            FROM candidates c
+            GROUP BY ai_project, ai_tool, ai_session_id, hostname
+         ),
+         event_counts AS (
+            SELECT l.ai_project,
+                   l.ai_tool,
+                   l.ai_session_id,
+                   l.hostname,
+                   COUNT(*) AS event_count
+            FROM logs l
+            JOIN grouped g
+              ON g.ai_project = l.ai_project
+             AND g.ai_tool = l.ai_tool
+             AND g.ai_session_id = l.ai_session_id
+             AND g.hostname = l.hostname
+            GROUP BY l.ai_project, l.ai_tool, l.ai_session_id, l.hostname
+         )
+         SELECT g.ai_project, g.ai_tool, g.ai_session_id, g.hostname,
+                g.first_seen,
+                g.last_seen,
+                COALESCE(ec.event_count, 0) AS event_count,
+                g.match_count,
+                g.best_snippet,
+                COUNT(*) OVER() AS total_candidates,
+                (SELECT COUNT(*) FROM candidates) AS raw_candidate_count
+         FROM grouped g
+         LEFT JOIN event_counts ec
+           ON ec.ai_project = g.ai_project
+          AND ec.ai_tool = g.ai_tool
+          AND ec.ai_session_id = g.ai_session_id
+          AND ec.hostname = g.hostname
+         ORDER BY g.last_seen DESC
+         LIMIT {limit}",
+        CANDIDATE_CAP + 1
+    ));
+    (sql, query_params.bindings)
+}
+
 pub fn search_ai_anchors(pool: &DbPool, params: &AiCorrelateParams) -> Result<Vec<LogEntry>> {
     let conn = pool.get()?;
     let limit = params.limit.unwrap_or(10).clamp(1, 50);
@@ -425,10 +498,7 @@ pub fn search_ai_anchors(pool: &DbPool, params: &AiCorrelateParams) -> Result<Ve
                     l.ai_tool, l.ai_project, l.ai_session_id, l.ai_transcript_path, l.metadata_json
              FROM logs_fts
              JOIN logs l ON l.id = logs_fts.rowid
-             WHERE logs_fts MATCH ?1
-               AND l.ai_project IS NOT NULL AND l.ai_project != ''
-               AND l.ai_tool IS NOT NULL AND l.ai_tool != ''
-               AND l.ai_session_id IS NOT NULL AND l.ai_session_id != ''",
+             WHERE logs_fts MATCH ?1",
         )
     } else {
         String::from(
@@ -436,12 +506,11 @@ pub fn search_ai_anchors(pool: &DbPool, params: &AiCorrelateParams) -> Result<Ve
                     l.app_name, l.process_id, l.message, l.received_at, l.source_ip,
                     l.ai_tool, l.ai_project, l.ai_session_id, l.ai_transcript_path, l.metadata_json
              FROM logs l
-             WHERE l.ai_project IS NOT NULL AND l.ai_project != ''
-               AND l.ai_tool IS NOT NULL AND l.ai_tool != ''
-               AND l.ai_session_id IS NOT NULL AND l.ai_session_id != ''",
+             WHERE 1=1",
         )
     };
 
+    push_required_ai_filters(&mut sql, "l");
     if let Some(project) = &params.ai_project {
         sql.push_str(&format!(" AND l.ai_project = ?{idx}"));
         bindings.push(rusqlite::types::Value::Text(project.clone()));
@@ -474,6 +543,133 @@ pub fn search_ai_anchors(pool: &DbPool, params: &AiCorrelateParams) -> Result<Ve
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(rusqlite::params_from_iter(bindings.iter()), map_row)?;
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+pub fn search_ai_related_logs(
+    pool: &DbPool,
+    params: &AiRelatedLogsParams,
+) -> Result<Vec<AiRelatedLogsForAnchor>> {
+    if params.windows.is_empty() {
+        return Ok(Vec::new());
+    }
+    if let Some(query) = &params.query {
+        validate_fts_query(query)?;
+    }
+
+    let conn = pool.get()?;
+    let limit = params.limit_per_anchor.clamp(1, 200) as usize;
+    let mut sql_params = SqlParams::new(1);
+    let values = params
+        .windows
+        .iter()
+        .map(|window| {
+            let anchor_idx = sql_params.push_i64(window.anchor_index as i64);
+            let from_idx = sql_params.push_text(window.window_from.clone());
+            let to_idx = sql_params.push_text(window.window_to.clone());
+            format!("(?{anchor_idx}, ?{from_idx}, ?{to_idx})")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let mut sql = format!(
+        "WITH windows(anchor_index, window_from, window_to) AS (VALUES {values}),
+         ranked AS (
+            SELECT w.anchor_index,
+                   l.id, l.timestamp, l.hostname, l.facility, l.severity,
+                   l.app_name, l.process_id, l.message, l.received_at, l.source_ip,
+                   l.ai_tool, l.ai_project, l.ai_session_id, l.ai_transcript_path, l.metadata_json,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY w.anchor_index
+                       ORDER BY l.timestamp DESC, l.id DESC
+                   ) AS related_rank
+            FROM windows w"
+    );
+    if let Some(query) = &params.query {
+        let query_idx = sql_params.push_text(query.clone());
+        sql.push_str(
+            "
+            JOIN logs_fts ON logs_fts MATCH ?",
+        );
+        sql.push_str(&query_idx.to_string());
+        sql.push_str(
+            "
+            JOIN logs l ON l.id = logs_fts.rowid
+             AND l.timestamp >= w.window_from
+             AND l.timestamp <= w.window_to",
+        );
+    } else {
+        sql.push_str(
+            "
+            JOIN logs l
+              ON l.timestamp >= w.window_from
+             AND l.timestamp <= w.window_to",
+        );
+    }
+    sql.push_str(" WHERE 1=1");
+
+    let search_params = SearchParams {
+        query: None,
+        hostname: params.hostname.clone(),
+        source_ip: params.source_ip.clone(),
+        severity: None,
+        severity_in: Some(params.severity_in.clone()),
+        app_name: params.app_name.clone(),
+        facility: None,
+        process_id: None,
+        from: None,
+        to: None,
+        limit: None,
+        ai_tool: None,
+        ai_project: None,
+        ai_session_id: None,
+        exclude_ai: true,
+    };
+    append_filters(
+        &mut sql,
+        &mut sql_params.bindings,
+        &mut sql_params.next_idx,
+        &search_params,
+    );
+    sql.push_str(&format!(
+        "
+         )
+         SELECT anchor_index, id, timestamp, hostname, facility, severity,
+                app_name, process_id, message, received_at, source_ip,
+                ai_tool, ai_project, ai_session_id, ai_transcript_path, metadata_json,
+                related_rank
+         FROM ranked
+         WHERE related_rank <= {}
+         ORDER BY anchor_index ASC, related_rank ASC",
+        limit + 1
+    ));
+
+    let mut grouped = params
+        .windows
+        .iter()
+        .map(|window| AiRelatedLogsForAnchor {
+            anchor_index: window.anchor_index,
+            logs: Vec::new(),
+            truncated: false,
+        })
+        .collect::<Vec<_>>();
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(rusqlite::params_from_iter(sql_params.bindings.iter()))?;
+    while let Some(row) = rows.next()? {
+        let anchor_index = row.get::<_, i64>(0)? as usize;
+        let related_rank = row.get::<_, i64>(16)? as usize;
+        if let Some(anchor) = grouped
+            .iter_mut()
+            .find(|group| group.anchor_index == anchor_index)
+        {
+            if related_rank > limit {
+                anchor.truncated = true;
+            } else {
+                anchor.logs.push(map_row_offset(row, 1)?);
+            }
+        }
+    }
+
+    Ok(grouped)
 }
 
 const DEFAULT_AI_ABUSE_TERMS: &[&str] = &[
@@ -1000,22 +1196,26 @@ fn append_filters(
 }
 
 pub(super) fn map_row(row: &rusqlite::Row) -> rusqlite::Result<LogEntry> {
+    map_row_offset(row, 0)
+}
+
+fn map_row_offset(row: &rusqlite::Row, offset: usize) -> rusqlite::Result<LogEntry> {
     Ok(LogEntry {
-        id: row.get(0)?,
-        timestamp: row.get(1)?,
-        hostname: row.get(2)?,
-        facility: row.get(3)?,
-        severity: row.get(4)?,
-        app_name: row.get(5)?,
-        process_id: row.get(6)?,
-        message: row.get(7)?,
-        received_at: row.get(8)?,
-        source_ip: row.get(9)?,
-        ai_tool: row.get(10)?,
-        ai_project: row.get(11)?,
-        ai_session_id: row.get(12)?,
-        ai_transcript_path: row.get(13)?,
-        metadata_json: row.get(14)?,
+        id: row.get(offset)?,
+        timestamp: row.get(offset + 1)?,
+        hostname: row.get(offset + 2)?,
+        facility: row.get(offset + 3)?,
+        severity: row.get(offset + 4)?,
+        app_name: row.get(offset + 5)?,
+        process_id: row.get(offset + 6)?,
+        message: row.get(offset + 7)?,
+        received_at: row.get(offset + 8)?,
+        source_ip: row.get(offset + 9)?,
+        ai_tool: row.get(offset + 10)?,
+        ai_project: row.get(offset + 11)?,
+        ai_session_id: row.get(offset + 12)?,
+        ai_transcript_path: row.get(offset + 13)?,
+        metadata_json: row.get(offset + 14)?,
     })
 }
 

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -652,15 +652,23 @@ pub fn search_ai_related_logs(
             truncated: false,
         })
         .collect::<Vec<_>>();
+    let mut anchor_pos: std::collections::HashMap<usize, usize> =
+        std::collections::HashMap::with_capacity(grouped.len());
+    for (pos, group) in grouped.iter().enumerate() {
+        if anchor_pos.insert(group.anchor_index, pos).is_some() {
+            anyhow::bail!(
+                "duplicate anchor_index {} in AiRelatedLogsParams windows",
+                group.anchor_index
+            );
+        }
+    }
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query(rusqlite::params_from_iter(sql_params.bindings.iter()))?;
     while let Some(row) = rows.next()? {
         let anchor_index = row.get::<_, i64>(0)? as usize;
         let related_rank = row.get::<_, i64>(16)? as usize;
-        if let Some(anchor) = grouped
-            .iter_mut()
-            .find(|group| group.anchor_index == anchor_index)
-        {
+        if let Some(&pos) = anchor_pos.get(&anchor_index) {
+            let anchor = &mut grouped[pos];
             if related_rank > limit {
                 anchor.truncated = true;
             } else {

--- a/src/db/queries_tests.rs
+++ b/src/db/queries_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::config::StorageConfig;
-use crate::db::{init_pool, insert_logs_batch, DbPool, LogBatchEntry};
+use crate::db::{init_pool, insert_logs_batch, AiRelatedWindow, DbPool, LogBatchEntry};
 
 fn test_storage_config(db_path: std::path::PathBuf) -> StorageConfig {
     StorageConfig::for_test(db_path)
@@ -442,6 +442,67 @@ fn search_ai_sessions_groups_results() {
 }
 
 #[test]
+fn search_ai_sessions_query_plan_uses_session_host_time_index() {
+    let (pool, _dir) = test_pool();
+    let mut entries = Vec::new();
+    for i in 0..150 {
+        entries.push(make_ai_entry(
+            &format!("2026-01-01T00:{:02}:00Z", i % 60),
+            "host-a",
+            "claude",
+            "/tmp/project",
+            "sess-1",
+            if i % 10 == 0 {
+                "indexed authentication match"
+            } else {
+                "background transcript event"
+            },
+        ));
+    }
+    for i in 0..50 {
+        entries.push(make_ai_entry(
+            &format!("2026-01-02T00:{:02}:00Z", i % 60),
+            "host-b",
+            "codex",
+            "/tmp/other",
+            "sess-2",
+            "indexed authentication match",
+        ));
+    }
+    insert_logs_batch(&pool, &entries).unwrap();
+
+    let params = SearchAiSessionsParams {
+        query: "authentication".into(),
+        ai_project: Some("/tmp/project".into()),
+        ai_tool: Some("claude".into()),
+        limit: Some(10),
+        ..Default::default()
+    };
+    let result = search_ai_sessions(&pool, &params).unwrap();
+    assert_eq!(result.sessions.len(), 1);
+    assert_eq!(result.sessions[0].event_count, 150);
+
+    let (sql, bindings) = search_ai_sessions_sql(&params, 10);
+    assert!(sql.contains("event_counts AS"));
+    assert!(!sql.contains("FROM logs total"));
+
+    let conn = pool.get().unwrap();
+    let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+    let plan = stmt
+        .query_map(rusqlite::params_from_iter(bindings.iter()), |row| {
+            row.get::<_, String>(3)
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+        .join("\n");
+    assert!(
+        plan.contains("idx_logs_ai_session_host_time"),
+        "expected AI session event-count plan to use idx_logs_ai_session_host_time, got:\n{plan}"
+    );
+}
+
+#[test]
 fn search_ai_sessions_candidate_cap_prefers_newer_rows() {
     let (pool, _dir) = test_pool();
     let mut entries = Vec::new();
@@ -513,6 +574,90 @@ fn search_ai_sessions_zero_limit_clamps_to_one_with_metadata() {
     assert_eq!(result.total_candidates, 1);
     assert_eq!(result.candidate_rows, 1);
     assert!(!result.truncated);
+}
+
+#[test]
+fn search_ai_related_logs_batches_windows_and_caps_per_anchor() {
+    let (pool, _dir) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            make_ai_entry(
+                "2026-01-01T00:00:00Z",
+                "localhost",
+                "codex",
+                "/tmp/project",
+                "sess-1",
+                "anchor one deploy failure",
+            ),
+            make_entry(
+                "2026-01-01T00:00:30Z",
+                "host-a",
+                "err",
+                "deploy failed on host-a",
+            ),
+            make_entry(
+                "2026-01-01T00:00:40Z",
+                "host-a",
+                "warning",
+                "deploy warning on host-a",
+            ),
+            make_entry(
+                "2026-01-01T00:00:50Z",
+                "host-a",
+                "info",
+                "deploy info below severity",
+            ),
+            make_ai_entry(
+                "2026-01-01T00:10:00Z",
+                "localhost",
+                "codex",
+                "/tmp/project",
+                "sess-2",
+                "anchor two deploy failure",
+            ),
+            make_entry(
+                "2026-01-01T00:10:30Z",
+                "host-b",
+                "err",
+                "deploy failed on host-b",
+            ),
+        ],
+    )
+    .unwrap();
+
+    let rows = search_ai_related_logs(
+        &pool,
+        &AiRelatedLogsParams {
+            windows: vec![
+                AiRelatedWindow {
+                    anchor_index: 0,
+                    window_from: "2026-01-01T00:00:00.000Z".into(),
+                    window_to: "2026-01-01T00:01:00.000Z".into(),
+                },
+                AiRelatedWindow {
+                    anchor_index: 1,
+                    window_from: "2026-01-01T00:10:00.000Z".into(),
+                    window_to: "2026-01-01T00:11:00.000Z".into(),
+                },
+            ],
+            query: Some("deploy".into()),
+            severity_in: vec!["err".into(), "warning".into()],
+            limit_per_anchor: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].anchor_index, 0);
+    assert_eq!(rows[0].logs.len(), 1);
+    assert_eq!(rows[0].logs[0].message, "deploy warning on host-a");
+    assert!(rows[0].truncated);
+    assert_eq!(rows[1].anchor_index, 1);
+    assert_eq!(rows[1].logs.len(), 1);
+    assert_eq!(rows[1].logs[0].message, "deploy failed on host-b");
+    assert!(!rows[1].truncated);
 }
 
 #[test]

--- a/src/db/queries_tests.rs
+++ b/src/db/queries_tests.rs
@@ -496,9 +496,11 @@ fn search_ai_sessions_query_plan_uses_session_host_time_index() {
         .collect::<rusqlite::Result<Vec<_>>>()
         .unwrap()
         .join("\n");
+    // SQLite's planner is free to pick equivalent indices; accept any
+    // ai-session-prefixed index so the test stays green across SQLite versions.
     assert!(
-        plan.contains("idx_logs_ai_session_host_time"),
-        "expected AI session event-count plan to use idx_logs_ai_session_host_time, got:\n{plan}"
+        plan.contains("idx_logs_ai_session"),
+        "expected AI session event-count plan to use an idx_logs_ai_session_* index, got:\n{plan}"
     );
 }
 

--- a/src/db/queries_tests.rs
+++ b/src/db/queries_tests.rs
@@ -496,11 +496,14 @@ fn search_ai_sessions_query_plan_uses_session_host_time_index() {
         .collect::<rusqlite::Result<Vec<_>>>()
         .unwrap()
         .join("\n");
-    // SQLite's planner is free to pick equivalent indices; accept any
-    // ai-session-prefixed index so the test stays green across SQLite versions.
+    // Pin the EXACT index that the new (host, time) composite was added
+    // for so a planner regression that falls back to the broader
+    // `idx_logs_ai_session` is caught by this guard. If SQLite version
+    // drift starts flapping this in CI, prefer documenting the SQLite
+    // version pin over loosening this assertion.
     assert!(
-        plan.contains("idx_logs_ai_session"),
-        "expected AI session event-count plan to use an idx_logs_ai_session_* index, got:\n{plan}"
+        plan.contains("idx_logs_ai_session_host_time"),
+        "expected AI session event-count plan to use idx_logs_ai_session_host_time, got:\n{plan}"
     );
 }
 


### PR DESCRIPTION
## Summary
- replace search_ai_sessions per-group full-history event_count subquery with grouped event_counts join
- add idx_logs_ai_session_host_time migration/index for AI session event-count lookups
- batch ai_correlate related-log window lookups into one bounded DB query
- add query-plan/load regression tests for AI session search and batched correlation behavior
- bump version to 0.25.4 and add changelog entry

## Verification
- RUSTC_WRAPPER= cargo test search_ai
- RUSTC_WRAPPER= cargo test correlate_ai_logs
- RUSTC_WRAPPER= cargo test
- RUSTC_WRAPPER= cargo clippy -- -D warnings
- bash scripts/check-version-sync.sh .
- pre-commit hook: cargo fmt; cargo clippy -- -D warnings
- pre-push hook: cargo test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts AI analytics query cost and speeds up session search and log correlation. Replaces per-group counts with a grouped join, batches related-log lookups into one query, adds a composite index, and tightens tests to guard the query plan.

- **Bug Fixes**
  - `search_ai_sessions`: grouped join for event counts; uses AI session/host/time index; avoids per-group full-history count.
  - Correlation: batch related-log windows into one bounded query; O(1) anchor grouping via `HashMap`; moves results to avoid cloning; rejects duplicate `anchor_index`; excludes AI logs.
  - Tests/metadata: pins query-plan test to `idx_logs_ai_session_host_time`; adds query-plan/load and service-level regression tests; bump `syslog-mcp` to `0.25.4`; update changelog and `server.json`; add notes under `docs/sessions/2026-05-18-cfr-ai-analytics-query-performance.md`.

- **Migration**
  - Creates `idx_logs_ai_session_host_time` on startup. May take time on large datasets; no manual steps required.

<sup>Written for commit 487c777c0b72bcd375bb08d0528313234dbf79c9. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/33?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

