### PR TITLE
feat(ai): add headless Gemini assessment runner

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.3] - 2026-05-24
+
+### Fixed
+
+- **Headless Gemini assessment runner**: Recover Markdown assessments from
+  Gemini `write_file` stream events and reinforce the prompt to return
+  Markdown directly instead of creating artifacts. Also pass a non-empty
+  `--prompt` stub so Gemini does not exit before consuming stdin evidence.
+
 ## [0.32.2] - 2026-05-24
 
 ### Fixed
@@ -1549,7 +1558,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.32.2...HEAD
+[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.32.3...HEAD
+[0.32.3]: https://github.com/jmagar/syslog-mcp/compare/v0.32.2...v0.32.3
 [0.32.2]: https://github.com/jmagar/syslog-mcp/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/jmagar/syslog-mcp/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/jmagar/syslog-mcp/compare/v0.31.3...v0.32.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.32.2"
+version = "0.32.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.32.2"
+version = "0.32.3"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "syslog-mcp",
   "display_name": "Syslog MCP",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "description": "Query local syslog-mcp SQLite logs through a bundled stdio MCP server.",
   "long_description": "Syslog MCP packages the existing syslog mcp stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/syslog-mcp",
     "source": "github"
   },
-  "version": "0.32.2",
+  "version": "0.32.3",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.32.2",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.32.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/assessment.rs
+++ b/src/assessment.rs
@@ -10,6 +10,7 @@ use tokio::process::{Child, Command};
 const DEFAULT_GEMINI_MODEL: &str = "gemini-3.1-flash-lite-preview";
 const DEFAULT_COMPLETION_TIMEOUT_SECS: u64 = 120;
 const STDERR_TAIL_LIMIT: usize = 4096;
+const GEMINI_STDIN_PROMPT_STUB: &str = "Read the assessment instructions and evidence from stdin.";
 const GEMINI_AUTH_FILES: &[&str] = &[
     "oauth_creds.json",
     "gemini-credentials.json",
@@ -23,6 +24,8 @@ pub(crate) const SKILL_MD: &str =
 pub(crate) const ASSESSMENT_SYSTEM_PROMPT: &str = concat!(
     "Use the syslog-frustration-assessment skill to assess the supplied bounded ",
     "syslog abuse incident evidence bundle.\n\n",
+    "Return the assessment as Markdown in the assistant response. Do not write ",
+    "files, create plans, or persist artifacts.\n\n",
     "You must also follow these instructions directly if native skill activation ",
     "is unavailable:\n\n",
     include_str!("../plugins/syslog/skills/syslog-frustration-assessment/SKILL.md"),
@@ -64,7 +67,7 @@ impl GeminiAssessConfig {
             program: self.program.clone(),
             args: vec![
                 "--prompt".to_string(),
-                String::new(),
+                GEMINI_STDIN_PROMPT_STUB.to_string(),
                 "--approval-mode".to_string(),
                 "plan".to_string(),
                 "--extensions".to_string(),
@@ -391,18 +394,7 @@ impl GeminiStreamState {
         let value: Value = serde_json::from_str(trimmed)
             .map_err(|err| anyhow!("malformed Gemini stream JSON: {err}: {trimmed}"))?;
         match value.get("type").and_then(Value::as_str) {
-            Some("tool_use") => {
-                let tool_name = value
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .or_else(|| value.get("tool_name").and_then(Value::as_str));
-                if !matches!(tool_name, Some("activate_skill") | Some("update_topic")) {
-                    bail!(
-                        "Gemini headless emitted unexpected tool call '{}' in assessment mode; raw event: {value}",
-                        tool_name.unwrap_or("unknown")
-                    );
-                }
-            }
+            Some("tool_use") => self.handle_tool_use(&value)?,
             Some("tool_result") => {}
             Some("error") => bail!("Gemini headless stream error: {value}"),
             Some("message") if value.get("role").and_then(Value::as_str) == Some("assistant") => {
@@ -430,6 +422,34 @@ impl GeminiStreamState {
         }
         self.saw_success = true;
         Ok(())
+    }
+
+    fn handle_tool_use(&mut self, value: &Value) -> Result<()> {
+        let tool_name = value
+            .get("name")
+            .and_then(Value::as_str)
+            .or_else(|| value.get("tool_name").and_then(Value::as_str));
+        match tool_name {
+            Some("activate_skill") | Some("update_topic") => Ok(()),
+            Some("write_file") => {
+                let Some(content) = value
+                    .get("parameters")
+                    .and_then(|params| params.get("content"))
+                    .and_then(Value::as_str)
+                    .filter(|content| !content.trim().is_empty())
+                else {
+                    bail!(
+                        "Gemini headless emitted write_file without assessment content; raw event: {value}"
+                    );
+                };
+                self.result_text = Some(content.to_string());
+                Ok(())
+            }
+            _ => bail!(
+                "Gemini headless emitted unexpected tool call '{}' in assessment mode; raw event: {value}",
+                tool_name.unwrap_or("unknown")
+            ),
+        }
     }
 
     fn push_delta<F>(&mut self, delta: &str, on_delta: &mut F) -> Result<()>
@@ -589,6 +609,7 @@ mod tests {
     fn assessment_prompt_references_skill_and_wraps_evidence() {
         let prompt = build_assessment_prompt(r#"{"incident_id":"inc-1"}"#);
         assert!(prompt.contains("syslog-frustration-assessment"));
+        assert!(prompt.contains("Do not write files"));
         assert!(prompt.contains("Use this skill after running"));
         assert!(prompt.contains("<untrusted-evidence"));
         assert!(prompt.contains(r#""incident_id":"inc-1""#));
@@ -605,7 +626,10 @@ mod tests {
         let spec = config.command_spec().unwrap();
         assert_eq!(spec.program, "gemini");
         assert_eq!(spec.output_mode, "stream-json");
-        assert!(spec.args.windows(2).any(|w| w == ["--prompt", ""]));
+        assert!(spec
+            .args
+            .windows(2)
+            .any(|w| w == ["--prompt", GEMINI_STDIN_PROMPT_STUB]));
         assert!(spec
             .args
             .windows(2)
@@ -697,6 +721,24 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("unexpected tool call"));
+    }
+
+    #[test]
+    fn stream_parser_recovers_markdown_from_write_file_tool_call() {
+        let mut parser = GeminiStreamState::default();
+        parser
+            .handle_line(
+                r##"{"type":"tool_use","tool_name":"write_file","parameters":{"file_path":"/tmp/syslog-gemini-headless-x/.gemini/tmp/session/plans/frustration_assessment.md","content":"# Frustration Assessment\n\nRecovered report."}}"##,
+                &mut |_| Ok(()),
+            )
+            .unwrap();
+        parser
+            .handle_line(r#"{"type":"result","status":"success"}"#, &mut |_| Ok(()))
+            .unwrap();
+        assert_eq!(
+            parser.finish().unwrap(),
+            "# Frustration Assessment\n\nRecovered report."
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add an isolated headless Gemini runner for `syslog ai assess` using a temporary HOME/cwd and copied Gemini auth files.
- Install the bundled `syslog-frustration-assessment` skill into the isolated Gemini HOME and inline the skill as prompt fallback.
- Parse Gemini `stream-json`, stream assistant deltas in text mode, reject unexpected tool calls, bound/redact stderr, and kill/reap on timeout.
- Document syslog-specific Gemini env knobs and bump release metadata to `0.30.0`.

## Verification

- `bash scripts/check-version-sync.sh`
- `cargo test assessment`
- `cargo test parse_ai_assess`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Pre-commit hook: `cargo fmt`, `cargo clippy -- -D warnings`
- Pre-push hook: full test suite
- Live smoke: `syslog ai assess inc-f9a1d8e70cad13e6 --limit 3` with Gemini CLI 0.41.2 produced a 3704-byte Markdown assessment and `[assessed incident=inc-f9a1d8e70cad13e6 anchors=6 bundles=1]`.

## Tracker

- Closes `syslog-mcp-kmib.7`.
- Parent epic `syslog-mcp-kmib` remains open for `syslog-mcp-kmib.4` and `syslog-mcp-kmib.5`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a headless Gemini runner for `syslog ai assess` with an isolated runtime, safe defaults, live streaming, strict timeouts, and a stricter prompt that returns Markdown and avoids artifacts. Recovers assessments when Gemini writes files, bundles the `syslog-frustration-assessment` skill, and completes `syslog-mcp-kmib.7`.

- **New Features**
  - Isolated runtime: temp HOME/CWD; copies `.gemini` auth from `$HOME` or `SYSLOG_HEADLESS_GEMINI_HOME`; sanitizes `settings.json` (clears `mcpServers`/`hooks`/`context.fileName`, removes `admin`, sets `security.auth.selectedType` to `oauth-personal`).
  - Prompt and skill: installs `syslog-frustration-assessment`; instructs to return Markdown and not write files; requires evidence-backed trend language, preserves uncertainty, and distinguishes real frustration from incidental profanity.
  - Streaming and execution: parses `stream-json`; CLI prints assistant deltas live (unless `--json`); runs with `--approval-mode plan`, `--extensions none`, `--output-format stream-json`, and a non-empty `--prompt` stub; restricts tool calls and recovers report content from `write_file`.
  - Env knobs: `SYSLOG_HEADLESS_GEMINI_CMD`, `SYSLOG_HEADLESS_GEMINI_MODEL` (default `gemini-3.1-flash-lite-preview`), `SYSLOG_HEADLESS_GEMINI_HOME`, `SYSLOG_LLM_COMPLETION_TIMEOUT_SECS` (default `120`).

- **Bug Fixes**
  - Recover assessments from `write_file` stream events and prefer assistant text when available.
  - Preserve child-process status and stderr when stdin closes early; bound and redact stderr; kill/reap on timeout; reject dangerous flags (e.g. `--yolo`).
  - Include the embedded skill in the Docker image.

<sup>Written for commit b623710a184a65301f0447326eacb1b17485c9e0. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/49?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.30.0

* **New Features**
  * Added headless Gemini assessment runner with streaming output support for real-time feedback.
  * Introduced isolated execution environment for assessments with automated skill installation.

* **Documentation**
  * Added configuration guide for Gemini assessment environment variables, including timeout and model customization options.

* **Chores**
  * Version bump and dependency updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->