### PR TITLE
Add shell and agent command ingestion

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.32.0",
+  "version": "0.32.2",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.31.3",
+  "version": "0.32.0",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-05-24
+
+### Added
+
+- **Shell history ingestion**: Add `syslog shell index` for zsh extended
+  history backfill into the main log corpus with `shell-history` source
+  metadata.
+- **Agent command capture**: Add `syslog agent-command` spool ingestion and a
+  `syslog setup agent-command` Claude Code shell-prefix wrapper for Bash tool,
+  hook, and MCP startup command correlation.
+
 ## [0.31.3] - 2026-05-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.2] - 2026-05-24
+
+### Fixed
+
+- **Agent command setup**: Harden existing telemetry spool files during install
+  and reject symlink or non-file spool targets during setup checks.
+- **Agent command wrapper**: Keep recursion prevention scoped to argv-level
+  `syslog agent-command ingest-spool` invocations, execute wrapped multi-arg
+  commands without shell re-parsing, and preserve wrapped command flags after
+  `--`.
+- **Command source identity**: Percent-encode shell and agent command source
+  URI path segments without lossy character replacement.
+
+## [0.32.1] - 2026-05-24
+
+### Fixed
+
+- **Agent command wrapper**: Preserve wrapped command exit status when telemetry
+  spool append fails, and avoid mutating permissions on existing spool parent
+  directories.
+
 ## [0.32.0] - 2026-05-24
 
 ### Added
@@ -1528,7 +1549,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.31.3...HEAD
+[Unreleased]: https://github.com/jmagar/syslog-mcp/compare/v0.32.2...HEAD
+[0.32.2]: https://github.com/jmagar/syslog-mcp/compare/v0.32.1...v0.32.2
+[0.32.1]: https://github.com/jmagar/syslog-mcp/compare/v0.32.0...v0.32.1
+[0.32.0]: https://github.com/jmagar/syslog-mcp/compare/v0.31.3...v0.32.0
 [0.31.3]: https://github.com/jmagar/syslog-mcp/compare/v0.31.2...v0.31.3
 [0.31.2]: https://github.com/jmagar/syslog-mcp/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/jmagar/syslog-mcp/compare/v0.31.0...v0.31.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.32.0"
+version = "0.32.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.32.0"
+version = "0.32.2"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.31.3"
+version = "0.32.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/README.md
+++ b/README.md
@@ -427,9 +427,42 @@ Imported AI transcript messages are scrubbed for known credential/token patterns
 before storage and FTS indexing. The rows still live in the main `logs` table,
 so raw actions such as `search`, `tail`, `context`, and `get` can return
 scrubbed transcript text and local `ai_transcript_path` values within seconds of
-the transcript write. Scrubbing is best-effort, not a compliance boundary. If
-storage guardrails cannot recover enough space, indexing fails before committing
-additional chunks.
+the transcript write. Scrubbing is best-effort, not a compliance boundary.
+If storage guardrails cannot recover enough space, indexing fails before
+committing additional chunks.
+
+### Shell and agent command history
+
+Local command history can be correlated with system logs without introducing a
+separate table:
+
+```bash
+syslog shell index --path ~/.zsh_history --shell zsh
+syslog setup agent-command install
+export CLAUDE_CODE_SHELL_PREFIX="$HOME/.local/bin/syslog-agent-command-wrapper"
+syslog agent-command ingest-spool --path ~/.local/state/syslog-mcp/agent-command.jsonl
+```
+
+`syslog shell index` imports zsh extended history lines with timestamps and
+durations as `source_kind="shell-history"` rows. Plain untimestamped history is
+skipped because it cannot support time-window correlation.
+
+`syslog setup agent-command install` writes a small local wrapper for Claude
+Code's `CLAUDE_CODE_SHELL_PREFIX`. Claude Code invokes that prefix for spawned
+shell commands, including Bash tool calls, hook commands, and stdio MCP server
+startup commands. The wrapper preserves stdio and exit code, appends one
+scrubbed JSONL record under `~/.local/state/syslog-mcp/`, and
+`syslog agent-command ingest-spool` imports those records as
+`source_kind="agent-command"` rows, then truncates the locked spool after a
+successful import so repeated runs only process new commands. The wrapper
+records command text, cwd, duration, exit status, agent name, PID, host/user, and
+`CLAUDE_CODE_SESSION_ID` when present. It does not capture environment
+variables, stdout, or stderr by default.
+
+Both command import paths run the AI scrubber plus command-specific redaction
+for token flags, sensitive assignments, Authorization headers, URL userinfo,
+`curl -u`, and private-key blocks before storage. Scrubbing is best-effort, not
+a compliance boundary.
 
 **Important:** `hostname` is taken from the syslog message body, which any LAN device can set to an arbitrary value over UDP. For syslog entries, `source_ip` is the only trustworthy network identifier. For Docker ingest entries, `source_ip` identifies the configured Docker ingest host/container/stream and should be trusted only as far as the configured docker-socket-proxy endpoint and network path are trusted. `metadata_json` preserves source-specific context for debugging and correlation, but it is not an authorization boundary. Retention cutoffs use `received_at` (server clock) so that devices with misconfigured clocks cannot cause premature or indefinite log retention.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -401,6 +401,57 @@ syslog ai smoke-watch --json
 This is a live command. It requires `syslog-ai-watch.service` to be running and
 writing to the same `SYSLOG_MCP_DB_PATH` used by the CLI process.
 
+### `syslog shell index`
+
+Backfill local shell history into the main log corpus.
+
+```bash
+syslog shell index --path ~/.zsh_history
+syslog shell index --path ~/.zsh_history --shell zsh --json
+```
+
+The importer currently supports zsh extended history lines in the
+`: <epoch>:<duration>;<command>` format. Plain history lines without timestamps
+are counted as skipped because they cannot be correlated reliably. Commands are
+scrubbed before storage, written with `source_kind="shell-history"`, and use
+`source_ip` identities shaped like `shell-history://<hostname>/<user>/<shell>`.
+Rows are deduped by source identity, timestamp, and scrubbed command text, and
+the importer records a private byte-offset cursor under the syslog-mcp state
+directory so repeated imports only read newly appended history.
+
+### `syslog agent-command`
+
+Capture shell commands launched by agent tools, then ingest the private JSONL
+spool into SQLite.
+
+```bash
+syslog setup agent-command install
+export CLAUDE_CODE_SHELL_PREFIX="$HOME/.local/bin/syslog-agent-command-wrapper"
+
+syslog agent-command ingest-spool --path ~/.local/state/syslog-mcp/agent-command.jsonl
+syslog agent-command wrap --spool ~/.local/state/syslog-mcp/agent-command.jsonl -- cargo test
+```
+
+`CLAUDE_CODE_SHELL_PREFIX` is the Claude Code hook point for commands spawned by
+Claude Code, including Bash tool calls, hook commands, and stdio MCP server
+startup commands. The generated wrapper executes the original command, preserves
+stdio and exit code, then appends one scrubbed JSONL record. It removes
+`CLAUDE_CODE_SHELL_PREFIX` and sets an internal recursion guard for the child
+process so the wrapper does not wrap itself.
+
+The wrapper does not capture environment variables, stdout, or stderr by
+default. Command strings are scrubbed for known token, secret flag, assignment,
+Authorization header, URL-userinfo, `curl -u`, and private-key forms before they
+reach the spool. The spool directory is created as `0700`, the spool file as
+`0600`, symlink paths are rejected, and import refuses group/world writable
+parents or spools. Wrapper appends and spool imports use the same advisory file
+lock; after a successful import the spool is truncated so repeated imports do
+not rescan already-ingested commands. Imported rows use
+`source_kind="agent-command"`, `facility`
+`agent`, `app_name`/`ai_tool` set to the agent name, `event_action="command"`,
+and `source_ip` identities shaped like
+`agent-command://<hostname>/<agent>/<session_id>`.
+
 ### `syslog setup ai-watch-service`
 
 Install, remove, or inspect the supported host-local user-systemd watcher for

--- a/docs/contracts/metadata-json-shape.md
+++ b/docs/contracts/metadata-json-shape.md
@@ -51,6 +51,8 @@ caught at write time (see §5).
 | `unifi` | `unifi-api` poller (Epic C §4) | spec C | `key`, `_id`, `ip`, `mac`, `ap`, `ssid`, `user`. No parser in V1. If a future parser lands, it writes under `unifi.parsed`. |
 | `otlp` | OTLP ingest (`src/otlp.rs`, existing) | existing code | Carries OpenTelemetry `attributes`, `resource`, `scope` — already populated by today's code. |
 | `agent` | `syslog agent` (Epic A §4.1) | spec A | The agent's free-form `AgentLogEntry.metadata` blob is wrapped wholesale under this key by the server-side ingest handler. **The agent CANNOT write to any other namespace.** This boundary is what prevents a compromised agent from forging parser provenance. |
+| `shell` | shell history import (`src/command_log.rs`) | command-log source | Shell name, user, history path, line number, duration, and timestamp quality for local shell-history rows. Command text is scrubbed before `message`/`raw`; unsanitized command text must not be stored here. |
+| `agent_command` | agent command spool import (`src/command_log.rs`) | command-log source | Claude/agent command metadata: schema version, agent name, command surface, cwd, pid, exit status, duration, finish time, and session id. The wrapper does not capture env/stdout/stderr by default. |
 | `parser` | parser dispatcher (Epic B §4) | spec B | Provenance for the parser that ran: `{"name": "authelia", "version": 1, "match_via": "container_name" \| "app_name" \| "compose_service"}`. Always present when a parser ran. |
 | `source_kind` | enrichment pipeline | log-row-shape.md §5, source-kinds.md | Denormalised string copy of the row's `source_kind` (reconstructed from `source_ip` scheme). Always present. See source-kinds.md for the closed value set. |
 
@@ -202,6 +204,7 @@ mapping is hardcoded:
 | `adguard` | (1) adguard-api poller + (3) adguard parser |
 | `unifi`, `otlp` | (1) transport-specific shaping only |
 | `agent` | (1) ws handler only |
+| `shell`, `agent_command` | command-log import only |
 | `parser` | (3) parser dispatch only |
 | `source_kind` | (4) final enrichment only |
 

--- a/docs/contracts/source-kinds.md
+++ b/docs/contracts/source-kinds.md
@@ -71,6 +71,8 @@ no-match, §7). Renaming an existing value is a major version bump.
 | `otlp` | `src/otlp.rs` | OpenTelemetry logs received on `/v1/logs` |
 | `unifi-api` | UniFi poller (epic C `syslog-mcp-awvr`) | UniFi controller events + alarms poller |
 | `adguard-api` | AdGuard poller (epic C `syslog-mcp-awvr`) | AdGuard Home `/control/querylog` poller |
+| `shell-history` | `src/command_log.rs` | Local shell history backfill, currently zsh extended history |
+| `agent-command` | `src/command_log.rs` | AI agent-launched shell commands imported from a private JSONL spool |
 
 **Removed / renamed during reconciliation:**
 
@@ -106,6 +108,8 @@ percent-encoded as required.
 | `otlp` | `otlp://<peer_ip>` (no port; one exporter, many records) | `otlp://10.0.0.5/plex` (optional path: `service.name`) |
 | `unifi-api` | `unifi://<controller_host>/` (single-site v1; per spec C §14 open question 1) | `unifi://udm-pro.lan/` |
 | `adguard-api` | `adguard://<adguard_host>/` | `adguard://adguard.lan/` |
+| `shell-history` | `shell-history://<hostname>/<user>/<shell>` | `shell-history://dookie/jmagar/zsh` |
+| `agent-command` | `agent-command://<hostname>/<agent>/<session_id>` | `agent-command://dookie/claude-code/019e588f` |
 
 ### Notes on the `agent://` authority
 
@@ -159,6 +163,8 @@ scheme reconstruction):
      directly under `metadata_json.unifi`).
    - `otlp` → `app_name` (= OTLP `service.name`).
    - `agent` → `app_name` exact match, same path as syslog.
+   - `shell-history` / `agent-command` → no parser in V1; the importer
+     writes scrubbed command rows and structured metadata directly.
 
 2. **Retention selector** (`runtime.rs` line 58 / spec C §5 storage
    projection). AdGuard rows tagged via the `adguard-*` prefix get a

--- a/docs/superpowers/plans/2026-05-24-shell-agent-command-ingestion.md
+++ b/docs/superpowers/plans/2026-05-24-shell-agent-command-ingestion.md
@@ -1,0 +1,78 @@
+# Shell and Agent Command Ingestion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture zsh history and Claude Code command executions as searchable, scrubbed log rows that participate in existing syslog-mcp correlation.
+
+**Architecture:** Add two first-class ingest source kinds: `shell-history` for passive shell history backfill and `agent-command` for Claude Code shell-prefix command execution. Both normalize into `LogBatchEntry`; the Claude wrapper writes append-only JSONL spool records and never touches SQLite on the command hot path.
+
+**Tech Stack:** Rust, rusqlite, serde JSONL, chrono, existing `LogBatchEntry`, `SyslogService::run_db`, `SourceKind`, and CLI dispatch modules.
+
+---
+
+## Findings Applied
+
+- `source_kind` is a closed contract in `docs/contracts/source-kinds.md`; new sources must update the enum, docs, dispatch mapping, and tests together.
+- A broad `LogSource` trait would be premature. The useful abstraction is a small mapper from source-specific records into `LogBatchEntry`.
+- `CLAUDE_CODE_SHELL_PREFIX` is the intended Claude Code hook point for Bash tool calls, hook commands, and stdio MCP startup commands. The wrapper must preserve stdout, stderr, stdin, and exit status.
+- The Claude wrapper must not write SQLite directly. It appends JSONL to a user-private spool path and a separate ingest command imports that spool.
+- Command text is sensitive. Reuse the existing AI scrubber and metadata sanitizer, do not capture stdout/stderr by default, and document that command-read access implies access to scrubbed local operator activity.
+
+## Files
+
+- Modify `src/enrich/parser.rs`: add `ShellHistory` and `AgentCommand` source kinds.
+- Modify `docs/contracts/source-kinds.md`: register `shell-history` and `agent-command` plus URI schemes.
+- Create `src/command_log.rs`: zsh parser, agent spool JSONL model, command wrapper, import logic, and tests.
+- Modify `src/lib.rs`: export `command_log`.
+- Modify `src/app/service.rs`: add local DB methods for shell history and agent spool import.
+- Modify `src/cli/args.rs`: add `ShellCommand`, `AgentCommandCommand`, and argument structs.
+- Modify `src/cli/parse.rs`: route `shell` and `agent-command`.
+- Create `src/cli/parse_command_log.rs`: parse the new CLI surfaces.
+- Create `src/cli/dispatch_command_log.rs`: call service methods and run wrapper.
+- Modify `src/cli/run.rs`: dispatch the new commands.
+- Modify `src/cli.rs`: include the new modules.
+- Modify `src/main.rs`: usage text.
+- Modify `README.md` and `docs/CLI.md`: document setup, backfill, wrapper, and caveats.
+
+## Task 1: Source Kinds and Row Mapping
+
+- [ ] Add `ShellHistory` and `AgentCommand` to `SourceKind`.
+- [ ] Update `as_str()` and dispatch string mapping.
+- [ ] Add parser tests asserting kebab-case serialization for both variants.
+- [ ] Update `docs/contracts/source-kinds.md` with `shell-history://<hostname>/<user>/<shell>` and `agent-command://<hostname>/<agent>/<session>`.
+
+## Task 2: Command Log Module
+
+- [ ] Create `src/command_log.rs` with `CommandLogImportResult`.
+- [ ] Implement `parse_zsh_extended_history_line(": 1716500000:3;cargo test")`.
+- [ ] Skip timestamp-less history rows by default and count them as skipped.
+- [ ] Map zsh rows to `LogBatchEntry` with `facility=shell`, `app_name=zsh`, scrubbed command text, and metadata including `timestamp_quality`, `duration_secs`, `history_path`, `line_no`, and `content_scrubbed`.
+- [ ] Implement `AgentCommandSpoolRecord` JSONL parsing and mapping to `LogBatchEntry`.
+- [ ] Implement `run_agent_command_wrapper(spool_path, command_args)` that appends one JSONL record after the command exits, inherits stdin/stdout/stderr, and exits with the original status.
+- [ ] Add unit tests for zsh parsing, skip counts, command scrubbing, metadata source kinds, and failed-command severity.
+
+## Task 3: Service and CLI Integration
+
+- [ ] Add service methods `import_shell_history(path, shell)` and `import_agent_command_spool(path)`.
+- [ ] Add CLI commands:
+  - `syslog shell index --path PATH [--shell zsh] [--json]`
+  - `syslog agent-command ingest-spool --path PATH [--json]`
+  - `syslog agent-command wrap --spool PATH -- COMMAND...`
+- [ ] Keep `shell index` and `agent-command ingest-spool` local-only through `SyslogService`; the wrapper must not require DB config.
+- [ ] Add parser tests for all new CLI commands.
+- [ ] Add dispatch tests for HTTP-mode rejection if practical.
+
+## Task 4: Documentation
+
+- [ ] Document zsh backfill and the requirement for `EXTENDED_HISTORY` for reliable timestamps.
+- [ ] Document Claude setup using `CLAUDE_CODE_SHELL_PREFIX`.
+- [ ] Document spool privacy and permissions: create parent directories with `0700`; append records with user-readable permissions only.
+- [ ] Document no stdout/stderr capture and no direct DB writes from wrapper.
+
+## Task 5: Verification and Release Hygiene
+
+- [ ] Run focused tests for `command_log`, `enrich::parser`, and CLI parsing.
+- [ ] Run `cargo fmt`.
+- [ ] Run `cargo test`.
+- [ ] Bump the patch version across all version-bearing files and add `CHANGELOG.md` entry because this is a feature branch push.
+- [ ] Commit and push branch, then create PR if GitHub auth/remotes are available.

--- a/docs/superpowers/plans/2026-05-24-shell-agent-command-ingestion.md
+++ b/docs/superpowers/plans/2026-05-24-shell-agent-command-ingestion.md
@@ -74,5 +74,5 @@
 - [ ] Run focused tests for `command_log`, `enrich::parser`, and CLI parsing.
 - [ ] Run `cargo fmt`.
 - [ ] Run `cargo test`.
-- [ ] Bump the patch version across all version-bearing files and add `CHANGELOG.md` entry because this is a feature branch push.
+- [ ] Verify the commit prefix, then run the normal bump tooling using the repo policy (`feat!:`/`BREAKING CHANGE` -> major, `feat:` -> minor, everything else -> patch) and add a `CHANGELOG.md` entry.
 - [ ] Commit and push branch, then create PR if GitHub auth/remotes are available.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "syslog-mcp",
   "display_name": "Syslog MCP",
-  "version": "0.31.3",
+  "version": "0.32.0",
   "description": "Query local syslog-mcp SQLite logs through a bundled stdio MCP server.",
   "long_description": "Syslog MCP packages the existing syslog mcp stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "syslog-mcp",
   "display_name": "Syslog MCP",
-  "version": "0.32.0",
+  "version": "0.32.2",
   "description": "Query local syslog-mcp SQLite logs through a bundled stdio MCP server.",
   "long_description": "Syslog MCP packages the existing syslog mcp stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/syslog-mcp",
     "source": "github"
   },
-  "version": "0.31.3",
+  "version": "0.32.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.31.3",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.32.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/syslog-mcp",
     "source": "github"
   },
-  "version": "0.32.0",
+  "version": "0.32.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.32.0",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.32.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -29,6 +29,7 @@ use super::os_adapter::{OsAdapter, SystemOsAdapter};
 use super::time::{parse_optional_timestamp, parse_required_timestamp, rfc3339_z};
 use super::{ServiceError, ServiceResult};
 use crate::assessment::{build_assessment_prompt, run_gemini_assessment, GeminiAssessConfig};
+use crate::command_log::{self, CommandLogImportResult};
 use crate::config::StorageConfig;
 use crate::db::{self, Bucket, ContextRef, DbPool, SearchParams, TimelineGroupBy};
 use crate::scanner;
@@ -285,6 +286,23 @@ impl SyslogService {
         req: ServiceLogsRequest,
     ) -> ServiceResult<ServiceLogsResponse> {
         run_service_logs(req, self.os.as_ref()).await
+    }
+
+    pub async fn import_shell_history(
+        &self,
+        path: PathBuf,
+        shell: String,
+    ) -> ServiceResult<CommandLogImportResult> {
+        self.run_db(move |pool| command_log::import_zsh_history(pool, &path, &shell))
+            .await
+    }
+
+    pub async fn import_agent_command_spool(
+        &self,
+        path: PathBuf,
+    ) -> ServiceResult<CommandLogImportResult> {
+        self.run_db(move |pool| command_log::import_agent_command_spool(pool, &path))
+            .await
     }
 
     pub async fn incident(&self, req: IncidentRequest) -> ServiceResult<IncidentResponse> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,15 +7,16 @@ use syslog_mcp::compose::{
 mod args;
 mod args_config;
 pub(crate) use args::{
-    AiAbuseArgs, AiAddArgs, AiAskHistoryArgs, AiAssessArgs, AiBlocksArgs, AiCheckpointsArgs,
-    AiCommand, AiContextArgs, AiCorrelateArgs, AiDoctorArgs, AiErrorsArgs, AiIncidentContextArgs,
-    AiIncidentsArgs, AiIndexArgs, AiInvestigateArgs, AiListArgs, AiPruneCheckpointsArgs,
-    AiSearchArgs, AiSimilarArgs, AiWatchArgs, CliCommand, ComposeArgs, ComposeCommand,
-    ComposeLogsArgs, ComposeMutationArgs, CorrelateArgs, DbBackupArgs, DbCheckpointArgs, DbCommand,
-    DbIntegrityArgs, DbStatusArgs, DbVacuumArgs, IncidentArgs, IngestRateArgs, NotifyRecentArgs,
-    NotifyTestArgs, OutputArgs, PatternsArgs, PluginHookArgs, SearchArgs, ServiceCommand,
-    ServiceLogsArgs, SessionsArgs, SetupArgs, SetupCommand, SigAckArgs, SigListArgs, SigUnackArgs,
-    SourceIpsArgs, TailArgs, TimeRangeArgs, TimelineArgs,
+    AgentCommandCommand, AgentCommandIngestSpoolArgs, AgentCommandWrapArgs, AiAbuseArgs, AiAddArgs,
+    AiAskHistoryArgs, AiAssessArgs, AiBlocksArgs, AiCheckpointsArgs, AiCommand, AiContextArgs,
+    AiCorrelateArgs, AiDoctorArgs, AiErrorsArgs, AiIncidentContextArgs, AiIncidentsArgs,
+    AiIndexArgs, AiInvestigateArgs, AiListArgs, AiPruneCheckpointsArgs, AiSearchArgs,
+    AiSimilarArgs, AiWatchArgs, CliCommand, ComposeArgs, ComposeCommand, ComposeLogsArgs,
+    ComposeMutationArgs, CorrelateArgs, DbBackupArgs, DbCheckpointArgs, DbCommand, DbIntegrityArgs,
+    DbStatusArgs, DbVacuumArgs, IncidentArgs, IngestRateArgs, NotifyRecentArgs, NotifyTestArgs,
+    OutputArgs, PatternsArgs, PluginHookArgs, SearchArgs, ServiceCommand, ServiceLogsArgs,
+    SessionsArgs, SetupArgs, SetupCommand, ShellCommand, ShellIndexArgs, SigAckArgs, SigListArgs,
+    SigUnackArgs, SourceIpsArgs, TailArgs, TimeRangeArgs, TimelineArgs,
 };
 pub(crate) use args_config::{
     ConfigCommand, ConfigGetArgs, ConfigListArgs, ConfigSetArgs, ConfigTarget, ConfigUnsetArgs,
@@ -24,6 +25,7 @@ pub(crate) use args_config::{
 mod commands;
 
 mod run;
+pub(crate) use dispatch_command_log::run_agent_command_wrap;
 #[allow(unused_imports)]
 pub(crate) use run::ENV_USE_HTTP;
 pub(crate) use run::{run, CliMode, GlobalFlags};
@@ -32,6 +34,7 @@ mod ai_watch;
 mod config_cmd;
 mod config_toml;
 mod coordination;
+mod dispatch_command_log;
 mod output_ai;
 mod output_ai_more;
 mod output_common;
@@ -41,6 +44,7 @@ mod parse;
 mod parse_admin;
 mod parse_ai;
 mod parse_ai_more;
+mod parse_command_log;
 mod parse_common;
 mod parse_config;
 mod parse_logs;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -23,6 +23,8 @@ pub(crate) enum CliCommand {
     IngestRate(IngestRateArgs),
     Sig(SigCommand),
     Notify(NotifyCommand),
+    Shell(ShellCommand),
+    AgentCommand(AgentCommandCommand),
     // ── Surface parity gap closure (2026-05-22) ─────────────────────────────
     SilentHosts(SilentHostsArgs),
     ClockSkew(ClockSkewArgs),
@@ -42,6 +44,36 @@ pub(crate) enum SigCommand {
 pub(crate) enum NotifyCommand {
     Recent(NotifyRecentArgs),
     Test(NotifyTestArgs),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ShellCommand {
+    Index(ShellIndexArgs),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AgentCommandCommand {
+    IngestSpool(AgentCommandIngestSpoolArgs),
+    Wrap(AgentCommandWrapArgs),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShellIndexArgs {
+    pub path: String,
+    pub shell: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentCommandIngestSpoolArgs {
+    pub path: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentCommandWrapArgs {
+    pub spool: String,
+    pub command: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/cli/dispatch_command_log.rs
+++ b/src/cli/dispatch_command_log.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+use syslog_mcp::command_log::{self, CommandLogImportResult};
+
+use super::{AgentCommandIngestSpoolArgs, AgentCommandWrapArgs, CliMode, ShellIndexArgs};
+
+pub(crate) async fn run_shell_index(mode: &CliMode, args: ShellIndexArgs) -> Result<()> {
+    let CliMode::Local(service) = mode else {
+        bail!("shell index is local-only; run without --http/--server/--token");
+    };
+    let result = service
+        .import_shell_history(PathBuf::from(args.path), args.shell)
+        .await?;
+    print_import_result("shell index", &result, args.json)
+}
+
+pub(crate) async fn run_agent_command_ingest_spool(
+    mode: &CliMode,
+    args: AgentCommandIngestSpoolArgs,
+) -> Result<()> {
+    let CliMode::Local(service) = mode else {
+        bail!("agent-command ingest-spool is local-only; run without --http/--server/--token");
+    };
+    let result = service
+        .import_agent_command_spool(PathBuf::from(args.path))
+        .await?;
+    print_import_result("agent-command ingest-spool", &result, args.json)
+}
+
+pub(crate) fn run_agent_command_wrap(args: AgentCommandWrapArgs) -> Result<i32> {
+    command_log::run_agent_command_wrapper(PathBuf::from(args.spool).as_path(), &args.command)
+}
+
+fn print_import_result(label: &str, result: &CommandLogImportResult, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string_pretty(result)?);
+    } else {
+        println!("{label}");
+        println!("scanned: {}", result.scanned);
+        println!("imported: {}", result.imported);
+        println!("skipped: {}", result.skipped);
+        println!("skipped_duplicates: {}", result.skipped_duplicates);
+        println!("errors: {}", result.errors);
+    }
+    Ok(())
+}

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, bail, Result};
 
 use super::parse_admin::{parse_compose, parse_db, parse_service, parse_setup, parse_stats};
 use super::parse_ai::parse_ai;
+use super::parse_command_log::{parse_agent_command, parse_shell};
 use super::parse_logs::{
     parse_correlate, parse_errors, parse_hosts, parse_incident, parse_ingest_rate, parse_patterns,
     parse_search, parse_sessions, parse_source_ips, parse_tail, parse_timeline,
@@ -20,6 +21,8 @@ pub(crate) fn parse_command(args: Vec<String>) -> Result<CliCommand> {
         "sessions" => parse_sessions(rest),
         "incident" => parse_incident(rest),
         "ai" => parse_ai(rest),
+        "shell" => parse_shell(rest),
+        "agent-command" => parse_agent_command(rest),
         "correlate" => parse_correlate(rest),
         "stats" => parse_stats(rest),
         "compose" => parse_compose(rest),

--- a/src/cli/parse_command_log.rs
+++ b/src/cli/parse_command_log.rs
@@ -1,0 +1,124 @@
+use anyhow::{bail, Result};
+
+use super::{
+    AgentCommandCommand, AgentCommandIngestSpoolArgs, AgentCommandWrapArgs, CliCommand,
+    ShellCommand, ShellIndexArgs,
+};
+
+pub(crate) fn parse_shell(args: &[String]) -> Result<CliCommand> {
+    let (command, rest) = args
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("shell subcommand is required"))?;
+    match command.as_str() {
+        "index" => parse_shell_index(rest),
+        _ => bail!("unknown shell subcommand: {command}"),
+    }
+}
+
+pub(crate) fn parse_agent_command(args: &[String]) -> Result<CliCommand> {
+    let (command, rest) = args
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("agent-command subcommand is required"))?;
+    match command.as_str() {
+        "ingest-spool" => parse_agent_command_ingest_spool(rest),
+        "wrap" => parse_agent_command_wrap(rest),
+        _ => bail!("unknown agent-command subcommand: {command}"),
+    }
+}
+
+fn parse_shell_index(args: &[String]) -> Result<CliCommand> {
+    let mut path = None;
+    let mut shell = "zsh".to_string();
+    let mut json = false;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--path" => {
+                i += 1;
+                path = Some(required_value(args, i, "--path")?);
+            }
+            "--shell" => {
+                i += 1;
+                shell = required_value(args, i, "--shell")?;
+            }
+            "--json" => json = true,
+            other => bail!("unknown shell index argument: {other}"),
+        }
+        i += 1;
+    }
+    let path = path.ok_or_else(|| anyhow::anyhow!("shell index requires --path PATH"))?;
+    if shell != "zsh" {
+        bail!("shell index currently supports only --shell zsh");
+    }
+    Ok(CliCommand::Shell(ShellCommand::Index(ShellIndexArgs {
+        path,
+        shell,
+        json,
+    })))
+}
+
+fn parse_agent_command_ingest_spool(args: &[String]) -> Result<CliCommand> {
+    let mut path = None;
+    let mut json = false;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--path" => {
+                i += 1;
+                path = Some(required_value(args, i, "--path")?);
+            }
+            "--json" => json = true,
+            other => bail!("unknown agent-command ingest-spool argument: {other}"),
+        }
+        i += 1;
+    }
+    let path =
+        path.ok_or_else(|| anyhow::anyhow!("agent-command ingest-spool requires --path PATH"))?;
+    Ok(CliCommand::AgentCommand(AgentCommandCommand::IngestSpool(
+        AgentCommandIngestSpoolArgs { path, json },
+    )))
+}
+
+fn parse_agent_command_wrap(args: &[String]) -> Result<CliCommand> {
+    let mut spool = None;
+    let mut command_start = None;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--spool" => {
+                i += 1;
+                spool = Some(required_value(args, i, "--spool")?);
+            }
+            "--" => {
+                command_start = Some(i + 1);
+                break;
+            }
+            other => bail!("unknown agent-command wrap argument: {other}"),
+        }
+        i += 1;
+    }
+    let spool = spool.ok_or_else(|| anyhow::anyhow!("agent-command wrap requires --spool PATH"))?;
+    let start =
+        command_start.ok_or_else(|| anyhow::anyhow!("agent-command wrap requires -- COMMAND"))?;
+    let command = args[start..].to_vec();
+    if command.is_empty() {
+        bail!("agent-command wrap requires COMMAND after --");
+    }
+    Ok(CliCommand::AgentCommand(AgentCommandCommand::Wrap(
+        AgentCommandWrapArgs { spool, command },
+    )))
+}
+
+fn required_value(args: &[String], index: usize, flag: &str) -> Result<String> {
+    let value = args
+        .get(index)
+        .ok_or_else(|| anyhow::anyhow!("{flag} requires a value"))?;
+    if value.starts_with('-') {
+        bail!("{flag} requires a value");
+    }
+    Ok(value.clone())
+}
+
+#[cfg(test)]
+#[path = "parse_command_log_tests.rs"]
+mod tests;

--- a/src/cli/parse_command_log_tests.rs
+++ b/src/cli/parse_command_log_tests.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+#[test]
+fn parses_shell_index() {
+    let args = vec![
+        "index".to_string(),
+        "--path".to_string(),
+        "/tmp/.zsh_history".to_string(),
+        "--json".to_string(),
+    ];
+
+    let command = parse_shell(&args).unwrap();
+
+    match command {
+        CliCommand::Shell(ShellCommand::Index(args)) => {
+            assert_eq!(args.path, "/tmp/.zsh_history");
+            assert_eq!(args.shell, "zsh");
+            assert!(args.json);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn parses_agent_command_ingest_spool() {
+    let args = vec![
+        "ingest-spool".to_string(),
+        "--path".to_string(),
+        "/tmp/commands.jsonl".to_string(),
+    ];
+
+    let command = parse_agent_command(&args).unwrap();
+
+    match command {
+        CliCommand::AgentCommand(AgentCommandCommand::IngestSpool(args)) => {
+            assert_eq!(args.path, "/tmp/commands.jsonl");
+            assert!(!args.json);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn parses_agent_command_wrap_after_separator() {
+    let args = vec![
+        "wrap".to_string(),
+        "--spool".to_string(),
+        "/tmp/commands.jsonl".to_string(),
+        "--".to_string(),
+        "echo".to_string(),
+        "hello".to_string(),
+    ];
+
+    let command = parse_agent_command(&args).unwrap();
+
+    match command {
+        CliCommand::AgentCommand(AgentCommandCommand::Wrap(args)) => {
+            assert_eq!(args.spool, "/tmp/commands.jsonl");
+            assert_eq!(args.command, vec!["echo", "hello"]);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, bail, Result};
 use syslog_mcp::app::SyslogService;
 
-use super::args::{AiCommand, CliCommand, DbCommand, NotifyCommand, SigCommand};
+use super::args::{
+    AgentCommandCommand, AiCommand, CliCommand, DbCommand, NotifyCommand, ShellCommand, SigCommand,
+};
 use super::dispatch;
 
 /// Env var that opts a process into HTTP transport without passing `--http`.
@@ -82,6 +84,19 @@ pub(crate) async fn run(mode: CliMode, command: CliCommand) -> Result<()> {
             AiCommand::Incidents(args) => dispatch::run_ai_incidents(&mode, args).await,
             AiCommand::Investigate(args) => dispatch::run_ai_investigate(&mode, args).await,
             AiCommand::Assess(args) => dispatch::run_ai_assess(&mode, args).await,
+        },
+        CliCommand::Shell(shell) => match shell {
+            ShellCommand::Index(args) => {
+                super::dispatch_command_log::run_shell_index(&mode, args).await
+            }
+        },
+        CliCommand::AgentCommand(command) => match command {
+            AgentCommandCommand::IngestSpool(args) => {
+                super::dispatch_command_log::run_agent_command_ingest_spool(&mode, args).await
+            }
+            AgentCommandCommand::Wrap(_) => {
+                bail!("internal: agent-command wrap must be dispatched before CliMode creation")
+            }
         },
         // DB commands (bead 0p8r.9). 4 are HTTP-capable; backup stays LOCAL
         // and bails in HTTP mode with an inline message.

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -165,7 +165,7 @@ impl GlobalFlags {
     /// Unknown args are left in place untouched so the existing per-subcommand
     /// parsers see exactly what they used to. We deliberately allow both
     /// `syslog --http search foo` and `syslog search --http foo` — the
-    /// stripper walks the whole vec, not just a prefix.
+    /// stripper walks the command args until a `--` wrapped-command sentinel.
     ///
     /// `--server` / `--token` without a following value error out; an empty
     /// value (e.g. `--token=`) is also an error so a stray trailing `=` does
@@ -174,6 +174,9 @@ impl GlobalFlags {
         let mut out = GlobalFlags::default();
         let mut i = 0;
         while i < args.len() {
+            if args[i] == "--" {
+                break;
+            }
             // Two flag families: bare "--http", and value-bearing
             // "--server"/"--token" which accept "--flag VALUE" or "--flag=VALUE".
             let arg = args[i].as_str();

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -1,0 +1,707 @@
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::LazyLock;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::db::{self, LogBatchEntry};
+use crate::enrich::{stamp_source_kind, SourceKind};
+use crate::ingest_metadata::bounded_metadata_json;
+use crate::syslog::enrichment::scrub_ai_message;
+
+static COMMAND_SECRET_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    [
+        r#"(?i)\bAuthorization:\s*Bearer\s+['"]?[^'"\s]+"#,
+        r#"(?i)(?:^|\s)(?:--?(?:api[-_]?key|token|secret|password|passwd|client[-_]?secret))=("[^"]*"|'[^']*'|[^\s]+)"#,
+        r#"(?i)(?:^|\s)(?:--?(?:api[-_]?key|token|secret|password|passwd|client[-_]?secret))\s+("[^"]*"|'[^']*'|[^\s]+)"#,
+        r#"(?i)\b(?:[A-Z_][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PWD|AUTH)[A-Z0-9_]*)=("[^"]*"|'[^']*'|[^\s]+)"#,
+        r#"(?i)\bcurl\s+-u\s+("[^"]*"|'[^']*'|[^\s]+)"#,
+        r#"(?i)\bhttps?://[^/\s:@]+:[^/\s@]+@"#,
+        r#"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"#,
+    ]
+    .iter()
+    .map(|pattern| Regex::new(pattern).expect("static command secret regex"))
+    .collect()
+});
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommandLogImportResult {
+    pub scanned: usize,
+    pub imported: usize,
+    pub skipped: usize,
+    pub skipped_duplicates: usize,
+    pub errors: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ZshHistoryRecord {
+    pub started_at: DateTime<Utc>,
+    pub duration_secs: u64,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentCommandSpoolRecord {
+    pub started_at: String,
+    pub finished_at: String,
+    pub duration_ms: u64,
+    pub exit_status: Option<i32>,
+    pub command: String,
+    pub cwd: Option<String>,
+    pub agent: String,
+    pub command_surface: Option<String>,
+    pub hostname: String,
+    pub user: Option<String>,
+    pub pid: u32,
+    pub session_id: Option<String>,
+    #[serde(default = "schema_version_one")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub content_scrubbed: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct ShellHistoryImportState {
+    path: String,
+    shell: String,
+    offset: u64,
+    #[serde(default)]
+    line_no: usize,
+}
+
+pub fn import_zsh_history(
+    pool: &db::DbPool,
+    path: &Path,
+    shell: &str,
+) -> Result<CommandLogImportResult> {
+    let state_path = shell_history_state_path(path, shell)?;
+    import_zsh_history_with_state(pool, path, shell, &state_path)
+}
+
+fn import_zsh_history_with_state(
+    pool: &db::DbPool,
+    path: &Path,
+    shell: &str,
+    state_path: &Path,
+) -> Result<CommandLogImportResult> {
+    let mut file =
+        fs::File::open(path).with_context(|| format!("open shell history {}", path.display()))?;
+    let file_len = file
+        .metadata()
+        .with_context(|| format!("stat shell history {}", path.display()))?
+        .len();
+    let mut state = read_shell_history_state(state_path, path, shell)?.unwrap_or_default();
+    if state.offset > file_len {
+        state.offset = 0;
+        state.line_no = 0;
+    }
+    file.seek(SeekFrom::Start(state.offset))
+        .with_context(|| format!("seek shell history {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let hostname = hostname();
+    let user = username();
+    let mut result = CommandLogImportResult::default();
+    let mut batch = Vec::new();
+    let mut line = String::new();
+    let mut line_no = state.line_no;
+
+    loop {
+        line.clear();
+        let bytes = reader
+            .read_line(&mut line)
+            .with_context(|| format!("read shell history {}", path.display()))?;
+        if bytes == 0 {
+            break;
+        }
+        result.scanned += 1;
+        line_no += 1;
+        let line = line.trim_end_matches(['\r', '\n']);
+        let Some(record) = parse_zsh_extended_history_line(line) else {
+            result.skipped += 1;
+            continue;
+        };
+        let entry = zsh_record_to_entry(&record, path, line_no, shell, &hostname, user.as_deref());
+        if entry_exists(pool, &entry)? {
+            result.skipped_duplicates += 1;
+        } else {
+            batch.push(entry);
+        }
+    }
+
+    let next_offset = reader
+        .stream_position()
+        .with_context(|| format!("tell shell history {}", path.display()))?;
+    if !batch.is_empty() {
+        result.imported = db::insert_logs_batch(pool, &batch)?;
+    }
+    write_shell_history_state(state_path, path, shell, next_offset, line_no)?;
+    Ok(result)
+}
+
+pub fn import_agent_command_spool(
+    pool: &db::DbPool,
+    path: &Path,
+) -> Result<CommandLogImportResult> {
+    validate_spool_path_for_read(path)?;
+    let mut file = open_spool_for_update(path)?;
+    lock_file_exclusive(&file, path)?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("seek agent command spool {}", path.display()))?;
+    let reader = BufReader::new(&mut file);
+    let mut result = CommandLogImportResult::default();
+    let mut batch = Vec::new();
+
+    for line in reader.lines() {
+        result.scanned += 1;
+        let line = match line {
+            Ok(line) => line,
+            Err(_) => {
+                result.errors += 1;
+                continue;
+            }
+        };
+        if line.trim().is_empty() {
+            result.skipped += 1;
+            continue;
+        }
+        match serde_json::from_str::<AgentCommandSpoolRecord>(&line) {
+            Ok(record) => {
+                let entry = agent_record_to_entry(&record);
+                if entry_exists(pool, &entry)? {
+                    result.skipped_duplicates += 1;
+                } else {
+                    batch.push(entry);
+                }
+            }
+            Err(_) => result.errors += 1,
+        }
+    }
+
+    if !batch.is_empty() {
+        result.imported = db::insert_logs_batch(pool, &batch)?;
+    }
+    file.set_len(0)
+        .with_context(|| format!("truncate agent command spool {}", path.display()))?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("rewind agent command spool {}", path.display()))?;
+    Ok(result)
+}
+
+pub fn run_agent_command_wrapper(spool_path: &Path, command_args: &[String]) -> Result<i32> {
+    anyhow::ensure!(
+        !command_args.is_empty(),
+        "agent-command wrap requires COMMAND after --"
+    );
+    ensure_private_parent(spool_path)?;
+
+    let command = command_args_to_shell_command(command_args);
+    if std::env::var("SYSLOG_AGENT_COMMAND_WRAPPER")
+        .ok()
+        .as_deref()
+        == Some("1")
+        || command.contains("agent-command ingest-spool")
+    {
+        return run_command_unwrapped(&command);
+    }
+    let cwd = std::env::current_dir()
+        .ok()
+        .map(|path| path.display().to_string());
+    let started = Utc::now();
+    let timer = Instant::now();
+    let status = command_status(&command).context("run wrapped command")?;
+    let finished = Utc::now();
+    let duration_ms = timer.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    let record = AgentCommandSpoolRecord {
+        started_at: rfc3339(started),
+        finished_at: rfc3339(finished),
+        duration_ms,
+        exit_status: status.code(),
+        command: scrub_command(&command),
+        cwd,
+        agent: std::env::var("SYSLOG_AGENT_COMMAND_AGENT")
+            .unwrap_or_else(|_| "claude-code".to_string()),
+        command_surface: std::env::var("SYSLOG_AGENT_COMMAND_SURFACE").ok(),
+        hostname: hostname(),
+        user: username(),
+        pid: std::process::id(),
+        session_id: std::env::var("CLAUDE_CODE_SESSION_ID")
+            .ok()
+            .or_else(|| std::env::var("CLAUDE_SESSION_ID").ok())
+            .or_else(|| std::env::var("SYSLOG_AGENT_COMMAND_SESSION").ok()),
+        schema_version: 1,
+        content_scrubbed: true,
+    };
+    append_spool_record(spool_path, &record)?;
+    Ok(status.code().unwrap_or(1))
+}
+
+pub fn scrub_command(command: &str) -> String {
+    let mut out = scrub_ai_message(command, None);
+    for pattern in COMMAND_SECRET_PATTERNS.iter() {
+        out = pattern.replace_all(&out, "[REDACTED]").into_owned();
+    }
+    out
+}
+
+fn run_command_unwrapped(command: &str) -> Result<i32> {
+    Ok(command_status(command)?.code().unwrap_or(1))
+}
+
+fn command_args_to_shell_command(command_args: &[String]) -> String {
+    if command_args.len() == 1 {
+        command_args[0].clone()
+    } else {
+        command_args
+            .iter()
+            .map(|arg| shell_quote(arg))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+    if value.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric()
+            || matches!(byte, b'_' | b'-' | b'.' | b'/' | b':' | b'=' | b',' | b'+')
+    }) {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn command_status(command: &str) -> Result<std::process::ExitStatus> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    Command::new(shell)
+        .arg("-lc")
+        .arg(command)
+        .env("SYSLOG_AGENT_COMMAND_WRAPPER", "1")
+        .env_remove("CLAUDE_CODE_SHELL_PREFIX")
+        .status()
+        .context("run command")
+}
+
+pub fn parse_zsh_extended_history_line(line: &str) -> Option<ZshHistoryRecord> {
+    let rest = line.strip_prefix(": ")?;
+    let (epoch, rest) = rest.split_once(':')?;
+    let (duration, command) = rest.split_once(';')?;
+    let epoch = epoch.trim().parse::<i64>().ok()?;
+    let duration_secs = duration.trim().parse::<u64>().ok()?;
+    let started_at = Utc.timestamp_opt(epoch, 0).single()?;
+    Some(ZshHistoryRecord {
+        started_at,
+        duration_secs,
+        command: command.to_string(),
+    })
+}
+
+fn zsh_record_to_entry(
+    record: &ZshHistoryRecord,
+    path: &Path,
+    line_no: usize,
+    shell: &str,
+    hostname: &str,
+    user: Option<&str>,
+) -> LogBatchEntry {
+    let command = scrub_command(&record.command);
+    let metadata_json = bounded_metadata_json(serde_json::json!({
+        "source_type": "shell_history",
+        "source_kind": SourceKind::ShellHistory.as_str(),
+        "shell": {
+            "name": shell,
+            "user": user,
+            "history_path": path.display().to_string(),
+            "line_no": line_no,
+            "duration_secs": record.duration_secs,
+            "timestamp_quality": "zsh_extended_history"
+        },
+        "content_scrubbed": true,
+    }));
+    let mut entry = LogBatchEntry {
+        timestamp: rfc3339(record.started_at),
+        hostname: hostname.to_string(),
+        facility: Some("shell".to_string()),
+        severity: "info".to_string(),
+        app_name: Some(shell.to_string()),
+        process_id: None,
+        message: command.clone(),
+        raw: command,
+        source_ip: format!(
+            "shell-history://{}/{}/{}",
+            sanitize_uri_segment(hostname),
+            sanitize_uri_segment(user.unwrap_or("unknown")),
+            sanitize_uri_segment(shell)
+        ),
+        docker_checkpoint: None,
+        ai_tool: None,
+        ai_project: None,
+        ai_session_id: None,
+        ai_transcript_path: None,
+        metadata_json: Some(metadata_json),
+        http_status: None,
+        auth_outcome: None,
+        dns_blocked: None,
+        event_action: None,
+        parse_error: None,
+    };
+    stamp_source_kind(&mut entry, SourceKind::ShellHistory);
+    entry
+}
+
+fn agent_record_to_entry(record: &AgentCommandSpoolRecord) -> LogBatchEntry {
+    let command = scrub_command(&record.command);
+    let exit_status = record.exit_status;
+    let severity = match exit_status {
+        Some(0) => "info",
+        Some(_) => "warning",
+        None => "err",
+    };
+    let metadata_json = bounded_metadata_json(serde_json::json!({
+        "source_type": "agent_command",
+        "source_kind": SourceKind::AgentCommand.as_str(),
+        "agent_command": {
+            "schema_version": record.schema_version,
+            "agent": record.agent,
+            "command_surface": record.command_surface,
+            "cwd": record.cwd,
+            "user": record.user,
+            "pid": record.pid,
+            "exit_status": exit_status,
+            "duration_ms": record.duration_ms,
+            "finished_at": record.finished_at,
+            "session_id": record.session_id
+        },
+        "content_scrubbed": true,
+    }));
+    let mut entry = LogBatchEntry {
+        timestamp: normalize_or_now(&record.started_at),
+        hostname: record.hostname.clone(),
+        facility: Some("agent".to_string()),
+        severity: severity.to_string(),
+        app_name: Some(record.agent.clone()),
+        process_id: Some(record.pid.to_string()),
+        message: command.clone(),
+        raw: command,
+        source_ip: format!(
+            "agent-command://{}/{}/{}",
+            sanitize_uri_segment(&record.hostname),
+            sanitize_uri_segment(&record.agent),
+            sanitize_uri_segment(record.session_id.as_deref().unwrap_or("unknown"))
+        ),
+        docker_checkpoint: None,
+        ai_tool: Some(record.agent.clone()),
+        ai_project: record.cwd.clone(),
+        ai_session_id: record.session_id.clone(),
+        ai_transcript_path: None,
+        metadata_json: Some(metadata_json),
+        http_status: None,
+        auth_outcome: None,
+        dns_blocked: None,
+        event_action: Some("command".to_string()),
+        parse_error: None,
+    };
+    stamp_source_kind(&mut entry, SourceKind::AgentCommand);
+    entry
+}
+
+fn append_spool_record(path: &Path, record: &AgentCommandSpoolRecord) -> Result<()> {
+    validate_spool_path_for_write(path)?;
+    let mut file = open_spool_for_append(path)?;
+    lock_file_exclusive(&file, path)?;
+    serde_json::to_writer(&mut file, record)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn open_spool_for_update(path: &Path) -> Result<fs::File> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    options
+        .open(path)
+        .with_context(|| format!("open agent command spool {}", path.display()))
+}
+
+fn open_spool_for_append(path: &Path) -> Result<fs::File> {
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = options
+        .open(path)
+        .with_context(|| format!("open agent command spool {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("chmod agent command spool {}", path.display()))?;
+    }
+    Ok(file)
+}
+
+fn lock_file_exclusive(file: &fs::File, path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsRawFd;
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        anyhow::ensure!(
+            rc == 0,
+            "lock file {}: {}",
+            path.display(),
+            std::io::Error::last_os_error()
+        );
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (file, path);
+    }
+    Ok(())
+}
+
+fn shell_history_state_path(path: &Path, shell: &str) -> Result<PathBuf> {
+    let state_dir = command_log_state_dir(path)?;
+    let identity = format!("{}\0{}", shell, path.display());
+    Ok(state_dir.join(format!(
+        "shell-history-{:016x}.json",
+        stable_hash(&identity)
+    )))
+}
+
+fn command_log_state_dir(path: &Path) -> Result<PathBuf> {
+    if let Some(value) = std::env::var_os("SYSLOG_COMMAND_LOG_STATE_DIR") {
+        let state_dir = PathBuf::from(value);
+        ensure_private_parent(&state_dir.join(".keep"))?;
+        return Ok(state_dir);
+    }
+    if let Some(value) = std::env::var_os("XDG_STATE_HOME") {
+        let state_dir = PathBuf::from(value).join("syslog-mcp");
+        ensure_private_parent(&state_dir.join(".keep"))?;
+        return Ok(state_dir);
+    }
+    if let Some(value) = std::env::var_os("HOME") {
+        let state_dir = PathBuf::from(value).join(".local/state/syslog-mcp");
+        ensure_private_parent(&state_dir.join(".keep"))?;
+        return Ok(state_dir);
+    }
+    let fallback = path
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".syslog-mcp-state");
+    ensure_private_parent(&fallback.join(".keep"))?;
+    Ok(fallback)
+}
+
+fn read_shell_history_state(
+    state_path: &Path,
+    history_path: &Path,
+    shell: &str,
+) -> Result<Option<ShellHistoryImportState>> {
+    let raw = match fs::read_to_string(state_path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("read shell history state {}", state_path.display()))
+        }
+    };
+    let state: ShellHistoryImportState = serde_json::from_str(&raw)
+        .with_context(|| format!("parse shell history state {}", state_path.display()))?;
+    if state.path == history_path.display().to_string() && state.shell == shell {
+        Ok(Some(state))
+    } else {
+        Ok(None)
+    }
+}
+
+fn write_shell_history_state(
+    state_path: &Path,
+    history_path: &Path,
+    shell: &str,
+    offset: u64,
+    line_no: usize,
+) -> Result<()> {
+    if let Some(parent) = state_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create shell history state dir {}", parent.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(parent, fs::Permissions::from_mode(0o700))
+                .with_context(|| format!("chmod shell history state dir {}", parent.display()))?;
+        }
+    }
+    let state = ShellHistoryImportState {
+        path: history_path.display().to_string(),
+        shell: shell.to_string(),
+        offset,
+        line_no,
+    };
+    let mut options = OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(state_path)
+        .with_context(|| format!("open shell history state {}", state_path.display()))?;
+    serde_json::to_writer(&mut file, &state)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn stable_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in value.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn entry_exists(pool: &db::DbPool, entry: &LogBatchEntry) -> Result<bool> {
+    let conn = pool.get()?;
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM logs WHERE source_ip = ?1 AND timestamp = ?2 AND message = ?3",
+        (&entry.source_ip, &entry.timestamp, &entry.message),
+        |row| row.get(0),
+    )?;
+    Ok(count > 0)
+}
+
+fn ensure_private_parent(path: &Path) -> Result<()> {
+    let parent = path
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."));
+    fs::create_dir_all(&parent)
+        .with_context(|| format!("create spool parent {}", parent.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("chmod spool parent {}", parent.display()))?;
+    }
+    Ok(())
+}
+
+fn validate_spool_path_for_write(path: &Path) -> Result<()> {
+    reject_symlink(path)?;
+    if let Some(parent) = path.parent() {
+        reject_unsafe_parent(parent)?;
+    }
+    Ok(())
+}
+
+fn validate_spool_path_for_read(path: &Path) -> Result<()> {
+    reject_symlink(path)?;
+    if let Some(parent) = path.parent() {
+        reject_unsafe_parent(parent)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let mode = fs::metadata(path)
+            .with_context(|| format!("stat spool {}", path.display()))?
+            .mode()
+            & 0o777;
+        anyhow::ensure!(
+            mode & 0o077 == 0,
+            "agent command spool must not be readable or writable by group/other: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn reject_symlink(path: &Path) -> Result<()> {
+    if let Ok(metadata) = fs::symlink_metadata(path) {
+        anyhow::ensure!(
+            !metadata.file_type().is_symlink(),
+            "agent command spool must not be a symlink: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn reject_unsafe_parent(parent: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if parent.exists() {
+            let mode = fs::metadata(parent)
+                .with_context(|| format!("stat spool parent {}", parent.display()))?
+                .mode()
+                & 0o777;
+            anyhow::ensure!(
+                mode & 0o022 == 0,
+                "agent command spool parent must not be group/world writable: {}",
+                parent.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn schema_version_one() -> u32 {
+    1
+}
+
+fn normalize_or_now(value: &str) -> String {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| rfc3339(dt.with_timezone(&Utc)))
+        .unwrap_or_else(|_| rfc3339(Utc::now()))
+}
+
+fn rfc3339(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn hostname() -> String {
+    std::env::var("HOSTNAME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "localhost".to_string())
+}
+
+fn username() -> Option<String> {
+    std::env::var("USER")
+        .ok()
+        .or_else(|| std::env::var("LOGNAME").ok())
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn sanitize_uri_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "command_log_tests.rs"]
+mod tests;

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -1,7 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitStatus};
 use std::sync::LazyLock;
 use std::time::Instant;
 
@@ -201,20 +201,15 @@ pub fn run_agent_command_wrapper(spool_path: &Path, command_args: &[String]) -> 
     ensure_private_parent(spool_path)?;
 
     let command = command_args_to_shell_command(command_args);
-    if std::env::var("SYSLOG_AGENT_COMMAND_WRAPPER")
-        .ok()
-        .as_deref()
-        == Some("1")
-        || command.contains("agent-command ingest-spool")
-    {
-        return run_command_unwrapped(&command);
+    if should_run_agent_command_unwrapped(command_args) {
+        return run_command_unwrapped(command_args, &command);
     }
     let cwd = std::env::current_dir()
         .ok()
         .map(|path| path.display().to_string());
     let started = Utc::now();
     let timer = Instant::now();
-    let status = command_status(&command).context("run wrapped command")?;
+    let status = command_status(command_args, &command).context("run wrapped command")?;
     let finished = Utc::now();
     let duration_ms = timer.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
     let record = AgentCommandSpoolRecord {
@@ -237,7 +232,9 @@ pub fn run_agent_command_wrapper(spool_path: &Path, command_args: &[String]) -> 
         schema_version: 1,
         content_scrubbed: true,
     };
-    append_spool_record(spool_path, &record)?;
+    if let Err(error) = append_spool_record(spool_path, &record) {
+        eprintln!("syslog agent-command: failed to append command record: {error:#}");
+    }
     Ok(status.code().unwrap_or(1))
 }
 
@@ -249,8 +246,10 @@ pub fn scrub_command(command: &str) -> String {
     out
 }
 
-fn run_command_unwrapped(command: &str) -> Result<i32> {
-    Ok(command_status(command)?.code().unwrap_or(1))
+fn run_command_unwrapped(command_args: &[String], fallback_shell_command: &str) -> Result<i32> {
+    Ok(command_status(command_args, fallback_shell_command)?
+        .code()
+        .unwrap_or(1))
 }
 
 fn command_args_to_shell_command(command_args: &[String]) -> String {
@@ -263,6 +262,27 @@ fn command_args_to_shell_command(command_args: &[String]) -> String {
             .collect::<Vec<_>>()
             .join(" ")
     }
+}
+
+fn should_run_agent_command_unwrapped(command_args: &[String]) -> bool {
+    std::env::var("SYSLOG_AGENT_COMMAND_WRAPPER")
+        .ok()
+        .as_deref()
+        == Some("1")
+        || is_agent_command_ingest_spool_invocation(command_args)
+}
+
+fn is_agent_command_ingest_spool_invocation(command_args: &[String]) -> bool {
+    let Some(program) = command_args.first() else {
+        return false;
+    };
+    let program_name = Path::new(program)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(program);
+    program_name == "syslog"
+        && command_args.get(1).map(String::as_str) == Some("agent-command")
+        && command_args.get(2).map(String::as_str) == Some("ingest-spool")
 }
 
 fn shell_quote(value: &str) -> String {
@@ -278,7 +298,22 @@ fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
-fn command_status(command: &str) -> Result<std::process::ExitStatus> {
+fn command_status(command_args: &[String], fallback_shell_command: &str) -> Result<ExitStatus> {
+    if command_args.len() == 1 {
+        return shell_command_status(fallback_shell_command);
+    }
+    let (program, args) = command_args
+        .split_first()
+        .expect("wrapper validates command args are not empty");
+    Command::new(program)
+        .args(args)
+        .env("SYSLOG_AGENT_COMMAND_WRAPPER", "1")
+        .env_remove("CLAUDE_CODE_SHELL_PREFIX")
+        .status()
+        .with_context(|| format!("run command {}", shell_quote(program)))
+}
+
+fn shell_command_status(command: &str) -> Result<ExitStatus> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
     Command::new(shell)
         .arg("-lc")
@@ -591,13 +626,16 @@ fn ensure_private_parent(path: &Path) -> Result<()> {
         .parent()
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));
+    let parent_existed = parent.exists();
     fs::create_dir_all(&parent)
         .with_context(|| format!("create spool parent {}", parent.display()))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&parent, fs::Permissions::from_mode(0o700))
-            .with_context(|| format!("chmod spool parent {}", parent.display()))?;
+        if !parent_existed {
+            fs::set_permissions(&parent, fs::Permissions::from_mode(0o700))
+                .with_context(|| format!("chmod spool parent {}", parent.display()))?;
+        }
     }
     Ok(())
 }
@@ -690,16 +728,15 @@ fn username() -> Option<String> {
 }
 
 fn sanitize_uri_segment(value: &str) -> String {
-    value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
-                ch
-            } else {
-                '-'
-            }
-        })
-        .collect()
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(*byte, b'-' | b'_' | b'.' | b'~') {
+            encoded.push(char::from(*byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
 }
 
 #[cfg(test)]

--- a/src/command_log_tests.rs
+++ b/src/command_log_tests.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use crate::config::StorageConfig;
 use crate::db::{init_pool, search_logs, SearchParams};
+use serial_test::serial;
 
 use super::*;
 
@@ -45,6 +46,85 @@ fn command_args_to_shell_command_quotes_multi_arg_invocations() {
     assert_eq!(
         command_args_to_shell_command(&["printf wrappedok >/dev/null".to_string()]),
         "printf wrappedok >/dev/null"
+    );
+}
+
+#[test]
+fn agent_command_ingest_spool_guard_is_argv_scoped() {
+    assert!(is_agent_command_ingest_spool_invocation(&[
+        "/usr/local/bin/syslog".to_string(),
+        "agent-command".to_string(),
+        "ingest-spool".to_string(),
+        "--path".to_string(),
+        "/tmp/spool.jsonl".to_string(),
+    ]));
+    assert!(!is_agent_command_ingest_spool_invocation(&[
+        "echo".to_string(),
+        "agent-command ingest-spool".to_string(),
+    ]));
+    assert!(!is_agent_command_ingest_spool_invocation(&[
+        "syslog".to_string(),
+        "agent-command ingest-spool".to_string(),
+    ]));
+}
+
+#[test]
+fn sanitize_uri_segment_percent_encodes_losslessly() {
+    assert_eq!(sanitize_uri_segment("a/b"), "a%2Fb");
+    assert_eq!(sanitize_uri_segment("a b"), "a%20b");
+    assert_eq!(sanitize_uri_segment("a-b"), "a-b");
+    assert_eq!(sanitize_uri_segment("lambda-λ"), "lambda-%CE%BB");
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn wrapper_executes_multi_arg_commands_without_shell_reparse() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let fake_shell = dir.path().join("fake-shell");
+    let arg_out = dir.path().join("args.txt");
+    let spool_dir = dir.path().join("state");
+    std::fs::create_dir(&spool_dir).unwrap();
+    std::fs::set_permissions(&spool_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let spool = spool_dir.join("agent-command.jsonl");
+    std::fs::write(
+        &fake_shell,
+        "#!/bin/sh\nprintf shell-used >\"$SYSLOG_TEST_ARG_OUT\"\nexit 97\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&fake_shell, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let previous_shell = std::env::var_os("SHELL");
+    let previous_out = std::env::var_os("SYSLOG_TEST_ARG_OUT");
+    std::env::set_var("SHELL", &fake_shell);
+    std::env::set_var("SYSLOG_TEST_ARG_OUT", &arg_out);
+
+    let exit_code = run_agent_command_wrapper(
+        &spool,
+        &[
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "printf '%s\\n%s\\n%s\\n' \"$#\" \"$1\" \"$2\" >\"$SYSLOG_TEST_ARG_OUT\"".to_string(),
+            "sh".to_string(),
+            "two words".to_string(),
+            "literal;not-shell".to_string(),
+        ],
+    )
+    .unwrap();
+
+    match previous_shell {
+        Some(value) => std::env::set_var("SHELL", value),
+        None => std::env::remove_var("SHELL"),
+    }
+    match previous_out {
+        Some(value) => std::env::set_var("SYSLOG_TEST_ARG_OUT", value),
+        None => std::env::remove_var("SYSLOG_TEST_ARG_OUT"),
+    }
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        std::fs::read_to_string(arg_out).unwrap(),
+        "2\ntwo words\nliteral;not-shell\n"
     );
 }
 
@@ -197,4 +277,44 @@ fn imports_agent_spool_as_agent_command_rows() {
     let second = import_agent_command_spool(&pool, &spool).unwrap();
     assert_eq!(second.scanned, 0);
     assert_eq!(second.imported, 0);
+}
+
+#[test]
+fn wrapper_preserves_command_exit_when_spool_append_fails() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let exit_code =
+        run_agent_command_wrapper(dir.path(), &["true".to_string()]).expect("wrapper runs command");
+
+    assert_eq!(exit_code, 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn existing_spool_parent_permissions_are_not_mutated() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().join("existing-parent");
+    std::fs::create_dir(&parent).unwrap();
+    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    ensure_private_parent(&parent.join("agent-command.jsonl")).unwrap();
+
+    let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o755);
+}
+
+#[cfg(unix)]
+#[test]
+fn newly_created_spool_parent_is_private() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let parent = dir.path().join("new-parent");
+
+    ensure_private_parent(&parent.join("agent-command.jsonl")).unwrap();
+
+    let mode = std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o700);
 }

--- a/src/command_log_tests.rs
+++ b/src/command_log_tests.rs
@@ -1,0 +1,200 @@
+use std::io::Write;
+
+use crate::config::StorageConfig;
+use crate::db::{init_pool, search_logs, SearchParams};
+
+use super::*;
+
+#[test]
+fn parses_zsh_extended_history_line() {
+    let parsed = parse_zsh_extended_history_line(": 1716500000:3;cargo test").unwrap();
+
+    assert_eq!(parsed.duration_secs, 3);
+    assert_eq!(parsed.command, "cargo test");
+    assert_eq!(parsed.started_at.timestamp(), 1_716_500_000);
+}
+
+#[test]
+fn skips_plain_zsh_history_line_without_timestamp() {
+    assert!(parse_zsh_extended_history_line("cargo test").is_none());
+}
+
+#[test]
+fn command_scrubber_redacts_shell_specific_secret_forms() {
+    let command = "env OPENAI_API_KEY=sk-proj-123 gh auth token --token abc curl -u user:pass https://user:pass@example.test";
+    let scrubbed = scrub_command(command);
+
+    assert!(!scrubbed.contains("sk-proj-123"));
+    assert!(!scrubbed.contains("abc"));
+    assert!(!scrubbed.contains("user:pass"));
+    assert!(scrubbed.contains("[REDACTED]"));
+}
+
+#[test]
+fn command_args_to_shell_command_quotes_multi_arg_invocations() {
+    let args = vec![
+        "sh".to_string(),
+        "-lc".to_string(),
+        "printf wrappedok >/dev/null".to_string(),
+    ];
+
+    assert_eq!(
+        command_args_to_shell_command(&args),
+        "sh -lc 'printf wrappedok >/dev/null'"
+    );
+    assert_eq!(
+        command_args_to_shell_command(&["printf wrappedok >/dev/null".to_string()]),
+        "printf wrappedok >/dev/null"
+    );
+}
+
+#[test]
+fn imports_zsh_history_as_shell_history_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("syslog.db");
+    let pool = init_pool(&StorageConfig::for_test(db_path)).unwrap();
+    let history = dir.path().join(".zsh_history");
+    std::fs::write(
+        &history,
+        ": 1716500000:3;export API_KEY=abc123\nplain command\n",
+    )
+    .unwrap();
+
+    let result = import_zsh_history(&pool, &history, "zsh").unwrap();
+
+    assert_eq!(result.scanned, 2);
+    assert_eq!(result.imported, 1);
+    assert_eq!(result.skipped, 1);
+    let rows = search_logs(
+        &pool,
+        &SearchParams {
+            query: Some("export".into()),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].facility.as_deref(), Some("shell"));
+    assert_eq!(rows[0].app_name.as_deref(), Some("zsh"));
+    assert!(rows[0]
+        .metadata_json
+        .as_deref()
+        .unwrap()
+        .contains("shell-history"));
+    assert!(rows[0]
+        .metadata_json
+        .as_deref()
+        .unwrap()
+        .contains("\"shell\""));
+    assert!(rows[0].message.contains("[REDACTED]"));
+}
+
+#[test]
+fn imports_zsh_history_from_saved_offset() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("syslog.db");
+    let pool = init_pool(&StorageConfig::for_test(db_path)).unwrap();
+    let history = dir.path().join(".zsh_history");
+    let state = dir.path().join("shell-state.json");
+    std::fs::write(&history, ": 1716500000:3;cargo test\n").unwrap();
+
+    let first = import_zsh_history_with_state(&pool, &history, "zsh", &state).unwrap();
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&history)
+        .unwrap()
+        .write_all(b": 1716500010:1;cargo fmt\n")
+        .unwrap();
+    let second = import_zsh_history_with_state(&pool, &history, "zsh", &state).unwrap();
+    let third = import_zsh_history_with_state(&pool, &history, "zsh", &state).unwrap();
+
+    assert_eq!(first.scanned, 1);
+    assert_eq!(first.imported, 1);
+    assert_eq!(second.scanned, 1);
+    assert_eq!(second.imported, 1);
+    assert_eq!(third.scanned, 0);
+    assert_eq!(third.imported, 0);
+    let rows = search_logs(
+        &pool,
+        &SearchParams {
+            query: Some("cargo".into()),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 2);
+}
+
+#[test]
+fn imports_agent_spool_as_agent_command_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("syslog.db");
+    let pool = init_pool(&StorageConfig::for_test(db_path)).unwrap();
+    let spool_dir = dir.path().join("private-state");
+    std::fs::create_dir(&spool_dir).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&spool_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+    }
+    let spool = spool_dir.join("claude-commands.jsonl");
+    let auth_header = format!("{} {}", "Authorization:", "Bearer test-token");
+    let record = AgentCommandSpoolRecord {
+        started_at: "2026-05-24T05:00:00.000Z".into(),
+        finished_at: "2026-05-24T05:00:01.000Z".into(),
+        duration_ms: 1000,
+        exit_status: Some(2),
+        command: format!("curl -H '{auth_header}' http://example.test"),
+        cwd: Some("/tmp/project".into()),
+        agent: "claude-code".into(),
+        command_surface: Some("bash_tool".into()),
+        hostname: "dookie".into(),
+        user: Some("jmagar".into()),
+        pid: 42,
+        session_id: Some("session-1".into()),
+        schema_version: 1,
+        content_scrubbed: false,
+    };
+    let mut file = std::fs::File::create(&spool).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&spool, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+    serde_json::to_writer(&mut file, &record).unwrap();
+    writeln!(file).unwrap();
+
+    let result = import_agent_command_spool(&pool, &spool).unwrap();
+
+    assert_eq!(result.imported, 1);
+    let rows = search_logs(
+        &pool,
+        &SearchParams {
+            query: Some("curl".into()),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].facility.as_deref(), Some("agent"));
+    assert_eq!(rows[0].severity, "warning");
+    assert_eq!(rows[0].ai_tool.as_deref(), Some("claude-code"));
+    assert!(rows[0].message.contains("[REDACTED]"));
+    assert!(rows[0]
+        .metadata_json
+        .as_deref()
+        .unwrap()
+        .contains("agent-command"));
+    assert!(rows[0]
+        .metadata_json
+        .as_deref()
+        .unwrap()
+        .contains("agent_command"));
+    assert_eq!(std::fs::read_to_string(&spool).unwrap(), "");
+    let second = import_agent_command_spool(&pool, &spool).unwrap();
+    assert_eq!(second.scanned, 0);
+    assert_eq!(second.imported, 0);
+}

--- a/src/enrich/dispatch.rs
+++ b/src/enrich/dispatch.rs
@@ -174,6 +174,8 @@ fn to_source_kind(raw: Option<&str>) -> SourceKind {
         Some("adguard-api") => SourceKind::AdguardApi,
         Some("unifi-api") => SourceKind::UnifiApi,
         Some("agent") => SourceKind::Agent,
+        Some("shell-history") => SourceKind::ShellHistory,
+        Some("agent-command") => SourceKind::AgentCommand,
         _ => SourceKind::SyslogTcp,
     }
 }

--- a/src/enrich/parser.rs
+++ b/src/enrich/parser.rs
@@ -25,6 +25,8 @@ use thiserror::Error;
 /// - `AdguardApi` → `"adguard-api"`
 /// - `UnifiApi` → `"unifi-api"`
 /// - `Agent` → `"agent"` (per-host agent WebSocket)
+/// - `ShellHistory` → `"shell-history"` (local shell history backfill)
+/// - `AgentCommand` → `"agent-command"` (AI agent-launched shell command spool)
 ///
 /// **History:** prior versions of this contract used `snake_case` with a
 /// bare `Syslog` variant. Both were corrected during the cross-cutting audit
@@ -41,6 +43,8 @@ pub enum SourceKind {
     AdguardApi,
     UnifiApi,
     Agent,
+    ShellHistory,
+    AgentCommand,
 }
 
 impl SourceKind {
@@ -57,6 +61,8 @@ impl SourceKind {
             SourceKind::AdguardApi => "adguard-api",
             SourceKind::UnifiApi => "unifi-api",
             SourceKind::Agent => "agent",
+            SourceKind::ShellHistory => "shell-history",
+            SourceKind::AgentCommand => "agent-command",
         }
     }
 

--- a/src/enrich/parser_tests.rs
+++ b/src/enrich/parser_tests.rs
@@ -7,6 +7,8 @@ fn source_kind_as_str_matches_serde() {
     assert_eq!(SourceKind::DockerEvent.as_str(), "docker-event");
     assert_eq!(SourceKind::AdguardApi.as_str(), "adguard-api");
     assert_eq!(SourceKind::UnifiApi.as_str(), "unifi-api");
+    assert_eq!(SourceKind::ShellHistory.as_str(), "shell-history");
+    assert_eq!(SourceKind::AgentCommand.as_str(), "agent-command");
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ai_watch;
 pub mod api;
 pub mod app;
 pub(crate) mod assessment;
+pub mod command_log;
 pub mod compose;
 pub mod config;
 pub mod deploy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,21 @@ async fn run_cli(invocation: CliInvocation) -> Result<()> {
         std::process::exit(code);
     }
 
+    if matches!(
+        command,
+        cli::CliCommand::Shell(_)
+            | cli::CliCommand::AgentCommand(cli::AgentCommandCommand::IngestSpool(_))
+    ) {
+        if let Some(trigger) = flags.http_flag_trigger() {
+            anyhow::bail!(
+                "{} has no effect on local command ingestion; remove --http / --server / --token",
+                trigger
+            );
+        }
+        let runtime = RuntimeCore::load_query_only().await?;
+        return cli::run(cli::CliMode::Local(runtime.service()), command).await;
+    }
+
     // Build CliMode ONCE per invocation, matching the per-invocation reqwest
     // Client rule from bead .5. For Local mode we lazily load the runtime so
     // HTTP-mode invocations don't pay the SQLite-open cost.

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,17 @@ async fn run_cli(invocation: CliInvocation) -> Result<()> {
         return cli::run_config(command);
     }
 
+    if let cli::CliCommand::AgentCommand(cli::AgentCommandCommand::Wrap(args)) = command {
+        if let Some(trigger) = flags.http_flag_trigger() {
+            anyhow::bail!(
+                "{} has no effect on `agent-command wrap` (wrapper command); remove --http / --server / --token",
+                trigger
+            );
+        }
+        let code = cli::run_agent_command_wrap(args)?;
+        std::process::exit(code);
+    }
+
     // Build CliMode ONCE per invocation, matching the per-invocation reqwest
     // Client rule from bead .5. For Local mode we lazily load the runtime so
     // HTTP-mode invocations don't pay the SQLite-open cost.
@@ -165,6 +176,9 @@ async fn run_setup(command: SetupCommand) -> Result<()> {
         }
         SetupCommandKind::AiWatchService(action) => {
             syslog_mcp::setup::run_ai_watch_service_setup(action).await?
+        }
+        SetupCommandKind::AgentCommand(action) => {
+            syslog_mcp::setup::run_agent_command_setup(action).await?
         }
         SetupCommandKind::DebugWrapper(action) => {
             syslog_mcp::setup::run_debug_wrapper_setup(action).await?
@@ -353,6 +367,7 @@ enum SetupCommandKind {
     Main(syslog_mcp::setup::SetupMode),
     AiIndexTimer(syslog_mcp::setup::AiIndexTimerAction),
     AiWatchService(syslog_mcp::setup::AiWatchServiceAction),
+    AgentCommand(syslog_mcp::setup::AgentCommandAction),
     DebugWrapper(syslog_mcp::setup::DebugWrapperAction),
     DebugCompose(syslog_mcp::setup::DebugComposeAction),
     Doctor,
@@ -428,6 +443,8 @@ impl Mode {
                         | "sessions"
                         | "incident"
                         | "ai"
+                        | "shell"
+                        | "agent-command"
                         | "correlate"
                         | "stats"
                         | "db"
@@ -463,7 +480,7 @@ impl Mode {
                 // ignored for `serve mcp`, `setup`, etc.
                 anyhow::bail!(
                     "--http / --server / --token only apply to CLI query commands \
-                     (search, tail, errors, hosts, sessions, ai, correlate, stats, incident, db); \
+                     (search, tail, errors, hosts, sessions, ai, shell, agent-command, correlate, stats, incident, db); \
                      compose, service, setup, and deploy are local-only and reject HTTP flags; \
                      got: {}",
                     args.join(" ")
@@ -538,6 +555,21 @@ fn parse_setup_command(args: &[String]) -> Result<SetupCommand> {
                 "install" => syslog_mcp::setup::AiWatchServiceAction::Install,
                 "remove" => syslog_mcp::setup::AiWatchServiceAction::Remove,
                 _ => syslog_mcp::setup::AiWatchServiceAction::Check,
+            }),
+            json,
+        });
+    }
+    if matches!(
+        iter.clone().next().map(String::as_str),
+        Some("agent-command")
+    ) {
+        let _ = iter.next();
+        let (action, json) = parse_setup_subcommand_args("agent-command", iter)?;
+        return Ok(SetupCommand {
+            kind: SetupCommandKind::AgentCommand(match action {
+                "install" => syslog_mcp::setup::AgentCommandAction::Install,
+                "remove" => syslog_mcp::setup::AgentCommandAction::Remove,
+                _ => syslog_mcp::setup::AgentCommandAction::Check,
             }),
             json,
         });
@@ -683,6 +715,7 @@ fn print_usage() {
   syslog setup [check|repair] [--json]
   syslog setup ai-index-timer install|remove|check [--json]
   syslog setup ai-watch-service install|remove|check [--json]
+  syslog setup agent-command install|remove|check [--json]
   syslog setup debug-wrapper install|remove|check [--json]
   syslog setup debug-compose install|remove|check [--json]
   syslog setup doctor [--json]
@@ -718,6 +751,9 @@ fn print_usage() {
   syslog ai doctor [--strict-permissions] [--json]
   syslog ai watch-status [--json]
   syslog ai smoke-watch [--json]
+  syslog shell index --path PATH [--shell zsh] [--json]
+  syslog agent-command ingest-spool --path PATH [--json]
+  syslog agent-command wrap --spool PATH -- COMMAND...
   syslog db status [--check-coord] [--json]
   syslog db integrity [--quick] [--json]
   syslog db checkpoint [--mode passive|full|restart|truncate] [--json]
@@ -730,6 +766,7 @@ fn print_usage() {
   syslog compose logs [--tail N] [--json]
   syslog service logs SERVICE [--from TIME] [--to TIME] [--tail N] [--json]
   syslog setup check|repair [--json]
+  syslog setup agent-command install|remove|check [--json]
   syslog setup plugin-hook [--no-repair] [--json]
   syslog deploy preflight [--json]
   syslog deploy local [--dry-run] [--json]

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -102,6 +102,58 @@ fn mode_parse_accepts_ai_watch_service_setup_namespace() {
 }
 
 #[test]
+fn mode_parse_accepts_agent_command_setup_namespace() {
+    assert!(matches!(
+        Mode::parse(vec![
+            "setup".into(),
+            "agent-command".into(),
+            "install".into(),
+            "--json".into()
+        ])
+        .unwrap(),
+        Mode::Setup(_)
+    ));
+}
+
+#[test]
+fn mode_parse_accepts_command_ingest_namespace() {
+    assert!(matches!(
+        Mode::parse(vec![
+            "shell".into(),
+            "index".into(),
+            "--path".into(),
+            "/tmp/history".into(),
+            "--json".into()
+        ])
+        .unwrap(),
+        Mode::Cli(_)
+    ));
+    assert!(matches!(
+        Mode::parse(vec![
+            "agent-command".into(),
+            "ingest-spool".into(),
+            "--path".into(),
+            "/tmp/spool.jsonl".into(),
+            "--json".into()
+        ])
+        .unwrap(),
+        Mode::Cli(_)
+    ));
+    assert!(matches!(
+        Mode::parse(vec![
+            "agent-command".into(),
+            "wrap".into(),
+            "--spool".into(),
+            "/tmp/spool.jsonl".into(),
+            "--".into(),
+            "true".into()
+        ])
+        .unwrap(),
+        Mode::Cli(_)
+    ));
+}
+
+#[test]
 fn mode_parse_accepts_debug_wrapper_setup_namespace() {
     assert!(matches!(
         Mode::parse(vec![

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -1,4 +1,4 @@
-use super::Mode;
+use super::{cli, Mode};
 
 #[test]
 fn mode_parse_accepts_single_binary_transport_commands() {
@@ -151,6 +151,42 @@ fn mode_parse_accepts_command_ingest_namespace() {
         .unwrap(),
         Mode::Cli(_)
     ));
+}
+
+#[test]
+fn mode_parse_preserves_wrapped_command_http_like_flags() {
+    let mode = Mode::parse(vec![
+        "agent-command".into(),
+        "wrap".into(),
+        "--spool".into(),
+        "/tmp/spool.jsonl".into(),
+        "--".into(),
+        "curl".into(),
+        "--http".into(),
+        "--server".into(),
+        "https://example.test".into(),
+        "--token=literal".into(),
+    ])
+    .unwrap();
+
+    let Mode::Cli(invocation) = mode else {
+        panic!("expected CLI mode");
+    };
+    assert_eq!(invocation.flags, cli::GlobalFlags::default());
+    let cli::CliCommand::AgentCommand(cli::AgentCommandCommand::Wrap(args)) = invocation.command
+    else {
+        panic!("expected agent-command wrap");
+    };
+    assert_eq!(
+        args.command,
+        vec![
+            "curl".to_string(),
+            "--http".to_string(),
+            "--server".to_string(),
+            "https://example.test".to_string(),
+            "--token=literal".to_string(),
+        ]
+    );
 }
 
 #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 const COMPOSE_ASSET: &str = include_str!("../docker-compose.prod.yml");
 const DOCKERFILE_ASSET: &str = include_str!("../config/Dockerfile");
 
+mod agent_command;
 mod ai_index;
 mod ai_watch;
 mod debug_wrapper;
@@ -16,6 +17,7 @@ mod doctor;
 mod firstrun;
 mod systemd;
 
+pub use agent_command::run_agent_command_setup;
 pub use ai_index::run_ai_index_timer_setup;
 pub use ai_watch::run_ai_watch_service_setup;
 pub use debug_wrapper::{run_debug_compose_setup, run_debug_wrapper_setup};
@@ -70,6 +72,13 @@ pub enum AiWatchServiceAction {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentCommandAction {
+    Install,
+    Remove,
+    Check,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DebugWrapperAction {
     Install,
     Remove,
@@ -109,6 +118,16 @@ impl AiWatchServiceAction {
             Self::Install => "ai-watch-service-install",
             Self::Remove => "ai-watch-service-remove",
             Self::Check => "ai-watch-service-check",
+        }
+    }
+}
+
+impl AgentCommandAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Install => "agent-command-install",
+            Self::Remove => "agent-command-remove",
+            Self::Check => "agent-command-check",
         }
     }
 }

--- a/src/setup/agent_command.rs
+++ b/src/setup/agent_command.rs
@@ -83,13 +83,39 @@ fn install_agent_command_files(
         wrapper_path,
         &agent_command_wrapper_script(syslog_bin, spool_path),
     )?;
-    if !spool_path.exists() {
-        write_private_file(spool_path, "")?;
-    }
+    ensure_agent_command_spool_file(spool_path)?;
     Ok(timer.finish(
         SetupStatus::Ok,
         format!("wrote {}, {}", wrapper_path.display(), spool_path.display()),
     ))
+}
+
+fn ensure_agent_command_spool_file(spool_path: &Path) -> io::Result<()> {
+    match std::fs::symlink_metadata(spool_path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("{} must not be a symlink", spool_path.display()),
+                ));
+            }
+            if !file_type.is_file() {
+                return Err(io::Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("{} must be a regular file", spool_path.display()),
+                ));
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(spool_path, std::fs::Permissions::from_mode(0o600))?;
+            }
+            Ok(())
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => write_private_file(spool_path, ""),
+        Err(error) => Err(error),
+    }
 }
 
 fn remove_agent_command_wrapper(wrapper_path: &Path) -> io::Result<SetupPhase> {
@@ -132,35 +158,51 @@ fn agent_command_content_phase(
 
 fn agent_command_state_phase(state_dir: &Path, spool_path: &Path) -> SetupPhase {
     let timer = PhaseTimer::start("agent-command-state");
-    if !state_dir.is_dir() {
+    let state_metadata = match std::fs::symlink_metadata(state_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return timer.finish(
+                SetupStatus::Warn,
+                format!(
+                    "missing {}; run syslog setup agent-command install",
+                    state_dir.display()
+                ),
+            );
+        }
+        Err(error) => return timer.finish(SetupStatus::Error, error.to_string()),
+    };
+    let state_type = state_metadata.file_type();
+    if state_type.is_symlink() || !state_type.is_dir() {
         return timer.finish(
-            SetupStatus::Warn,
-            format!(
-                "missing {}; run syslog setup agent-command install",
-                state_dir.display()
-            ),
+            SetupStatus::Error,
+            format!("{} must be a real directory", state_dir.display()),
         );
     }
-    if !spool_path.exists() {
+    let spool_metadata = match std::fs::symlink_metadata(spool_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return timer.finish(
+                SetupStatus::Warn,
+                format!(
+                    "missing {}; run syslog setup agent-command install",
+                    spool_path.display()
+                ),
+            );
+        }
+        Err(error) => return timer.finish(SetupStatus::Error, error.to_string()),
+    };
+    let spool_type = spool_metadata.file_type();
+    if spool_type.is_symlink() || !spool_type.is_file() {
         return timer.finish(
-            SetupStatus::Warn,
-            format!(
-                "missing {}; run syslog setup agent-command install",
-                spool_path.display()
-            ),
+            SetupStatus::Error,
+            format!("{} must be a regular file", spool_path.display()),
         );
     }
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let state_mode = match std::fs::metadata(state_dir) {
-            Ok(metadata) => metadata.permissions().mode() & 0o777,
-            Err(error) => return timer.finish(SetupStatus::Error, error.to_string()),
-        };
-        let spool_mode = match std::fs::metadata(spool_path) {
-            Ok(metadata) => metadata.permissions().mode() & 0o777,
-            Err(error) => return timer.finish(SetupStatus::Error, error.to_string()),
-        };
+        let state_mode = state_metadata.permissions().mode() & 0o777;
+        let spool_mode = spool_metadata.permissions().mode() & 0o777;
         if state_mode & 0o077 != 0 || spool_mode & 0o077 != 0 {
             return timer.finish(
                 SetupStatus::Error,
@@ -237,14 +279,15 @@ fn validate_agent_command_binary(path: &Path) -> io::Result<()> {
         ));
     }
     let version_output = String::from_utf8_lossy(&output.stdout);
-    let expected = env!("CARGO_PKG_VERSION");
-    if !version_output.contains(expected) {
+    let expected = format!("syslog-mcp {}", env!("CARGO_PKG_VERSION"));
+    let actual = version_output.trim();
+    if actual != expected {
         return Err(io::Error::new(
             ErrorKind::InvalidInput,
             format!(
                 "{} is not the current syslog binary: expected version {expected}, got {}",
                 path.display(),
-                version_output.trim()
+                actual
             ),
         ));
     }
@@ -272,26 +315,5 @@ fn claude_settings_shell_prefix(user_home: &Path) -> io::Result<Option<String>> 
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn agent_command_env_phase_accepts_claude_settings_json() {
-        let home = tempfile::tempdir().unwrap();
-        let claude_dir = home.path().join(".claude");
-        std::fs::create_dir(&claude_dir).unwrap();
-        let wrapper = home.path().join(".local/bin/syslog-agent-command-wrapper");
-        std::fs::write(
-            claude_dir.join("settings.json"),
-            format!(
-                r#"{{"env":{{"CLAUDE_CODE_SHELL_PREFIX":"{}"}}}}"#,
-                wrapper.display()
-            ),
-        )
-        .unwrap();
-
-        let phase = agent_command_env_phase(&wrapper, home.path());
-
-        assert_eq!(phase.status, SetupStatus::Ok);
-    }
-}
+#[path = "agent_command_tests.rs"]
+mod tests;

--- a/src/setup/agent_command.rs
+++ b/src/setup/agent_command.rs
@@ -1,0 +1,297 @@
+use std::io::{self, ErrorKind};
+use std::path::Path;
+use std::process::Command;
+use std::time::Instant;
+
+use super::firstrun::ensure_private_dir;
+use super::{
+    check_file_phase, host_local_report_input, setup_path_value, setup_report,
+    write_executable_file, write_private_file, AgentCommandAction, PhaseTimer, SetupPhase,
+    SetupReport, SetupStatus,
+};
+
+pub async fn run_agent_command_setup(action: AgentCommandAction) -> io::Result<SetupReport> {
+    let started = Instant::now();
+    let home = super::syslog_home_dir()?;
+    let env_path = home.join(".env");
+    let compose_dir = home.join("compose");
+    let data_dir = home.join("data");
+    let user_home = super::user_home_dir()?;
+    let state_dir = user_home.join(".local/state/syslog-mcp");
+    let spool_path = state_dir.join("agent-command.jsonl");
+    let wrapper_path = user_home.join(".local/bin/syslog-agent-command-wrapper");
+    let mut phases = Vec::new();
+
+    match action {
+        AgentCommandAction::Install => {
+            let syslog_bin = resolve_agent_command_syslog_binary()?;
+            phases.push(install_agent_command_files(
+                &wrapper_path,
+                &spool_path,
+                &state_dir,
+                &syslog_bin,
+            )?);
+            phases.push(agent_command_env_phase(&wrapper_path, &user_home));
+        }
+        AgentCommandAction::Remove => {
+            phases.push(remove_agent_command_wrapper(&wrapper_path)?);
+            phases.push(agent_command_env_phase(&wrapper_path, &user_home));
+        }
+        AgentCommandAction::Check => {
+            let syslog_bin = resolve_agent_command_syslog_binary()?;
+            phases.push(check_file_phase(
+                "agent-command-wrapper",
+                &wrapper_path,
+                "run syslog setup agent-command install",
+            ));
+            phases.push(agent_command_content_phase(
+                &wrapper_path,
+                &spool_path,
+                &syslog_bin,
+            ));
+            phases.push(agent_command_state_phase(&state_dir, &spool_path));
+            phases.push(agent_command_env_phase(&wrapper_path, &user_home));
+        }
+    }
+
+    let elapsed_ms = started.elapsed().as_millis();
+    Ok(setup_report(
+        host_local_report_input(
+            action.as_str(),
+            elapsed_ms,
+            home,
+            env_path,
+            compose_dir,
+            data_dir,
+        ),
+        phases,
+    ))
+}
+
+fn install_agent_command_files(
+    wrapper_path: &Path,
+    spool_path: &Path,
+    state_dir: &Path,
+    syslog_bin: &Path,
+) -> io::Result<SetupPhase> {
+    let timer = PhaseTimer::start("agent-command-files");
+    ensure_private_dir(state_dir)?;
+    if let Some(parent) = wrapper_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    write_executable_file(
+        wrapper_path,
+        &agent_command_wrapper_script(syslog_bin, spool_path),
+    )?;
+    if !spool_path.exists() {
+        write_private_file(spool_path, "")?;
+    }
+    Ok(timer.finish(
+        SetupStatus::Ok,
+        format!("wrote {}, {}", wrapper_path.display(), spool_path.display()),
+    ))
+}
+
+fn remove_agent_command_wrapper(wrapper_path: &Path) -> io::Result<SetupPhase> {
+    let timer = PhaseTimer::start("agent-command-wrapper");
+    match std::fs::remove_file(wrapper_path) {
+        Ok(()) => Ok(timer.finish(
+            SetupStatus::Ok,
+            format!("removed {}", wrapper_path.display()),
+        )),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(timer.finish(
+            SetupStatus::Ok,
+            format!("{} already absent", wrapper_path.display()),
+        )),
+        Err(error) => Err(error),
+    }
+}
+
+fn agent_command_content_phase(
+    wrapper_path: &Path,
+    spool_path: &Path,
+    syslog_bin: &Path,
+) -> SetupPhase {
+    let timer = PhaseTimer::start("agent-command-content");
+    let expected = agent_command_wrapper_script(syslog_bin, spool_path);
+    match std::fs::read_to_string(wrapper_path) {
+        Ok(current) if current == expected => timer.finish(
+            SetupStatus::Ok,
+            "agent command wrapper matches generated content",
+        ),
+        Ok(_) => timer.finish(
+            SetupStatus::Error,
+            format!(
+                "{} does not match generated agent command wrapper",
+                wrapper_path.display()
+            ),
+        ),
+        Err(error) => timer.finish(SetupStatus::Error, error.to_string()),
+    }
+}
+
+fn agent_command_state_phase(state_dir: &Path, spool_path: &Path) -> SetupPhase {
+    let timer = PhaseTimer::start("agent-command-state");
+    if !state_dir.is_dir() {
+        return timer.finish(
+            SetupStatus::Warn,
+            format!(
+                "missing {}; run syslog setup agent-command install",
+                state_dir.display()
+            ),
+        );
+    }
+    if !spool_path.exists() {
+        return timer.finish(
+            SetupStatus::Warn,
+            format!(
+                "missing {}; run syslog setup agent-command install",
+                spool_path.display()
+            ),
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let state_mode = match std::fs::metadata(state_dir) {
+            Ok(metadata) => metadata.permissions().mode() & 0o777,
+            Err(error) => return timer.finish(SetupStatus::Error, error.to_string()),
+        };
+        let spool_mode = match std::fs::metadata(spool_path) {
+            Ok(metadata) => metadata.permissions().mode() & 0o777,
+            Err(error) => return timer.finish(SetupStatus::Error, error.to_string()),
+        };
+        if state_mode & 0o077 != 0 || spool_mode & 0o077 != 0 {
+            return timer.finish(
+                SetupStatus::Error,
+                format!(
+                    "unsafe permissions state={state_mode:o} spool={spool_mode:o}; run syslog setup agent-command install"
+                ),
+            );
+        }
+    }
+    timer.finish(
+        SetupStatus::Ok,
+        format!("state ready at {}", spool_path.display()),
+    )
+}
+
+fn agent_command_env_phase(wrapper_path: &Path, user_home: &Path) -> SetupPhase {
+    let timer = PhaseTimer::start("agent-command-env");
+    let expected = wrapper_path.display().to_string();
+    if std::env::var("CLAUDE_CODE_SHELL_PREFIX").ok().as_deref() == Some(expected.as_str()) {
+        return timer.finish(
+            SetupStatus::Ok,
+            "CLAUDE_CODE_SHELL_PREFIX matches the generated wrapper",
+        );
+    }
+    match claude_settings_shell_prefix(user_home) {
+        Ok(Some(value)) if value == expected => timer.finish(
+            SetupStatus::Ok,
+            format!(
+                "{} configures CLAUDE_CODE_SHELL_PREFIX",
+                user_home.join(".claude/settings.json").display()
+            ),
+        ),
+        Ok(Some(value)) => timer.finish(
+            SetupStatus::Warn,
+            format!(
+                "CLAUDE_CODE_SHELL_PREFIX points to {}; expected {}",
+                value,
+                wrapper_path.display()
+            ),
+        ),
+        Ok(None) => timer.finish(
+            SetupStatus::Warn,
+            format!(
+                "set CLAUDE_CODE_SHELL_PREFIX={} in Claude Code's environment or ~/.claude/settings.json",
+                wrapper_path.display()
+            ),
+        ),
+        Err(error) => timer.finish(SetupStatus::Warn, error.to_string()),
+    }
+}
+
+fn agent_command_wrapper_script(syslog_bin: &Path, spool_path: &Path) -> String {
+    let syslog_bin = setup_path_value(syslog_bin).expect("validated syslog binary path");
+    let spool_path = setup_path_value(spool_path).expect("validated agent command spool path");
+    format!(
+        r#"#!/usr/bin/env sh
+exec {syslog_bin} agent-command wrap --spool {spool_path} -- "$@"
+"#
+    )
+}
+
+fn resolve_agent_command_syslog_binary() -> io::Result<std::path::PathBuf> {
+    let path = super::resolve_syslog_binary()?;
+    validate_agent_command_binary(&path)?;
+    Ok(path)
+}
+
+fn validate_agent_command_binary(path: &Path) -> io::Result<()> {
+    let output = Command::new(path).arg("--version").output()?;
+    if !output.status.success() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("{} --version failed", path.display()),
+        ));
+    }
+    let version_output = String::from_utf8_lossy(&output.stdout);
+    let expected = env!("CARGO_PKG_VERSION");
+    if !version_output.contains(expected) {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "{} is not the current syslog binary: expected version {expected}, got {}",
+                path.display(),
+                version_output.trim()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn claude_settings_shell_prefix(user_home: &Path) -> io::Result<Option<String>> {
+    let path = user_home.join(".claude/settings.json");
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let value: serde_json::Value = serde_json::from_str(&raw).map_err(|error| {
+        io::Error::new(
+            ErrorKind::InvalidData,
+            format!("parse {}: {error}", path.display()),
+        )
+    })?;
+    Ok(value
+        .get("env")
+        .and_then(|env| env.get("CLAUDE_CODE_SHELL_PREFIX"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_command_env_phase_accepts_claude_settings_json() {
+        let home = tempfile::tempdir().unwrap();
+        let claude_dir = home.path().join(".claude");
+        std::fs::create_dir(&claude_dir).unwrap();
+        let wrapper = home.path().join(".local/bin/syslog-agent-command-wrapper");
+        std::fs::write(
+            claude_dir.join("settings.json"),
+            format!(
+                r#"{{"env":{{"CLAUDE_CODE_SHELL_PREFIX":"{}"}}}}"#,
+                wrapper.display()
+            ),
+        )
+        .unwrap();
+
+        let phase = agent_command_env_phase(&wrapper, home.path());
+
+        assert_eq!(phase.status, SetupStatus::Ok);
+    }
+}

--- a/src/setup/agent_command_tests.rs
+++ b/src/setup/agent_command_tests.rs
@@ -1,0 +1,83 @@
+use super::*;
+
+#[cfg(unix)]
+#[test]
+fn install_agent_command_files_hardens_existing_spool_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = dir.path().join("state");
+    std::fs::create_dir(&state_dir).unwrap();
+    let spool = state_dir.join("agent-command.jsonl");
+    std::fs::write(&spool, "keep\n").unwrap();
+    std::fs::set_permissions(&spool, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let wrapper = dir.path().join("bin/wrapper");
+
+    let phase = install_agent_command_files(&wrapper, &spool, &state_dir, Path::new("/bin/sh"))
+        .expect("install files");
+
+    assert_eq!(phase.status, SetupStatus::Ok);
+    assert_eq!(std::fs::read_to_string(&spool).unwrap(), "keep\n");
+    let mode = std::fs::metadata(&spool).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o600);
+}
+
+#[cfg(unix)]
+#[test]
+fn agent_command_state_phase_rejects_spool_symlink() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = dir.path().join("state");
+    std::fs::create_dir(&state_dir).unwrap();
+    std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let target = dir.path().join("target.jsonl");
+    std::fs::write(&target, "").unwrap();
+    let spool = state_dir.join("agent-command.jsonl");
+    std::os::unix::fs::symlink(&target, &spool).unwrap();
+
+    let phase = agent_command_state_phase(&state_dir, &spool);
+
+    assert_eq!(phase.status, SetupStatus::Error);
+    assert!(phase.detail.contains("regular file"));
+}
+
+#[test]
+fn agent_command_state_phase_rejects_spool_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let state_dir = dir.path().join("state");
+    std::fs::create_dir(&state_dir).unwrap();
+    let spool = state_dir.join("agent-command.jsonl");
+    std::fs::create_dir(&spool).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        std::fs::set_permissions(&spool, std::fs::Permissions::from_mode(0o600)).unwrap();
+    }
+
+    let phase = agent_command_state_phase(&state_dir, &spool);
+
+    assert_eq!(phase.status, SetupStatus::Error);
+    assert!(phase.detail.contains("regular file"));
+}
+
+#[test]
+fn agent_command_env_phase_accepts_claude_settings_json() {
+    let home = tempfile::tempdir().unwrap();
+    let claude_dir = home.path().join(".claude");
+    std::fs::create_dir(&claude_dir).unwrap();
+    let wrapper = home.path().join(".local/bin/syslog-agent-command-wrapper");
+    std::fs::write(
+        claude_dir.join("settings.json"),
+        format!(
+            r#"{{"env":{{"CLAUDE_CODE_SHELL_PREFIX":"{}"}}}}"#,
+            wrapper.display()
+        ),
+    )
+    .unwrap();
+
+    let phase = agent_command_env_phase(&wrapper, home.path());
+
+    assert_eq!(phase.status, SetupStatus::Ok);
+}


### PR DESCRIPTION
## Summary
- Add shell-history and agent-command source kinds plus metadata/source URI contracts.
- Add zsh extended-history backfill and private JSONL agent command spool ingestion.
- Add Claude Code shell-prefix wrapper setup via `syslog setup agent-command install`.
- Bump version to 0.32.0 and document setup/security caveats.

## Verification
- `./scripts/check-version-sync.sh --require-changelog`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- pre-push hook `cargo test`

Beads: syslog-mcp-tncw

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ingestion of local zsh history and agent-launched commands into the main log corpus, plus a Claude Code shell-prefix wrapper and setup for safe, local-only capture. Improves correlation and search with structured metadata, precise source URIs, and strict permissions/scrubbing.

- New Features
  - New `source_kind` values `shell-history` and `agent-command` with structured metadata and `source_ip` URIs (`shell-history://<hostname>/<user>/<shell>`, `agent-command://<hostname>/<agent>/<session_id>`).
  - CLI: `syslog shell index` (zsh extended-history backfill with offset cursor and de-dupe) and `syslog agent-command ingest-spool|wrap` (local-only; HTTP flags rejected). `syslog setup agent-command install|remove|check` installs the wrapper and private spool. Version `0.32.2`.
  - Wrapper preserves stdio/exit, executes multi-arg commands without shell re-parse, records `facility=agent`, `event_action="command"`, `ai_tool`, `ai_session_id`, sets severity from exit, uses an exclusive lock and truncates after import. Commands are scrubbed and redacted (tokens, secret flags/assignments, Authorization headers, URL userinfo, `curl -u`, private keys).

- Bug Fixes
  - Setup hardens existing spool files, rejects symlink or non-file spools, and refuses group/world-writable parents without mutating existing parent perms.
  - Wrapper recursion guard is scoped to argv-level `syslog agent-command ingest-spool`; preserves wrapped args after `--`.
  - Percent-encode shell/agent command source URI path segments without lossy replacement, and preserve wrapped command exit status if spool append fails.

<sup>Written for commit 316974d5c46a41b5e7d83cde5341886126d2440e. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/50?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Index local zsh extended history into logs and ingest agent command spools; CLI/setup to install, ingest, wrap, and manage agent-command wrapper.

* **Bug Fixes**
  * Preserve wrapped command exit status on spool append failures; avoid changing existing parent-directory permissions during setup.

* **Documentation**
  * Extensive docs and README updates covering shell/agent-command flows, metadata, scrub/redaction behavior, CLI usage, and setup instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->