### PR TITLE
fix: tighten HTTP auth and MCP action docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1277,7 +1277,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 [Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.25.4...HEAD
-[0.25.4]: https://github.com/jmagar/syslog-mcp/compare/v0.25.3...v0.25.4
+[0.25.4]: https://github.com/jmagar/syslog-mcp/compare/v0.25.2...v0.25.4
 [0.25.2]: https://github.com/jmagar/syslog-mcp/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/jmagar/syslog-mcp/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/jmagar/syslog-mcp/compare/v0.24.1...v0.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1277,7 +1277,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 [Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.25.4...HEAD
-[0.25.4]: https://github.com/jmagar/syslog-mcp/compare/v0.25.2...v0.25.4
+[0.25.4]: https://github.com/jmagar/syslog-mcp/compare/v0.25.3...v0.25.4
+[0.25.3]: https://github.com/jmagar/syslog-mcp/compare/v0.25.2...v0.25.3
 [0.25.2]: https://github.com/jmagar/syslog-mcp/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/jmagar/syslog-mcp/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/jmagar/syslog-mcp/compare/v0.24.1...v0.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Doctor orchestration boundaries**: Moved full doctor report collection and
   formatting out of `main.rs` into a dedicated doctor module.
+- **HTTP CORS header allowlists**: MCP and non-MCP API CORS preflights now
+  allow only the request headers required by browser clients instead of
+  reflecting arbitrary headers.
 
 ### Fixed
 
@@ -26,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full-history count per grouped result. `ai_correlate` now batches related-log
   window lookups into one bounded query instead of issuing one database search
   per anchor.
+- **OTLP deferred endpoint auth parity**: `/v1/traces` now checks the same
+  bearer token policy as `/v1/logs` and `/v1/metrics` before returning its
+  deferred 404 response.
+- **MCP action inventory docs**: Updated the README action list to include
+  unaddressed error and notification administration actions.
 
 ## [0.25.2] - 2026-05-16
 
@@ -1268,7 +1276,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.25.2...HEAD
+[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.25.4...HEAD
+[0.25.4]: https://github.com/jmagar/syslog-mcp/compare/v0.25.3...v0.25.4
 [0.25.2]: https://github.com/jmagar/syslog-mcp/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/jmagar/syslog-mcp/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/jmagar/syslog-mcp/compare/v0.24.1...v0.25.0

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The daemon listens on a single port for both UDP and TCP syslog (default `1514`)
 
 ## Tools
 
-One MCP tool, `syslog`, is exposed. Use the required `action` argument to run `search`, `tail`, `errors`, `hosts`, `sessions`, `search_sessions`, `abuse`, `ai_correlate`, `usage_blocks`, `project_context`, `list_ai_tools`, `list_ai_projects`, `correlate`, `stats`, `status`, `apps`, `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`, `silent_hosts`, `clock_skew`, `anomalies`, `compare`, `compose_status`, `compose_doctor`, or `help`.
+One MCP tool, `syslog`, is exposed. Use the required `action` argument to run `search`, `tail`, `errors`, `hosts`, `sessions`, `search_sessions`, `abuse`, `ai_correlate`, `usage_blocks`, `project_context`, `list_ai_tools`, `list_ai_projects`, `correlate`, `stats`, `status`, `apps`, `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`, `silent_hosts`, `clock_skew`, `anomalies`, `compare`, `compose_status`, `compose_doctor`, `unaddressed_errors`, `ack_error`, `unack_error`, `notifications_recent`, `notifications_test`, or `help`.
 
 For the complete action-specific parameter reference, see [`docs/mcp/SCHEMA.md`](docs/mcp/SCHEMA.md).
 
@@ -58,6 +58,11 @@ For the complete action-specific parameter reference, see [`docs/mcp/SCHEMA.md`]
 | `compare` | Side-by-side comparison of two time ranges |
 | `compose_status` | Redacted read-only Compose deployment diagnostics |
 | `compose_doctor` | Alias for Compose deployment health diagnostics |
+| `unaddressed_errors` | Repeating unacknowledged error signatures |
+| `ack_error` | Acknowledge an error signature |
+| `unack_error` | Revoke an error acknowledgement |
+| `notifications_recent` | Recent notification firings |
+| `notifications_test` | Send a test notification via Apprise |
 | `help` | Markdown reference for all actions |
 
 ### `syslog search`
@@ -463,7 +468,7 @@ Useful installer controls:
 ```bash
 SYSLOG_INSTALL_DRY_RUN=1 ./install.sh
 SYSLOG_INSTALL_PREFIX=/opt/syslog-mcp ./install.sh
-SYSLOG_VERSION=0.25.2 ./install.sh
+SYSLOG_VERSION=0.25.4 ./install.sh
 SYSLOG_INSTALL_SKIP_SETUP=1 ./install.sh
 ```
 

--- a/docs/sessions/2026-05-18-cfr-http-docs.md
+++ b/docs/sessions/2026-05-18-cfr-http-docs.md
@@ -1,0 +1,118 @@
+---
+date: 2026-05-18 00:44:19 EDT
+repo: https://github.com/jmagar/syslog-mcp
+branch: work/cfr-http-docs
+head: 7062643
+plan: /home/jmagar/workspace/syslog-mcp/06-all-issues.md
+working directory: /home/jmagar/workspace/syslog-mcp/.worktrees/cfr-http-docs
+worktree: /home/jmagar/workspace/syslog-mcp/.worktrees/cfr-http-docs 7062643 [work/cfr-http-docs]
+---
+
+# CFR HTTP, OTLP, and README Docs
+
+## User Request
+
+Use the `work-it` workflow in an isolated worktree for Agent 5's CFR-017,
+CFR-018, and CFR-019 assignment from `/home/jmagar/workspace/syslog-mcp/06-all-issues.md`.
+
+## Session Overview
+
+- Created worktree `.worktrees/cfr-http-docs` on branch `work/cfr-http-docs`.
+- Replaced MCP and non-MCP API CORS `allow_headers(Any)` usage with explicit header allowlists.
+- Made deferred OTLP `/v1/traces` require the same bearer-token helper as `/v1/logs` and `/v1/metrics`.
+- Updated README action inventory for unaddressed error and notification actions.
+- Bumped release metadata to `0.25.4` and added a changelog entry.
+
+## Sequence of Events
+
+- Inspected main checkout state and read the consolidated issue register.
+- Created the requested worktree and reviewed route/API/OTLP/doc surfaces.
+- Implemented scoped CORS, OTLP, README, and test changes.
+- Ran focused tests first, then full verification gates.
+- Found the repo was already at `0.25.3` without a changelog entry, then bumped this branch to `0.25.4` per branch-push rules.
+- Checked available review tooling; the generic Lab `Agent` entry was present, but no runnable agent types were configured.
+
+## Key Findings
+
+- MCP CORS previously allowed any request header in `src/mcp/routes.rs`; required browser/RMCP headers are `Accept`, `Authorization`, `Content-Type`, `mcp-protocol-version`, and `mcp-session-id`.
+- Non-MCP API routes are GET-only and require only `Accept` and `Authorization` for browser callers.
+- `/v1/metrics` already shared OTLP auth behavior with `/v1/logs`; `/v1/traces` was the only deferred endpoint returning 404 before checking auth.
+- `docs/mcp/TOOLS.md` already listed the newer admin/notification actions; the stale surface was the README top-level inventory.
+
+## Technical Decisions
+
+- Kept changes out of `src/mcp/tools.rs` because another agent owns mutating action identity.
+- Preserved the deferred 404 contract for authorized `/v1/traces` callers instead of adding ingest behavior.
+- Added CORS preflight tests that assert allowed headers are concrete and do not reflect arbitrary request headers.
+- Used `RUSTC_WRAPPER=` for Rust verification after `sccache` failed while zipping compiler outputs.
+
+## Files Modified
+
+- `src/mcp/routes.rs` - explicit MCP CORS request-header allowlist.
+- `src/mcp/routes_tests.rs` - MCP CORS preflight regression coverage.
+- `src/api.rs` - explicit non-MCP API CORS request-header allowlist.
+- `src/api_tests.rs` - API CORS preflight regression coverage.
+- `src/otlp.rs` - `/v1/traces` now checks OTLP bearer auth before deferred 404.
+- `src/otlp_tests.rs` - `/v1/traces` unauthorized and authorized-deferred tests.
+- `README.md` - updated action inventory and installer version example.
+- `CHANGELOG.md` - added `0.25.4` release notes and comparison link.
+- `Cargo.toml`, `Cargo.lock`, `server.json` - bumped to `0.25.4`.
+- `docs/sessions/2026-05-18-cfr-http-docs.md` - this session note.
+
+## Commands Executed
+
+| Command | Result |
+| --- | --- |
+| `git worktree add -b work/cfr-http-docs .worktrees/cfr-http-docs HEAD` | Created worktree at `7062643`. |
+| `cargo fmt` | Passed. |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test mcp::routes` | Passed, 32 route tests. |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test api::tests` | Passed, 12 API tests. |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test otlp::tests` | Passed, 22 OTLP tests. |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test` | Passed after version bump. |
+| `cargo fmt --check` | Passed after version bump. |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo clippy -- -D warnings` | Passed after version bump. |
+| `bash scripts/check-version-sync.sh` | Passed: all 2 checked files at `v0.25.4`. |
+
+## Errors Encountered
+
+- Initial parallel `cargo test` jobs failed in `sccache` with `Allocation error : not enough memory` while zipping compiler outputs. Rerunning with `RUSTC_WRAPPER=` and `CARGO_BUILD_JOBS=2` resolved it.
+- `git status` inside the sandbox failed because Git LFS attempted to write under the shared `.git/lfs/tmp` path. Escalated `git status` succeeded.
+- Lab exposed a generic `Agent` tool, but calls failed with `Agent type 'general-purpose' not found. Available agents:`; named review-agent waves were unavailable in this runtime.
+
+## Behavior Changes
+
+- Browser CORS preflight responses for MCP/API no longer allow arbitrary request headers.
+- Unauthorized `/v1/traces` requests now return unauthorized when `SYSLOG_MCP_TOKEN` is configured.
+- Authorized `/v1/traces` requests still return the deferred `traces_not_supported` 404 response.
+- README top-level MCP action inventory now includes unaddressed error and notification actions.
+
+## Verification Evidence
+
+| command | expected | actual | status |
+| --- | --- | --- | --- |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test mcp::routes` | MCP route tests pass | 32 passed | pass |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test api::tests` | API route tests pass | 12 passed | pass |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test otlp::tests` | OTLP tests pass | 22 passed | pass |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test` | Full suite passes | 583 lib tests, 48 main tests, integration tests, and doc tests passed | pass |
+| `cargo fmt --check` | Formatting clean | no output, exit 0 | pass |
+| `RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo clippy -- -D warnings` | Lints pass | finished successfully | pass |
+| `bash scripts/check-version-sync.sh` | Version metadata synchronized | OK at `v0.25.4` | pass |
+
+## Risks and Rollback
+
+- CORS allowlists can block browser clients that depend on an undocumented custom request header. Roll back by restoring `allow_headers(Any)` or adding the specific missing header with a test.
+- `/v1/traces` now performs auth before its deferred 404, which is a stricter behavior for token-protected deployments. Roll back by restoring the no-argument handler only if intentionally public deferred 404s are desired.
+
+## Decisions Not Taken
+
+- Did not modify `src/mcp/tools.rs` because this assignment did not require action dispatch changes and another agent owns mutating action identity.
+- Did not generate README inventory from schema metadata because CFR-019 requested a low-risk inventory update and schema docs already contained the new actions.
+
+## Open Questions
+
+- The changelog had no `0.25.3` entry even though Cargo metadata started at `0.25.3`; this branch adds `0.25.4` but does not backfill `0.25.3`.
+
+## Next Steps
+
+- Create and push the PR for `work/cfr-http-docs`.
+- Fetch PR comments after the PR exists and resolve any actionable review feedback.

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Query, State},
-    http::StatusCode,
+    http::{header, StatusCode},
     response::{IntoResponse, Json},
     routing::get,
     Router,
 };
 use serde::Deserialize;
 use serde_json::json;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::CorsLayer;
 
 use crate::app::{
     CorrelateEventsRequest, GetErrorsRequest, SearchLogsRequest, SyslogService, TailLogsRequest,
@@ -215,7 +215,7 @@ fn cors_layer(port: u16) -> CorsLayer {
                 .expect("valid 127.0.0.1 origin"),
         ])
         .allow_methods([axum::http::Method::GET])
-        .allow_headers(Any)
+        .allow_headers([header::ACCEPT, header::AUTHORIZATION])
 }
 
 #[cfg(test)]

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -151,6 +151,39 @@ async fn api_routes_emit_cors_for_configured_port() {
 }
 
 #[tokio::test]
+async fn api_cors_preflight_allows_only_required_request_headers() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = router(state).unwrap();
+    let request = Request::builder()
+        .method("OPTIONS")
+        .uri("/api/stats")
+        .header("Origin", "http://localhost:3100")
+        .header("Access-Control-Request-Method", "GET")
+        .header(
+            "Access-Control-Request-Headers",
+            "authorization,accept,x-unexpected-header",
+        )
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let allowed = response
+        .headers()
+        .get("access-control-allow-headers")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_ascii_lowercase();
+    assert!(allowed.contains("authorization"));
+    assert!(allowed.contains("accept"));
+    assert!(
+        !allowed.contains("x-unexpected-header"),
+        "CORS allow-headers must not reflect arbitrary request headers: {allowed}"
+    );
+}
+
+#[tokio::test]
 async fn correlate_route_returns_plain_api_json() {
     let (state, _pool, _dir) = test_state(Some("secret".into()));
     let app = router(state).unwrap();

--- a/src/mcp/routes.rs
+++ b/src/mcp/routes.rs
@@ -4,22 +4,21 @@ use std::time::Instant;
 
 use axum::{
     extract::State,
-    http::{HeaderValue, Method, StatusCode},
+    http::{header, HeaderName, HeaderValue, Method, StatusCode},
     response::{IntoResponse, Json},
     routing::get,
     Router,
 };
 use serde_json::json;
-use tower_http::{
-    cors::{Any, CorsLayer},
-    limit::RequestBodyLimitLayer,
-};
+use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer};
 
 use super::rmcp_server::allowed_origins;
 use super::{build_auth_layer, streamable_http_config, streamable_http_service};
 use super::{AppState, AuthPolicy};
 
 const MCP_BODY_LIMIT_BYTES: u64 = 65_536;
+const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
 
 /// Build the MCP router
 pub fn router(state: AppState) -> Router {
@@ -145,7 +144,13 @@ fn cors_layer(config: &crate::config::McpConfig) -> CorsLayer {
     CorsLayer::new()
         .allow_origin(origins)
         .allow_methods([Method::POST, Method::GET])
-        .allow_headers(Any)
+        .allow_headers([
+            header::ACCEPT,
+            header::AUTHORIZATION,
+            header::CONTENT_TYPE,
+            HeaderName::from_static(MCP_PROTOCOL_VERSION_HEADER),
+            HeaderName::from_static(MCP_SESSION_ID_HEADER),
+        ])
 }
 
 /// Health check — lightweight probe that verifies DB connectivity without

--- a/src/mcp/routes_tests.rs
+++ b/src/mcp/routes_tests.rs
@@ -303,6 +303,7 @@ async fn mcp_cors_preflight_allows_only_required_request_headers() {
         .to_str()
         .unwrap()
         .to_ascii_lowercase();
+    let allowed_tokens: Vec<&str> = allowed.split(',').map(str::trim).collect();
     for header in [
         "authorization",
         "content-type",
@@ -311,12 +312,12 @@ async fn mcp_cors_preflight_allows_only_required_request_headers() {
         "mcp-session-id",
     ] {
         assert!(
-            allowed.contains(header),
+            allowed_tokens.iter().any(|t| *t == header),
             "missing {header} from allow-headers: {allowed}"
         );
     }
     assert!(
-        !allowed.contains("x-unexpected-header"),
+        !allowed_tokens.iter().any(|t| *t == "x-unexpected-header"),
         "CORS allow-headers must not reflect arbitrary request headers: {allowed}"
     );
 }

--- a/src/mcp/routes_tests.rs
+++ b/src/mcp/routes_tests.rs
@@ -278,6 +278,50 @@ async fn mcp_cors_allows_configured_origins() {
 }
 
 #[tokio::test]
+async fn mcp_cors_preflight_allows_only_required_request_headers() {
+    let (mut state, _dir) = test_state_no_auth();
+    state.config.allowed_origins = vec!["https://syslog.example.com".into()];
+    let app = router(state);
+    let request = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/mcp")
+        .header("Origin", "https://syslog.example.com")
+        .header("Access-Control-Request-Method", "POST")
+        .header(
+            "Access-Control-Request-Headers",
+            "authorization,content-type,accept,mcp-protocol-version,mcp-session-id",
+        )
+        .body(axum::body::Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let allowed = response
+        .headers()
+        .get("access-control-allow-headers")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_ascii_lowercase();
+    for header in [
+        "authorization",
+        "content-type",
+        "accept",
+        "mcp-protocol-version",
+        "mcp-session-id",
+    ] {
+        assert!(
+            allowed.contains(header),
+            "missing {header} from allow-headers: {allowed}"
+        );
+    }
+    assert!(
+        !allowed.contains("x-unexpected-header"),
+        "CORS allow-headers must not reflect arbitrary request headers: {allowed}"
+    );
+}
+
+#[tokio::test]
 async fn mcp_rejects_wrong_token() {
     let h = TestHarness::with_token("secret-token".into());
     let body = jsonrpc_request(9, "tools/list", None);

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -222,7 +222,18 @@ async fn metrics_handler(
         .into_response()
 }
 
-async fn traces_handler() -> axum::response::Response {
+async fn traces_handler(
+    State(state): State<OtlpState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    if !is_authorized(&state, &headers) {
+        return unauthorized();
+    }
+    tracing::warn!(
+        bytes = body.len(),
+        "OTLP traces received but traces ingestion is not supported"
+    );
     (
         StatusCode::NOT_FOUND,
         Json(json!({

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -203,13 +203,17 @@ async fn logs_handler(
 async fn metrics_handler(
     State(state): State<OtlpState>,
     headers: HeaderMap,
-    body: Bytes,
 ) -> axum::response::Response {
     if !is_authorized(&state, &headers) {
         return unauthorized();
     }
+    let content_length = headers
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
     tracing::warn!(
-        bytes = body.len(),
+        content_length,
         "OTLP metrics received but metrics ingestion is not supported"
     );
     (
@@ -225,13 +229,17 @@ async fn metrics_handler(
 async fn traces_handler(
     State(state): State<OtlpState>,
     headers: HeaderMap,
-    body: Bytes,
 ) -> axum::response::Response {
     if !is_authorized(&state, &headers) {
         return unauthorized();
     }
+    let content_length = headers
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
     tracing::warn!(
-        bytes = body.len(),
+        content_length,
         "OTLP traces received but traces ingestion is not supported"
     );
     (

--- a/src/otlp_tests.rs
+++ b/src/otlp_tests.rs
@@ -468,8 +468,7 @@ async fn metrics_handler_returns_not_supported() {
 
 #[tokio::test]
 async fn traces_handler_requires_bearer_when_token_configured() {
-    let response =
-        traces_handler(State(state_with_token(Some("secret"))), HeaderMap::new()).await;
+    let response = traces_handler(State(state_with_token(Some("secret"))), HeaderMap::new()).await;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 

--- a/src/otlp_tests.rs
+++ b/src/otlp_tests.rs
@@ -462,23 +462,14 @@ fn auth_rejects_non_bearer_scheme() {
 
 #[tokio::test]
 async fn metrics_handler_returns_not_supported() {
-    let response = metrics_handler(
-        State(state_with_token(None)),
-        HeaderMap::new(),
-        Bytes::from_static(b"metrics"),
-    )
-    .await;
+    let response = metrics_handler(State(state_with_token(None)), HeaderMap::new()).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
 async fn traces_handler_requires_bearer_when_token_configured() {
-    let response = traces_handler(
-        State(state_with_token(Some("secret"))),
-        HeaderMap::new(),
-        Bytes::from_static(b"traces"),
-    )
-    .await;
+    let response =
+        traces_handler(State(state_with_token(Some("secret"))), HeaderMap::new()).await;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
@@ -489,12 +480,7 @@ async fn traces_handler_returns_not_supported_after_auth() {
         axum::http::header::AUTHORIZATION,
         HeaderValue::from_static("Bearer secret"),
     );
-    let response = traces_handler(
-        State(state_with_token(Some("secret"))),
-        headers,
-        Bytes::from_static(b"traces"),
-    )
-    .await;
+    let response = traces_handler(State(state_with_token(Some("secret"))), headers).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 

--- a/src/otlp_tests.rs
+++ b/src/otlp_tests.rs
@@ -471,6 +471,33 @@ async fn metrics_handler_returns_not_supported() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+#[tokio::test]
+async fn traces_handler_requires_bearer_when_token_configured() {
+    let response = traces_handler(
+        State(state_with_token(Some("secret"))),
+        HeaderMap::new(),
+        Bytes::from_static(b"traces"),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn traces_handler_returns_not_supported_after_auth() {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::AUTHORIZATION,
+        HeaderValue::from_static("Bearer secret"),
+    );
+    let response = traces_handler(
+        State(state_with_token(Some("secret"))),
+        headers,
+        Bytes::from_static(b"traces"),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
 // ---- counters ----
 
 #[test]


### PR DESCRIPTION
## Summary
- replace broad MCP/API CORS request-header allowance with concrete browser/RMCP header allowlists
- require OTLP bearer auth on deferred /v1/traces before returning its unsupported 404
- refresh README MCP action inventory for error acknowledgement and notification actions
- bump release metadata to 0.25.4 with changelog/session note

## Verification
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test mcp::routes
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test api::tests
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test otlp::tests
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo test
- cargo fmt --check
- RUSTC_WRAPPER= CARGO_BUILD_JOBS=2 cargo clippy -- -D warnings
- bash scripts/check-version-sync.sh
- pre-push hook: cargo test

## Review tooling
- Lab Agent tool was present, but no runnable agent types were configured; attempted report-only review waves failed with 'Agent type general-purpose not found'. Manual review pass completed against final diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened HTTP CORS and OTLP auth to reduce attack surface, and refreshed MCP action docs. MCP/API preflights now allow only required headers, and OTLP `/v1/metrics` and `/v1/traces` check bearer auth before any body read; `/v1/traces` still returns its deferred 404 after auth.

- **Bug Fixes**
  - MCP CORS: allow only `Accept`, `Authorization`, `Content-Type`, `mcp-protocol-version`, `mcp-session-id`.
  - API CORS: allow only `Accept` and `Authorization`.
  - OTLP `/v1/metrics` and `/v1/traces`: no body buffering; authorize first and log `content-length`; `/v1/traces` returns deferred 404 after auth.
  - Docs: README adds `unaddressed_errors`, `ack_error`, `unack_error`, `notifications_recent`, `notifications_test` and updates installer example to `0.25.4`; CHANGELOG compare links fixed for `0.25.4` and `0.25.3`.
  - Tests: CORS preflights use exact comma-token matching for allow-headers; add traces auth coverage.

<sup>Written for commit 9c4d75339bba5c9b602bb91f28a806bbd6e54a9f. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/34?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

