### PR TITLE
feat: add CLI remote deploy

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.2] - 2026-05-23
+
+### Added
+
+- **Remote deploy CLI**: Add `syslog deploy remote <host>` for SSH-based
+  Compose deployment without adding REST or MCP mutation surfaces.
+
 ## [0.28.1] - 2026-05-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.28.1"
+version = "0.28.2"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@ x-common-service: &common-service
 services:
   syslog-mcp:
     <<: *common-service
-    image: ghcr.io/jmagar/syslog-mcp:${SYSLOG_MCP_VERSION:-0.27.1}
+    image: ghcr.io/jmagar/syslog-mcp:${SYSLOG_MCP_VERSION:-0.28.2}
     container_name: syslog-mcp
     user: "${SYSLOG_UID:-1000}:${SYSLOG_GID:-1000}"
     env_file:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -451,20 +451,28 @@ timer state, active/enabled watcher state, and container freshness via
 
 ### `syslog deploy`
 
-Run the local Compose-backed deployment workflow using operator-facing names.
-These commands call the same setup engine as `syslog setup check` and
-`syslog setup repair`.
+Run the Compose-backed deployment workflow using operator-facing names.
+`preflight` and `local` call the same setup engine as `syslog setup check`
+and `syslog setup repair`; `remote` uses SSH plus the shared setup assets.
 
 ```bash
 syslog deploy preflight
 syslog deploy preflight --json
 syslog deploy local
 syslog deploy local --dry-run --json
+syslog deploy remote tootie --dry-run
+syslog deploy remote tootie --json
 ```
 
 `deploy preflight` and `deploy local --dry-run` do not mutate Docker state.
 `deploy local` repairs `~/.syslog-mcp/.env`, rewrites managed Compose assets,
 pulls the configured image, starts the stack, and checks `/health`.
+`deploy remote` uses SSH and Docker Compose on the target host. Non-dry-run
+remote deploy writes/replaces `~/.syslog-mcp/.env`, the managed Compose YAML,
+and `config/Dockerfile` on the target; set token/env values in the local
+environment before running it when you need to preserve specific values. It is
+CLI-only, requires an explicit host argument, and does not add REST or MCP
+deploy mutation surfaces.
 
 ### `syslog setup ai-index-timer`
 

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -51,11 +51,25 @@ syslog setup repair   # rewrite managed assets and restart Compose
 syslog deploy preflight       # operator-facing preflight alias
 syslog deploy local           # operator-facing local deploy/reconcile alias
 syslog deploy local --dry-run # preflight without Docker mutation
+syslog deploy remote host-a --dry-run # SSH preflight for a remote Compose host
+syslog deploy remote host-a           # SSH deploy/reconcile on a remote host
 ```
 
 `syslog setup` also disables and removes stale user-level
 `syslog-mcp.service` units/drop-ins from older releases. The supported
 automated deployment path is Docker Compose only.
+
+### Remote CLI Deploy
+
+`syslog deploy remote <host>` writes/replaces `~/.syslog-mcp/.env`, the
+managed Compose YAML, and `config/Dockerfile` on the SSH target, then runs
+Docker Compose there. Use `--dry-run` first to verify SSH and Docker
+prerequisites. Set token/env values in the local environment before running the
+non-dry-run command when the target must keep specific generated secrets or
+configuration values.
+
+Deploy mutations remain CLI-only. MCP exposes only redacted read-only Compose
+diagnostics.
 
 ## Docker
 

--- a/docs/sessions/2026-05-23-cli-remote-deploy.md
+++ b/docs/sessions/2026-05-23-cli-remote-deploy.md
@@ -1,0 +1,32 @@
+# 2026-05-23 CLI Remote Deploy
+
+## Summary
+
+Implemented `syslog deploy remote <host>` as a CLI-only SSH deployment flow for the Docker Compose server bundle.
+
+REST and MCP deploy mutation handlers remain intentionally out of scope. Existing REST/MCP Compose surfaces are read-only diagnostics only.
+
+## Branch
+
+- Branch: `feat/cli-remote-deploy`
+- Bead: `syslog-mcp-i0q6`
+
+## Changes
+
+- Added `src/deploy.rs` with OpenSSH-based remote orchestration, dry-run support, phase reporting, and testable runner abstraction.
+- Extended top-level deploy parsing and usage for `syslog deploy remote HOST [--dry-run] [--json]`.
+- Reused setup Compose/env assets instead of adding another deploy model.
+- Documented remote deploy behavior and `.env` overwrite semantics in CLI and MCP deployment docs.
+- Bumped release metadata to `0.28.2`.
+
+## Verification
+
+- `cargo fmt --check` passed.
+- `cargo test deploy` passed.
+- `cargo clippy -- -D warnings` passed.
+- `cargo test` passed.
+- `bash scripts/check-version-sync.sh --require-changelog` passed.
+- `bash scripts/validate-marketplace.sh` passed.
+- `just check` still fails on the pre-existing module-size guard:
+  - `src/cli/args.rs` has 535 lines.
+  - `src/cli/dispatch_surface.rs` has 502 lines.

--- a/docs/superpowers/plans/2026-05-23-cli-remote-deploy.md
+++ b/docs/superpowers/plans/2026-05-23-cli-remote-deploy.md
@@ -1,0 +1,415 @@
+# CLI Remote Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `syslog deploy remote <host>` as a CLI-only SSH deploy flow for the same Docker Compose server bundle used by local setup.
+
+**Architecture:** Keep deploy mutation out of REST and MCP entirely. Add a focused `syslog_mcp::deploy` library module for remote SSH orchestration, wire `src/main.rs` to parse and print the command, and reuse existing setup assets (`docker-compose.prod.yml`, `config/Dockerfile`, token/env defaults) rather than adding a second deployment model.
+
+**Tech Stack:** Rust 2021, `std::process::Command`, OpenSSH CLI (`ssh`), Docker Compose on the remote host, existing `SetupReport`/`SetupPhase` report shapes, sidecar unit tests.
+
+---
+
+## Scope Boundary
+
+Implement:
+
+- `syslog deploy remote <host> [--dry-run] [--json]`
+- Remote preflight via `ssh -o BatchMode=yes -o ConnectTimeout=10 <host> ...`
+- Remote repair/deploy via SSH, writing `~/.syslog-mcp/.env`, `~/.syslog-mcp/compose/docker-compose.yml`, and `~/.syslog-mcp/compose/config/Dockerfile`
+- Remote Docker network check/create, `docker compose pull --ignore-buildable`, and `docker compose up -d`
+- Redacted, audit-friendly phase output
+- Docs and tests
+
+Do not implement:
+
+- REST deploy endpoints
+- MCP deploy actions
+- Background deploy jobs
+- Remote host auto-mutation without an explicit `<host>` argument
+- systemd deployment
+
+## File Structure
+
+- Modify `src/main.rs`: parse `deploy remote`, add remote variant to `DeployCommandKind`, dispatch to the new module, update usage text.
+- Create `src/deploy.rs`: CLI-only remote deployment orchestration, command runner abstraction, redaction helpers, tests.
+- Modify `src/lib.rs`: export `pub mod deploy`.
+- Modify `src/setup.rs`: re-export a small asset/env helper surface needed by `deploy.rs` without exposing REST/MCP surfaces.
+- Modify `src/setup/firstrun.rs`: make the existing setup asset/env helpers visible to `deploy.rs` where needed.
+- Modify `docs/CLI.md` and `docs/mcp/DEPLOY.md`: document the CLI-only remote flow and explicitly state REST/MCP deploy is out of scope.
+- Modify `CHANGELOG.md`, `Cargo.toml`, `Cargo.lock`, `.claude-plugin/plugin.json`, and `server.json`: patch bump per repo rule.
+
+## Task 1: Parse Remote Deploy
+
+**Files:**
+- Modify: `src/main.rs`
+- Test: `src/main_tests.rs`
+
+- [ ] **Step 1: Write parser tests**
+
+Add tests near the existing deploy parser tests:
+
+```rust
+#[test]
+fn mode_parse_accepts_remote_deploy_namespace() {
+    assert!(matches!(
+        Mode::parse(vec![
+            "deploy".into(),
+            "remote".into(),
+            "tootie".into(),
+            "--dry-run".into(),
+            "--json".into()
+        ])
+        .unwrap(),
+        Mode::Deploy(_)
+    ));
+}
+
+#[test]
+fn mode_parse_rejects_remote_deploy_without_host() {
+    let err = Mode::parse(vec!["deploy".into(), "remote".into()]).unwrap_err();
+    assert!(err.to_string().contains("deploy remote requires a host"));
+}
+```
+
+- [ ] **Step 2: Run the focused failing tests**
+
+Run:
+
+```bash
+cargo test mode_parse_accepts_remote_deploy_namespace mode_parse_rejects_remote_deploy_without_host
+```
+
+Expected: the first test fails because `remote` is still unknown.
+
+- [ ] **Step 3: Add the parser model**
+
+Update `DeployCommandKind`:
+
+```rust
+enum DeployCommandKind {
+    Preflight,
+    Local { dry_run: bool },
+    Remote { host: String, dry_run: bool },
+}
+```
+
+Update `parse_deploy_command` so:
+
+- `preflight` accepts only `--json`
+- `local` accepts `--dry-run` and `--json`
+- `remote` requires exactly one non-flag host and accepts `--dry-run` and `--json`
+- any second host produces `deploy remote accepts exactly one host`
+
+Use explicit parsing instead of treating every positional as unknown.
+
+- [ ] **Step 4: Run parser tests**
+
+Run:
+
+```bash
+cargo test deploy
+```
+
+Expected: deploy parser tests pass.
+
+## Task 2: Add Remote Deploy Library
+
+**Files:**
+- Create: `src/deploy.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/setup.rs`
+- Modify: `src/setup/firstrun.rs`
+
+- [ ] **Step 1: Write unit tests for command sequence and dry-run**
+
+Create `src/deploy.rs` with tests using a fake runner. The tests should assert:
+
+```rust
+#[test]
+fn remote_dry_run_only_checks_ssh_and_docker() {
+    let mut runner = FakeRemoteRunner::ok();
+    let report = run_remote_deploy_with_runner("host-a", true, &mut runner).unwrap();
+    assert_eq!(report.host, "host-a");
+    assert!(runner.commands.iter().any(|cmd| cmd.contains("docker --version")));
+    assert!(!runner.commands.iter().any(|cmd| cmd.contains("docker compose up -d")));
+    assert!(!runner.commands.iter().any(|cmd| cmd.contains("cat > ~/.syslog-mcp/.env")));
+}
+
+#[test]
+fn remote_repair_writes_assets_before_compose_up() {
+    let mut runner = FakeRemoteRunner::ok();
+    let report = run_remote_deploy_with_runner("host-a", false, &mut runner).unwrap();
+    assert!(!report.has_errors);
+    let joined = runner.commands.join("\n");
+    assert!(joined.contains("mkdir -p ~/.syslog-mcp/compose/config ~/.syslog-mcp/data"));
+    assert!(joined.contains("cat > ~/.syslog-mcp/.env.tmp"));
+    assert!(joined.contains("cat > ~/.syslog-mcp/compose/docker-compose.yml.tmp"));
+    assert!(joined.contains("docker compose"));
+    assert!(joined.contains("up -d"));
+}
+```
+
+- [ ] **Step 2: Add public types**
+
+Implement:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteDeployReport {
+    pub mode: &'static str,
+    pub host: String,
+    pub home: String,
+    pub env_path: String,
+    pub compose_dir: String,
+    pub data_dir: String,
+    pub health_url: String,
+    pub mcp_url: String,
+    pub phases: Vec<crate::setup::SetupPhase>,
+    pub has_errors: bool,
+}
+
+pub fn run_remote_deploy(host: &str, dry_run: bool) -> io::Result<RemoteDeployReport>
+```
+
+The report should mirror `SetupReport` enough for current CLI output patterns.
+
+- [ ] **Step 3: Add runner abstraction**
+
+Implement:
+
+```rust
+trait RemoteRunner {
+    fn run(&mut self, host: &str, script: &str, stdin: Option<&str>) -> io::Result<RemoteOutput>;
+}
+
+struct SshRemoteRunner;
+
+#[derive(Debug, Clone)]
+struct RemoteOutput {
+    status_success: bool,
+    stdout: String,
+    stderr: String,
+}
+```
+
+`SshRemoteRunner` should execute:
+
+```bash
+ssh -o BatchMode=yes -o ConnectTimeout=10 <host> sh -s
+```
+
+and pass the script through stdin. Do not put secrets or full env content on the command line.
+
+- [ ] **Step 4: Add deploy phases**
+
+Implement phases:
+
+- `ssh`: `true`
+- `remote-filesystem`: check-only uses `test -d ~/.syslog-mcp || true`; repair creates dirs and chmods home/data
+- `remote-env`: skipped in dry-run; repair writes `.env.tmp`, chmods it, then renames it
+- `remote-compose-assets`: skipped in dry-run; repair writes compose and Dockerfile temp files then renames them
+- `remote-docker`: `docker --version && docker compose version`
+- `remote-docker-network`: skipped in dry-run; repair creates `${DOCKER_NETWORK:-syslog-mcp}` if absent
+- `remote-compose-pull`: skipped in dry-run
+- `remote-compose-up`: skipped in dry-run
+- `remote-health`: skipped in dry-run; repair checks `curl -fsS http://127.0.0.1:${SYSLOG_MCP_PORT:-3100}/health`
+
+Use `SetupStatus::Skipped` for dry-run mutation phases.
+
+- [ ] **Step 5: Reuse setup assets**
+
+Expose from setup:
+
+```rust
+pub fn installed_compose_asset() -> String
+pub fn default_env_for_data_dir(data_dir: &Path) -> io::Result<BTreeMap<String, String>>
+pub fn render_env(values: &BTreeMap<String, String>) -> String
+pub fn dockerfile_asset() -> &'static str
+```
+
+The remote flow should generate env content locally using the same defaults and token generation as local setup, then send it over SSH stdin.
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+cargo test deploy
+```
+
+Expected: new deploy module tests and parser tests pass.
+
+## Task 3: Wire CLI Output
+
+**Files:**
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Dispatch remote deploy**
+
+Update `run_deploy`:
+
+```rust
+DeployCommandKind::Remote { host, dry_run } => {
+    let report = syslog_mcp::deploy::run_remote_deploy(&host, dry_run)?;
+    print_remote_deploy_report(&report, command.json)?;
+    if report.has_errors {
+        anyhow::bail!("syslog deploy remote {host} completed with failed phases");
+    }
+    return Ok(());
+}
+```
+
+- [ ] **Step 2: Add human output helper**
+
+Print:
+
+```text
+syslog deploy remote <host>
+mode: remote dry-run|remote
+host: <host>
+home: ~/.syslog-mcp
+env: ~/.syslog-mcp/.env
+compose: ~/.syslog-mcp/compose
+data: ~/.syslog-mcp/data
+health: http://127.0.0.1:3100/health
+mcp: http://127.0.0.1:3100/mcp
+```
+
+Then print phases with the existing `status name elapsed detail` shape.
+
+- [ ] **Step 3: Update usage**
+
+Add:
+
+```text
+syslog deploy remote HOST [--dry-run] [--json]
+```
+
+in both usage blocks.
+
+- [ ] **Step 4: Run focused parser and output-safe tests**
+
+Run:
+
+```bash
+cargo test deploy
+```
+
+Expected: all deploy tests pass.
+
+## Task 4: Document CLI-Only Remote Deploy
+
+**Files:**
+- Modify: `docs/CLI.md`
+- Modify: `docs/mcp/DEPLOY.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update CLI docs**
+
+In `docs/CLI.md`, update `syslog deploy` examples:
+
+```bash
+syslog deploy remote tootie --dry-run
+syslog deploy remote tootie --json
+```
+
+State:
+
+```markdown
+`deploy remote` uses SSH and Docker Compose on the target host. It is CLI-only and requires an explicit host argument. It does not add REST or MCP deploy mutation surfaces.
+```
+
+- [ ] **Step 2: Update deployment guide**
+
+In `docs/mcp/DEPLOY.md`, add a remote section:
+
+```markdown
+### Remote CLI Deploy
+
+`syslog deploy remote <host>` copies the managed Compose bundle to
+`~/.syslog-mcp` on the SSH target and runs Docker Compose there. Use
+`--dry-run` first to verify SSH and Docker prerequisites.
+
+Deploy mutations remain CLI-only. MCP exposes only read-only diagnostics.
+```
+
+- [ ] **Step 3: Add changelog entry**
+
+Patch bump to `0.28.2` and add:
+
+```markdown
+## [0.28.2] - 2026-05-23
+
+### Added
+
+- **Remote deploy CLI**: Add `syslog deploy remote <host>` for SSH-based
+  Compose deployment without adding REST or MCP mutation surfaces.
+```
+
+## Task 5: Version Bump and Full Verification
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `.claude-plugin/plugin.json`
+- Modify: `server.json`
+
+- [ ] **Step 1: Patch bump**
+
+Change every current version-bearing file from `0.28.1` to `0.28.2`; update `server.json` image tag to `ghcr.io/jmagar/syslog-mcp:v0.28.2`.
+
+- [ ] **Step 2: Refresh lockfile**
+
+Run:
+
+```bash
+cargo check
+```
+
+Expected: succeeds and updates `Cargo.lock` package version.
+
+- [ ] **Step 3: Run focused gates**
+
+Run:
+
+```bash
+cargo fmt --check
+bash scripts/check-version-sync.sh --require-changelog
+bash scripts/validate-marketplace.sh
+cargo test deploy
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Run full gates**
+
+Run:
+
+```bash
+cargo clippy -- -D warnings
+cargo test
+```
+
+Expected: all pass. If `just check` still fails on the pre-existing module-size guard, record it separately and do not hide it.
+
+## Self-Review Checklist
+
+- [ ] No REST route added.
+- [ ] No MCP action/schema added.
+- [ ] No systemd deploy option added.
+- [ ] Remote deploy requires an explicit host.
+- [ ] Dry-run does not write files or start Compose.
+- [ ] Secrets/env content are passed over SSH stdin, not command-line args or phase details.
+- [ ] Docs state deploy mutation remains CLI-only.
+
+## Implementation Status
+
+Implemented on branch `feat/cli-remote-deploy`.
+
+- [x] Added `syslog deploy remote HOST [--dry-run] [--json]` parser coverage.
+- [x] Added CLI-only SSH remote deploy orchestration in `src/deploy.rs`.
+- [x] Kept REST and MCP deploy mutation surfaces out of scope.
+- [x] Added docs for remote deploy behavior and `.env` overwrite semantics.
+- [x] Bumped version-bearing files to `0.28.2`.
+- [x] Verified focused deploy tests, full test suite, clippy, formatting, version sync, and plugin validation.

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/syslog-mcp",
     "source": "github"
   },
-  "version": "0.28.1",
+  "version": "0.28.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.28.1",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:0.28.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -1,0 +1,604 @@
+use std::io::{self, Write as _};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use serde::Serialize;
+
+use crate::setup::{
+    default_env_for_data_dir, dockerfile_asset, installed_compose_asset, render_env, PhaseTimer,
+    SetupPhase, SetupStatus,
+};
+
+const REMOTE_HOME_SUFFIX: &str = ".syslog-mcp";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RemoteDeployReport {
+    pub mode: &'static str,
+    pub host: String,
+    pub home: String,
+    pub env_path: String,
+    pub compose_dir: String,
+    pub data_dir: String,
+    pub health_url: String,
+    pub mcp_url: String,
+    pub phases: Vec<SetupPhase>,
+    pub has_errors: bool,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Debug, Clone)]
+struct RemoteOutput {
+    status_success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+trait RemoteRunner {
+    fn run(&mut self, host: &str, script: &str, stdin: Option<&str>) -> io::Result<RemoteOutput>;
+}
+
+struct SshRemoteRunner;
+
+impl RemoteRunner for SshRemoteRunner {
+    fn run(&mut self, host: &str, script: &str, stdin: Option<&str>) -> io::Result<RemoteOutput> {
+        let mut child = Command::new("ssh")
+            .args([
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                host,
+                "sh",
+                "-s",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        {
+            let child_stdin = child.stdin.as_mut().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "failed to open ssh stdin")
+            })?;
+            child_stdin.write_all(script.as_bytes())?;
+            if let Some(input) = stdin {
+                child_stdin.write_all(input.as_bytes())?;
+            }
+        }
+
+        let output = child.wait_with_output()?;
+        Ok(RemoteOutput {
+            status_success: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+}
+
+pub fn run_remote_deploy(host: &str, dry_run: bool) -> io::Result<RemoteDeployReport> {
+    let mut runner = SshRemoteRunner;
+    run_remote_deploy_with_runner(host, dry_run, &mut runner)
+}
+
+fn run_remote_deploy_with_runner(
+    host: &str,
+    dry_run: bool,
+    runner: &mut dyn RemoteRunner,
+) -> io::Result<RemoteDeployReport> {
+    let started = Instant::now();
+    let mut phases = Vec::new();
+
+    let ssh_phase = remote_phase(runner, host, "ssh", "true", None)?;
+    phases.push(ssh_phase);
+
+    let identity = remote_identity_phase(runner, host)?;
+    let identity_values = identity.values;
+    phases.push(identity.phase);
+    let Some(identity_values) = identity_values else {
+        append_skipped(
+            &mut phases,
+            &[
+                "remote-filesystem",
+                "remote-env",
+                "remote-compose-assets",
+                "remote-docker",
+                "remote-docker-network",
+                "remote-compose-pull",
+                "remote-compose-up",
+                "remote-health",
+            ],
+            "skipped because remote identity failed",
+        );
+        return Ok(report(
+            host,
+            dry_run,
+            "$HOME",
+            "3100",
+            phases,
+            started.elapsed().as_millis(),
+        ));
+    };
+    let remote_home = format!("{}/{}", identity_values.home, REMOTE_HOME_SUFFIX);
+    let remote_data_dir = format!("{remote_home}/data");
+    let mut env = default_env_for_data_dir(Path::new(&remote_data_dir))?;
+    env.insert(
+        "SYSLOG_MCP_DATA_VOLUME".to_string(),
+        remote_data_dir.clone(),
+    );
+    env.insert("SYSLOG_UID".to_string(), identity_values.uid.clone());
+    env.insert("SYSLOG_GID".to_string(), identity_values.gid.clone());
+    let docker_network = env
+        .get("DOCKER_NETWORK")
+        .cloned()
+        .unwrap_or_else(|| "syslog-mcp".to_string());
+    let mcp_port = env
+        .get("SYSLOG_MCP_PORT")
+        .cloned()
+        .unwrap_or_else(|| "3100".to_string());
+
+    if dry_run {
+        phases.push(remote_phase(
+            runner,
+            host,
+            "remote-filesystem",
+            "test -d ~/.syslog-mcp || test -w \"$HOME\"",
+            None,
+        )?);
+        phases.push(remote_phase(
+            runner,
+            host,
+            "remote-docker",
+            "docker --version && docker compose version",
+            None,
+        )?);
+        let dry_run_reason = "dry-run does not mutate remote Docker or files";
+        phases.push(skip_phase("remote-env", dry_run_reason));
+        phases.push(skip_phase("remote-compose-assets", dry_run_reason));
+        phases.push(skip_phase(
+            "remote-docker-network",
+            "dry-run does not create Docker networks",
+        ));
+        phases.push(skip_phase(
+            "remote-compose-pull",
+            "dry-run does not pull images",
+        ));
+        phases.push(skip_phase(
+            "remote-compose-up",
+            "dry-run does not start Docker services",
+        ));
+        phases.push(skip_phase(
+            "remote-health",
+            "dry-run does not check service health",
+        ));
+        return Ok(report(
+            host,
+            dry_run,
+            &identity_values.home,
+            &mcp_port,
+            phases,
+            started.elapsed().as_millis(),
+        ));
+    }
+
+    phases.push(remote_phase(
+        runner,
+        host,
+        "remote-filesystem",
+        "mkdir -p ~/.syslog-mcp/compose/config ~/.syslog-mcp/data && chmod 700 ~/.syslog-mcp ~/.syslog-mcp/data",
+        None,
+    )?);
+    phases.push(remote_phase(
+        runner,
+        host,
+        "remote-docker",
+        "docker --version && docker compose version",
+        None,
+    )?);
+    if phases_have_errors(&phases) {
+        append_skipped(
+            &mut phases,
+            &[
+                "remote-env",
+                "remote-compose-assets",
+                "remote-docker-network",
+                "remote-compose-pull",
+                "remote-compose-up",
+                "remote-health",
+            ],
+            "skipped because remote prerequisites failed",
+        );
+        return Ok(report(
+            host,
+            dry_run,
+            &identity_values.home,
+            &mcp_port,
+            phases,
+            started.elapsed().as_millis(),
+        ));
+    }
+
+    phases.push(write_remote_env_phase(runner, host, &env)?);
+    phases.push(write_remote_assets_phase(runner, host)?);
+    if phases_have_errors(&phases) {
+        append_skipped(
+            &mut phases,
+            &[
+                "remote-docker-network",
+                "remote-compose-pull",
+                "remote-compose-up",
+                "remote-health",
+            ],
+            "skipped because remote asset setup failed",
+        );
+        return Ok(report(
+            host,
+            dry_run,
+            &identity_values.home,
+            &mcp_port,
+            phases,
+            started.elapsed().as_millis(),
+        ));
+    }
+
+    phases.push(remote_phase(
+        runner,
+        host,
+        "remote-docker-network",
+        &format!(
+            "docker network inspect {network} >/dev/null 2>&1 || docker network create {network}",
+            network = shell_quote(&docker_network)
+        ),
+        None,
+    )?);
+    if phases_have_errors(&phases) {
+        append_skipped(
+            &mut phases,
+            &["remote-compose-pull", "remote-compose-up", "remote-health"],
+            "skipped because Docker network setup failed",
+        );
+        return Ok(report(
+            host,
+            dry_run,
+            &identity_values.home,
+            &mcp_port,
+            phases,
+            started.elapsed().as_millis(),
+        ));
+    }
+
+    phases.push(remote_phase(
+            runner,
+            host,
+            "remote-compose-pull",
+            "docker compose --env-file ~/.syslog-mcp/.env -f ~/.syslog-mcp/compose/docker-compose.yml pull --ignore-buildable",
+            None,
+    )?);
+    if phases_have_errors(&phases) {
+        append_skipped(
+            &mut phases,
+            &["remote-compose-up", "remote-health"],
+            "skipped because Compose pull failed",
+        );
+        return Ok(report(
+            host,
+            dry_run,
+            &identity_values.home,
+            &mcp_port,
+            phases,
+            started.elapsed().as_millis(),
+        ));
+    }
+
+    phases.push(remote_phase(
+            runner,
+            host,
+            "remote-compose-up",
+            "docker compose --env-file ~/.syslog-mcp/.env -f ~/.syslog-mcp/compose/docker-compose.yml up -d",
+            None,
+    )?);
+    if phases_have_errors(&phases) {
+        append_skipped(
+            &mut phases,
+            &["remote-health"],
+            "skipped because Compose up failed",
+        );
+        return Ok(report(
+            host,
+            dry_run,
+            &identity_values.home,
+            &mcp_port,
+            phases,
+            started.elapsed().as_millis(),
+        ));
+    }
+
+    phases.push(remote_phase(
+        runner,
+        host,
+        "remote-health",
+        &format!(
+            "curl -fsS {}",
+            shell_quote(&format!("http://127.0.0.1:{mcp_port}/health"))
+        ),
+        None,
+    )?);
+    Ok(report(
+        host,
+        dry_run,
+        &identity_values.home,
+        &mcp_port,
+        phases,
+        started.elapsed().as_millis(),
+    ))
+}
+
+struct RemoteIdentityPhase {
+    phase: SetupPhase,
+    values: Option<RemoteIdentity>,
+}
+
+struct RemoteIdentity {
+    home: String,
+    uid: String,
+    gid: String,
+}
+
+fn remote_identity_phase(
+    runner: &mut dyn RemoteRunner,
+    host: &str,
+) -> io::Result<RemoteIdentityPhase> {
+    let timer = PhaseTimer::start("remote-identity");
+    let output = runner.run(host, "printf '%s\\n' \"$HOME\" && id -u && id -g", None)?;
+    if output.status_success {
+        let mut lines = output.stdout.lines();
+        let home = lines.next().unwrap_or("$HOME").trim().to_string();
+        let uid = lines.next().unwrap_or("1000").trim().to_string();
+        let gid = lines.next().unwrap_or("1000").trim().to_string();
+        return Ok(RemoteIdentityPhase {
+            phase: timer.finish(SetupStatus::Ok, format!("home={home} uid={uid} gid={gid}")),
+            values: Some(RemoteIdentity { home, uid, gid }),
+        });
+    }
+    Ok(RemoteIdentityPhase {
+        phase: timer.finish(SetupStatus::Error, output_detail(&output)),
+        values: None,
+    })
+}
+
+fn write_remote_env_phase(
+    runner: &mut dyn RemoteRunner,
+    host: &str,
+    env: &std::collections::BTreeMap<String, String>,
+) -> io::Result<SetupPhase> {
+    let rendered = render_env(env);
+    let script = format!(
+        "umask 077\ncat > ~/.syslog-mcp/.env.tmp <<'__SYSLOG_MCP_ENV__'\n{rendered}__SYSLOG_MCP_ENV__\nchmod 600 ~/.syslog-mcp/.env.tmp\nmv ~/.syslog-mcp/.env.tmp ~/.syslog-mcp/.env"
+    );
+    remote_phase(runner, host, "remote-env", &script, None)
+}
+
+fn report(
+    host: &str,
+    dry_run: bool,
+    remote_user_home: &str,
+    mcp_port: &str,
+    phases: Vec<SetupPhase>,
+    elapsed_ms: u128,
+) -> RemoteDeployReport {
+    let remote_home = format!("{remote_user_home}/{REMOTE_HOME_SUFFIX}");
+    let has_errors = phases
+        .iter()
+        .any(|phase| matches!(phase.status, SetupStatus::Error));
+    RemoteDeployReport {
+        mode: if dry_run { "remote dry-run" } else { "remote" },
+        host: host.to_string(),
+        home: remote_home.clone(),
+        env_path: format!("{remote_home}/.env"),
+        compose_dir: format!("{remote_home}/compose"),
+        data_dir: format!("{remote_home}/data"),
+        health_url: format!("http://127.0.0.1:{mcp_port}/health"),
+        mcp_url: format!("http://127.0.0.1:{mcp_port}/mcp"),
+        phases,
+        has_errors,
+        elapsed_ms,
+    }
+}
+
+fn write_remote_assets_phase(runner: &mut dyn RemoteRunner, host: &str) -> io::Result<SetupPhase> {
+    let script = format!(
+        "cat > ~/.syslog-mcp/compose/docker-compose.yml.tmp <<'__SYSLOG_MCP_COMPOSE__'\n{}__SYSLOG_MCP_COMPOSE__\ncat > ~/.syslog-mcp/compose/config/Dockerfile.tmp <<'__SYSLOG_MCP_DOCKERFILE__'\n{}__SYSLOG_MCP_DOCKERFILE__\nmv ~/.syslog-mcp/compose/docker-compose.yml.tmp ~/.syslog-mcp/compose/docker-compose.yml\nmv ~/.syslog-mcp/compose/config/Dockerfile.tmp ~/.syslog-mcp/compose/config/Dockerfile",
+        installed_compose_asset(),
+        dockerfile_asset()
+    );
+    remote_phase(runner, host, "remote-compose-assets", &script, None)
+}
+
+fn remote_phase(
+    runner: &mut dyn RemoteRunner,
+    host: &str,
+    name: &'static str,
+    script: &str,
+    stdin: Option<&str>,
+) -> io::Result<SetupPhase> {
+    let timer = PhaseTimer::start(name);
+    match runner.run(host, script, stdin) {
+        Ok(output) if output.status_success => {
+            Ok(timer.finish(SetupStatus::Ok, output_detail(&output)))
+        }
+        Ok(output) => Ok(timer.finish(SetupStatus::Error, output_detail(&output))),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            Ok(timer.finish(SetupStatus::Error, "ssh not found on PATH"))
+        }
+        Err(err) => Ok(timer.finish(SetupStatus::Error, err.to_string())),
+    }
+}
+
+fn skip_phase(name: &'static str, detail: &'static str) -> SetupPhase {
+    PhaseTimer::start(name).finish(SetupStatus::Skipped, detail)
+}
+
+fn append_skipped(phases: &mut Vec<SetupPhase>, names: &[&'static str], detail: &'static str) {
+    phases.extend(names.iter().map(|name| skip_phase(name, detail)));
+}
+
+fn phases_have_errors(phases: &[SetupPhase]) -> bool {
+    phases
+        .iter()
+        .any(|phase| matches!(phase.status, SetupStatus::Error))
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn output_detail(output: &RemoteOutput) -> String {
+    let text = if output.status_success {
+        output.stdout.trim()
+    } else if !output.stderr.trim().is_empty() {
+        output.stderr.trim()
+    } else {
+        output.stdout.trim()
+    };
+    text.lines().last().unwrap_or("ok").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeRemoteRunner {
+        commands: Vec<String>,
+        fail_contains: Option<&'static str>,
+    }
+
+    impl FakeRemoteRunner {
+        fn ok() -> Self {
+            Self::default()
+        }
+
+        fn fail_on(needle: &'static str) -> Self {
+            Self {
+                commands: Vec::new(),
+                fail_contains: Some(needle),
+            }
+        }
+    }
+
+    impl RemoteRunner for FakeRemoteRunner {
+        fn run(
+            &mut self,
+            host: &str,
+            script: &str,
+            _stdin: Option<&str>,
+        ) -> io::Result<RemoteOutput> {
+            self.commands.push(format!("{host}: {script}"));
+            if self
+                .fail_contains
+                .is_some_and(|needle| script.contains(needle))
+            {
+                return Ok(RemoteOutput {
+                    status_success: false,
+                    stdout: String::new(),
+                    stderr: "forced failure\n".to_string(),
+                });
+            }
+            let stdout = if script.contains("id -u") {
+                "/home/syslog\n1001\n1002\n".to_string()
+            } else {
+                "ok\n".to_string()
+            };
+            Ok(RemoteOutput {
+                status_success: true,
+                stdout,
+                stderr: String::new(),
+            })
+        }
+    }
+
+    #[test]
+    fn remote_dry_run_only_checks_ssh_and_docker() {
+        let mut runner = FakeRemoteRunner::ok();
+        let report = run_remote_deploy_with_runner("host-a", true, &mut runner).unwrap();
+
+        assert_eq!(report.host, "host-a");
+        assert!(runner
+            .commands
+            .iter()
+            .any(|cmd| cmd.contains("docker --version")));
+        assert!(!runner
+            .commands
+            .iter()
+            .any(|cmd| cmd.contains("docker compose") && cmd.contains("up -d")));
+        assert!(!runner
+            .commands
+            .iter()
+            .any(|cmd| cmd.contains("cat > ~/.syslog-mcp/.env")));
+    }
+
+    #[test]
+    fn remote_repair_writes_assets_before_compose_up() {
+        let mut runner = FakeRemoteRunner::ok();
+        let report = run_remote_deploy_with_runner("host-a", false, &mut runner).unwrap();
+
+        assert!(!report.has_errors);
+        let index = |needle: &str| {
+            runner
+                .commands
+                .iter()
+                .position(|cmd| cmd.contains(needle))
+                .unwrap_or_else(|| panic!("missing command containing {needle}"))
+        };
+        let mkdir = index("mkdir -p ~/.syslog-mcp/compose/config ~/.syslog-mcp/data");
+        let docker_check = index("docker --version && docker compose version");
+        let env_write = index("cat > ~/.syslog-mcp/.env.tmp");
+        let assets_write = index("docker-compose.yml.tmp");
+        let compose_pull = index("pull --ignore-buildable");
+        let compose_up = index("up -d");
+        assert!(mkdir < docker_check);
+        assert!(docker_check < env_write);
+        assert!(env_write < assets_write);
+        assert!(assets_write < compose_pull);
+        assert!(compose_pull < compose_up);
+    }
+
+    #[test]
+    fn remote_env_uses_remote_uid_and_gid() {
+        let mut runner = FakeRemoteRunner::ok();
+        run_remote_deploy_with_runner("host-a", false, &mut runner).unwrap();
+
+        let env_write = runner
+            .commands
+            .iter()
+            .find(|cmd| cmd.contains("cat > ~/.syslog-mcp/.env.tmp"))
+            .expect("env write command should run");
+        assert!(env_write.contains("SYSLOG_UID=1001"));
+        assert!(env_write.contains("SYSLOG_GID=1002"));
+    }
+
+    #[test]
+    fn remote_deploy_skips_mutations_after_identity_failure() {
+        let mut runner = FakeRemoteRunner::fail_on("id -u");
+        let report = run_remote_deploy_with_runner("host-a", false, &mut runner).unwrap();
+
+        assert!(report.has_errors);
+        assert!(!runner.commands.iter().any(|cmd| cmd.contains("up -d")));
+        assert!(report
+            .phases
+            .iter()
+            .any(|phase| phase.name == "remote-compose-up"
+                && matches!(phase.status, SetupStatus::Skipped)));
+    }
+
+    #[test]
+    fn remote_deploy_does_not_source_env_as_shell() {
+        let mut runner = FakeRemoteRunner::ok();
+        run_remote_deploy_with_runner("host-a", false, &mut runner).unwrap();
+
+        assert!(!runner
+            .commands
+            .iter()
+            .any(|cmd| cmd.contains(". ~/.syslog-mcp/.env")));
+    }
+}

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -349,7 +349,15 @@ fn remote_identity_phase(
     host: &str,
 ) -> io::Result<RemoteIdentityPhase> {
     let timer = PhaseTimer::start("remote-identity");
-    let output = runner.run(host, "printf '%s\\n' \"$HOME\" && id -u && id -g", None)?;
+    let output = match runner.run(host, "printf '%s\\n' \"$HOME\" && id -u && id -g", None) {
+        Ok(output) => output,
+        Err(err) => {
+            return Ok(RemoteIdentityPhase {
+                phase: timer.finish(SetupStatus::Error, format!("ssh failed: {err}")),
+                values: None,
+            });
+        }
+    };
     if output.status_success {
         let mut lines = output.stdout.lines();
         let home = lines.next().unwrap_or("$HOME").trim().to_string();
@@ -471,6 +479,7 @@ mod tests {
     struct FakeRemoteRunner {
         commands: Vec<String>,
         fail_contains: Option<&'static str>,
+        error_contains: Option<&'static str>,
     }
 
     impl FakeRemoteRunner {
@@ -482,6 +491,15 @@ mod tests {
             Self {
                 commands: Vec::new(),
                 fail_contains: Some(needle),
+                error_contains: None,
+            }
+        }
+
+        fn error_on(needle: &'static str) -> Self {
+            Self {
+                commands: Vec::new(),
+                fail_contains: None,
+                error_contains: Some(needle),
             }
         }
     }
@@ -494,6 +512,12 @@ mod tests {
             _stdin: Option<&str>,
         ) -> io::Result<RemoteOutput> {
             self.commands.push(format!("{host}: {script}"));
+            if self
+                .error_contains
+                .is_some_and(|needle| script.contains(needle))
+            {
+                return Err(io::Error::new(io::ErrorKind::NotFound, "ssh not found"));
+            }
             if self
                 .fail_contains
                 .is_some_and(|needle| script.contains(needle))
@@ -589,6 +613,22 @@ mod tests {
             .iter()
             .any(|phase| phase.name == "remote-compose-up"
                 && matches!(phase.status, SetupStatus::Skipped)));
+    }
+
+    #[test]
+    fn remote_deploy_reports_identity_spawn_error_as_phase_failure() {
+        let mut runner = FakeRemoteRunner::error_on("id -u");
+        let report = run_remote_deploy_with_runner("host-a", false, &mut runner).unwrap();
+
+        assert!(report.has_errors);
+        let identity = report
+            .phases
+            .iter()
+            .find(|phase| phase.name == "remote-identity")
+            .expect("identity phase should be present");
+        assert!(matches!(identity.status, SetupStatus::Error));
+        assert!(identity.detail.contains("ssh failed"));
+        assert!(!runner.commands.iter().any(|cmd| cmd.contains("up -d")));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod api;
 pub mod app;
 pub mod compose;
 pub mod config;
+pub mod deploy;
 pub mod doctor;
 pub mod enrich;
 pub mod logging;

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,32 @@ async fn run_deploy(command: DeployCommand) -> Result<()> {
         DeployCommandKind::Local { dry_run: false } => {
             (syslog_mcp::setup::SetupMode::Repair, "local")
         }
+        DeployCommandKind::Remote { host, dry_run } => {
+            let report = syslog_mcp::deploy::run_remote_deploy(&host, dry_run)?;
+            if command.json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                println!("syslog deploy remote {host}");
+                println!("mode: {}", report.mode);
+                println!("host: {}", report.host);
+                println!("home: {}", report.home);
+                println!("env: {}", report.env_path);
+                println!("compose: {}", report.compose_dir);
+                println!("data: {}", report.data_dir);
+                println!("health: {}", report.health_url);
+                println!("mcp: {}", report.mcp_url);
+                for phase in &report.phases {
+                    println!(
+                        "{:?}\t{}\t{}ms\t{}",
+                        phase.status, phase.name, phase.elapsed_ms, phase.detail
+                    );
+                }
+            }
+            if report.has_errors {
+                anyhow::bail!("syslog deploy remote {host} completed with failed phases");
+            }
+            return Ok(());
+        }
     };
     let report = syslog_mcp::setup::run_setup(mode).await?;
     if command.json {
@@ -319,6 +345,7 @@ struct DeployCommand {
 enum DeployCommandKind {
     Preflight,
     Local { dry_run: bool },
+    Remote { host: String, dry_run: bool },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -564,18 +591,24 @@ fn parse_setup_command(args: &[String]) -> Result<SetupCommand> {
 }
 
 fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
-    let (subcommand, rest) = args
-        .split_first()
-        .ok_or_else(|| anyhow::anyhow!("deploy requires a subcommand: preflight or local"))?;
+    let (subcommand, rest) = args.split_first().ok_or_else(|| {
+        anyhow::anyhow!("deploy requires a subcommand: preflight, local, or remote")
+    })?;
     let mut json = false;
     let mut dry_run = false;
+    let mut host: Option<String> = None;
     for arg in rest {
         match arg.as_str() {
             "--json" => json = true,
-            "--dry-run" if subcommand == "local" => dry_run = true,
+            "--dry-run" if matches!(subcommand.as_str(), "local" | "remote") => dry_run = true,
             "--help" | "-h" => {
                 print_usage();
                 std::process::exit(0);
+            }
+            other if subcommand == "remote" && !other.starts_with('-') => {
+                if host.replace(other.to_string()).is_some() {
+                    anyhow::bail!("deploy remote accepts exactly one host");
+                }
             }
             other => anyhow::bail!("unknown deploy {subcommand} argument: {other}"),
         }
@@ -583,6 +616,10 @@ fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
     let kind = match subcommand.as_str() {
         "preflight" => DeployCommandKind::Preflight,
         "local" => DeployCommandKind::Local { dry_run },
+        "remote" => DeployCommandKind::Remote {
+            host: host.ok_or_else(|| anyhow::anyhow!("deploy remote requires a host"))?,
+            dry_run,
+        },
         other => anyhow::bail!("unknown deploy subcommand: {other}"),
     };
     Ok(DeployCommand { kind, json })
@@ -651,6 +688,7 @@ fn print_usage() {
   syslog setup doctor [--json]
   syslog deploy preflight [--json]
   syslog deploy local [--dry-run] [--json]
+  syslog deploy remote HOST [--dry-run] [--json]
   syslog doctor [--json]          Run all health checks (setup, compose, binary, AI)
   syslog doctor binary [--json]
   syslog serve mcp    Start syslog UDP/TCP ingest plus HTTP MCP server
@@ -692,6 +730,7 @@ fn print_usage() {
   syslog setup plugin-hook [--no-repair] [--json]
   syslog deploy preflight [--json]
   syslog deploy local [--dry-run] [--json]
+  syslog deploy remote HOST [--dry-run] [--json]
   syslog config get KEY [--env|--toml] [--toml-path PATH] [--json]
   syslog config set KEY VALUE [--env|--toml] [--toml-path PATH] [--json]
   syslog config unset KEY [--env|--toml] [--toml-path PATH] [--json]

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -153,14 +153,43 @@ fn mode_parse_accepts_deploy_namespace() {
         .unwrap(),
         Mode::Deploy(_)
     ));
+    assert!(matches!(
+        Mode::parse(vec![
+            "deploy".into(),
+            "remote".into(),
+            "tootie".into(),
+            "--dry-run".into(),
+            "--json".into()
+        ])
+        .unwrap(),
+        Mode::Deploy(_)
+    ));
 }
 
 #[test]
 fn mode_parse_rejects_unknown_deploy_subcommand() {
+    let err = Mode::parse(vec!["deploy".into(), "bogus".into()]).unwrap_err();
+    assert!(err.to_string().contains("unknown deploy subcommand: bogus"));
+}
+
+#[test]
+fn mode_parse_rejects_remote_deploy_without_host() {
     let err = Mode::parse(vec!["deploy".into(), "remote".into()]).unwrap_err();
+    assert!(err.to_string().contains("deploy remote requires a host"));
+}
+
+#[test]
+fn mode_parse_rejects_remote_deploy_with_multiple_hosts() {
+    let err = Mode::parse(vec![
+        "deploy".into(),
+        "remote".into(),
+        "host-a".into(),
+        "host-b".into(),
+    ])
+    .unwrap_err();
     assert!(err
         .to_string()
-        .contains("unknown deploy subcommand: remote"));
+        .contains("deploy remote accepts exactly one host"));
 }
 
 #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -21,6 +21,9 @@ pub use ai_watch::run_ai_watch_service_setup;
 pub use debug_wrapper::{run_debug_compose_setup, run_debug_wrapper_setup};
 pub use doctor::run_setup_doctor;
 pub use firstrun::run_setup;
+pub(crate) use firstrun::{
+    default_env_for_data_dir, dockerfile_asset, installed_compose_asset, render_env,
+};
 
 // Test-only re-exports of private items accessed via `use super::*` in setup_tests.rs.
 #[cfg(test)]
@@ -37,7 +40,7 @@ pub(crate) use debug_wrapper::{
     debug_wrapper_script,
 };
 #[cfg(test)]
-pub(crate) use firstrun::{ensure_env_file, installed_compose_asset, parse_env, write_env};
+pub(crate) use firstrun::{ensure_env_file, parse_env, write_env};
 #[cfg(test)]
 pub(crate) use systemd::inferred_user_bus_env;
 
@@ -194,24 +197,24 @@ struct SetupReportInput {
     mcp_url: String,
 }
 
-struct PhaseTimer {
+pub(crate) struct PhaseTimer {
     name: &'static str,
     start: Instant,
 }
 
 impl PhaseTimer {
-    fn start(name: &'static str) -> Self {
+    pub(crate) fn start(name: &'static str) -> Self {
         Self {
             name,
             start: Instant::now(),
         }
     }
 
-    fn finish(self, status: SetupStatus, detail: impl Into<String>) -> SetupPhase {
+    pub(crate) fn finish(self, status: SetupStatus, detail: impl Into<String>) -> SetupPhase {
         self.finish_with_issue(status, None, detail)
     }
 
-    fn finish_with_issue(
+    pub(crate) fn finish_with_issue(
         self,
         status: SetupStatus,
         issue_kind: Option<SetupIssueKind>,

--- a/src/setup/firstrun.rs
+++ b/src/setup/firstrun.rs
@@ -142,35 +142,54 @@ pub(crate) fn ensure_env_file(path: &Path, data_dir: &Path) -> io::Result<EnvRes
         BTreeMap::new()
     };
     let before = env.len();
+    populate_env_defaults(&mut env, data_dir)?;
 
-    insert_process_or_default(&mut env, "SYSLOG_HOST", "0.0.0.0");
-    insert_process_or_default(&mut env, "SYSLOG_PORT", "1514");
-    insert_process_or_default(&mut env, "SYSLOG_HOST_PORT", "1514");
-    insert_process_or_default(&mut env, "SYSLOG_MCP_HOST", "0.0.0.0");
-    insert_process_or_default(&mut env, "SYSLOG_MCP_PORT", "3100");
-    insert_process_or_default(&mut env, "NO_AUTH", "false");
-    insert_process_or_default(&mut env, "SYSLOG_MCP_AUTH_MODE", "bearer");
-    insert_process_or_default(&mut env, "SYSLOG_MCP_DB_PATH", "/data/syslog.db");
+    write_env(path, &env)?;
+    let added = env.len().saturating_sub(before);
+    Ok(EnvResult {
+        phase: timer.finish(
+            SetupStatus::Ok,
+            format!("{} {} keys; added {added}", path.display(), env.len()),
+        ),
+        values: env,
+    })
+}
+
+pub(crate) fn default_env_for_data_dir(data_dir: &Path) -> io::Result<BTreeMap<String, String>> {
+    let mut env = BTreeMap::new();
+    populate_env_defaults(&mut env, data_dir)?;
+    Ok(env)
+}
+
+fn populate_env_defaults(env: &mut BTreeMap<String, String>, data_dir: &Path) -> io::Result<()> {
+    insert_process_or_default(env, "SYSLOG_HOST", "0.0.0.0");
+    insert_process_or_default(env, "SYSLOG_PORT", "1514");
+    insert_process_or_default(env, "SYSLOG_HOST_PORT", "1514");
+    insert_process_or_default(env, "SYSLOG_MCP_HOST", "0.0.0.0");
+    insert_process_or_default(env, "SYSLOG_MCP_PORT", "3100");
+    insert_process_or_default(env, "NO_AUTH", "false");
+    insert_process_or_default(env, "SYSLOG_MCP_AUTH_MODE", "bearer");
+    insert_process_or_default(env, "SYSLOG_MCP_DB_PATH", "/data/syslog.db");
     insert_process_or_default(
-        &mut env,
+        env,
         "SYSLOG_MCP_DATA_VOLUME",
         &data_dir.display().to_string(),
     );
-    insert_process_or_default(&mut env, "SYSLOG_MCP_MAX_DB_SIZE_MB", "8192");
-    insert_process_or_default(&mut env, "SYSLOG_MCP_RETENTION_DAYS", "90");
-    insert_process_or_default(&mut env, "SYSLOG_BATCH_SIZE", "100");
-    insert_process_or_default(&mut env, "SYSLOG_WRITE_CHANNEL_CAPACITY", "10000");
-    insert_process_or_default(&mut env, "SYSLOG_DOCKER_INGEST_ENABLED", "false");
-    insert_process_or_default(&mut env, "RUST_LOG", "info");
-    insert_process_or_default(&mut env, "COMPOSE_PROJECT_NAME", "syslog-jmagar-lab");
-    insert_process_or_default(&mut env, "DOCKER_NETWORK", "syslog-mcp");
-    insert_process_optional(&mut env, "SYSLOG_DOCKER_HOSTS");
-    insert_process_optional(&mut env, "SYSLOG_MCP_PUBLIC_URL");
-    insert_process_optional(&mut env, "SYSLOG_MCP_GOOGLE_CLIENT_ID");
-    insert_process_optional(&mut env, "SYSLOG_MCP_GOOGLE_CLIENT_SECRET");
-    insert_process_optional(&mut env, "SYSLOG_MCP_AUTH_ADMIN_EMAIL");
-    insert_process_optional(&mut env, "SYSLOG_MCP_AUTH_ALLOWED_REDIRECT_URIS");
-    insert_process_optional(&mut env, "SYSLOG_MCP_AUTH_DISABLE_STATIC_TOKEN_WITH_OAUTH");
+    insert_process_or_default(env, "SYSLOG_MCP_MAX_DB_SIZE_MB", "8192");
+    insert_process_or_default(env, "SYSLOG_MCP_RETENTION_DAYS", "90");
+    insert_process_or_default(env, "SYSLOG_BATCH_SIZE", "100");
+    insert_process_or_default(env, "SYSLOG_WRITE_CHANNEL_CAPACITY", "10000");
+    insert_process_or_default(env, "SYSLOG_DOCKER_INGEST_ENABLED", "false");
+    insert_process_or_default(env, "RUST_LOG", "info");
+    insert_process_or_default(env, "COMPOSE_PROJECT_NAME", "syslog-jmagar-lab");
+    insert_process_or_default(env, "DOCKER_NETWORK", "syslog-mcp");
+    insert_process_optional(env, "SYSLOG_DOCKER_HOSTS");
+    insert_process_optional(env, "SYSLOG_MCP_PUBLIC_URL");
+    insert_process_optional(env, "SYSLOG_MCP_GOOGLE_CLIENT_ID");
+    insert_process_optional(env, "SYSLOG_MCP_GOOGLE_CLIENT_SECRET");
+    insert_process_optional(env, "SYSLOG_MCP_AUTH_ADMIN_EMAIL");
+    insert_process_optional(env, "SYSLOG_MCP_AUTH_ALLOWED_REDIRECT_URIS");
+    insert_process_optional(env, "SYSLOG_MCP_AUTH_DISABLE_STATIC_TOKEN_WITH_OAUTH");
 
     let (uid, gid) = current_uid_gid();
     env.entry("SYSLOG_UID".to_string()).or_insert(uid);
@@ -207,16 +226,7 @@ pub(crate) fn ensure_env_file(path: &Path, data_dir: &Path) -> io::Result<EnvRes
     // string or `false` — survives byte-for-byte. Operator intent wins.
     env.entry("SYSLOG_USE_HTTP".to_string())
         .or_insert_with(|| "true".to_string());
-
-    write_env(path, &env)?;
-    let added = env.len().saturating_sub(before);
-    Ok(EnvResult {
-        phase: timer.finish(
-            SetupStatus::Ok,
-            format!("{} {} keys; added {added}", path.display(), env.len()),
-        ),
-        values: env,
-    })
+    Ok(())
 }
 
 fn insert_process_or_default(env: &mut BTreeMap<String, String>, key: &str, default: &str) {
@@ -258,15 +268,7 @@ pub(crate) fn write_env(path: &Path, env: &BTreeMap<String, String>) -> io::Resu
     #[cfg(unix)]
     use std::os::unix::fs::OpenOptionsExt;
 
-    let mut out = String::new();
-    out.push_str("# syslog-mcp runtime environment.\n");
-    out.push_str("# Managed by `syslog setup`; secrets are preserved on repair.\n");
-    for (key, value) in env {
-        out.push_str(key);
-        out.push('=');
-        out.push_str(value);
-        out.push('\n');
-    }
+    let out = render_env(env);
 
     // Atomic write: temp file in the same directory (so rename(2) stays on
     // the same filesystem), fsync, then rename over the target. A kill
@@ -335,6 +337,19 @@ pub(crate) fn write_env(path: &Path, env: &BTreeMap<String, String>) -> io::Resu
     Ok(())
 }
 
+pub(crate) fn render_env(env: &BTreeMap<String, String>) -> String {
+    let mut out = String::new();
+    out.push_str("# syslog-mcp runtime environment.\n");
+    out.push_str("# Managed by `syslog setup`; secrets are preserved on repair.\n");
+    for (key, value) in env {
+        out.push_str(key);
+        out.push('=');
+        out.push_str(value);
+        out.push('\n');
+    }
+    out
+}
+
 fn write_compose_assets(compose_dir: &Path) -> io::Result<SetupPhase> {
     let timer = PhaseTimer::start("compose-assets");
     std::fs::create_dir_all(compose_dir.join("config"))?;
@@ -364,6 +379,10 @@ pub(crate) fn installed_compose_asset() -> String {
         "installed compose asset transform failed: expected `      - path: .env\\n` was not found in docker-compose.prod.yml"
     );
     installed
+}
+
+pub(crate) fn dockerfile_asset() -> &'static str {
+    super::DOCKERFILE_ASSET
 }
 
 fn command_phase<const N: usize>(name: &'static str, args: [&str; N]) -> SetupPhase {


### PR DESCRIPTION
## Summary
- add CLI-only `syslog deploy remote <host>` over SSH for the managed Docker Compose bundle
- reuse setup env/Compose assets and keep REST/MCP deploy mutations out of scope
- document remote behavior, dry-run usage, and .env overwrite semantics
- bump release metadata to 0.28.2

## Verification
- `cargo fmt --check`
- `cargo test deploy`
- `cargo clippy -- -D warnings`
- `cargo test`
- `bash scripts/check-version-sync.sh --require-changelog`
- `bash scripts/validate-marketplace.sh`
- `just check` still fails on the pre-existing module-size guard for `src/cli/args.rs` and `src/cli/dispatch_surface.rs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI-only remote deploy over SSH: `syslog deploy remote <host>` to install and manage the Docker Compose bundle on a remote host. Requires SSH access and Docker Compose on the target; deploy remains CLI-only (no REST/MCP mutations). Also fixes remote identity spawn error handling; version bumped to `0.28.2`.

- **New Features**
  - Command: `syslog deploy remote HOST [--dry-run] [--json]`.
  - Dry-run verifies SSH and Docker only; no remote mutations.
  - Non-dry-run writes/replaces `~/.syslog-mcp/.env`, Compose YAML, and `config/Dockerfile`; runs `docker compose pull` and `up -d`; checks `/health`.
  - Reuses existing setup assets; phase-by-phase output with JSON; secrets passed over SSH stdin.
  - Default image/tag references updated to `0.28.2`.

- **Bug Fixes**
  - Report remote identity spawn failures as a phase error and skip later phases (e.g., show "ssh not found on PATH" when `ssh` is missing).

<sup>Written for commit 8ffca49e15556de3855126c19f1a991c8a0ef806. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/47?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `syslog deploy remote <host>` CLI command for SSH-based Docker Compose deployment to remote hosts
  * Supports optional `--dry-run` and `--json` flags for testing and machine-readable output
  * Remotely manages `.env`, Compose configuration, and Docker setup on target systems

* **Documentation**
  * Updated CLI documentation and added remote deployment workflow guide

* **Chores**
  * Version bumped to 0.28.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->