### PR TITLE
Add SafeSkill security badge (60/100 — Use with Caution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Syslog MCP
 
 [![crates.io](https://img.shields.io/crates/v/syslog-mcp)](https://crates.io/crates/syslog-mcp) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Fsyslog--mcp-blue?logo=docker)](https://github.com/jmagar/syslog-mcp/pkgs/container/syslog-mcp)
+[![SafeSkill 60/100](https://img.shields.io/badge/SafeSkill-60%2F100_Use%20with%20Caution-orange)](https://safeskill.dev/scan/jmagar-syslog-mcp)
 
 Rust syslog receiver and MCP server for homelab log intelligence. Ingests syslog over UDP and TCP, stores it in SQLite with FTS5 full-text indexing, and exposes action-based log search, inventory, correlation, status, and analysis tools through MCP, REST, and CLI adapters backed by the shared service layer.
 


### PR DESCRIPTION
## 🟠 SafeSkill Security Scan Results

| Metric | Value |
|:-------|:------|
| **Overall Score** | **60/100** (Use with Caution) |
| Code Score | 100/100 |
| Content Score | 57/100 |
| Findings | 21 findings detected (1 critical) |
| Taint Flows | 0 |
| Files Scanned | 0 |
| Scan Duration | 1.0s |

### Top Findings

- 🔴 **critical**: Tool/shell abuse instruction detected (tool-abuse-pattern): "run
curl" (`docs/plans/2026-05-12-compose-lifecycle-cli.md:455`)
- 🟠 **high**: Hidden/invisible text detected (html-comment) at byte offset 11526: "BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f" (`CLAUDE.md:239`)
- 🟠 **high**: Context boundary escape detected (fake-xml-boundary): "<message>" (`docs/api.md:21`)
- 🟠 **high**: Data exfiltration pattern detected (data-exfil-pattern): "Forward the `Authorization`, `X-Mcp-Token" (`docs/contracts/http-endpoints.md:234`)
- 🟠 **high**: Persona/safety hijack attempt detected (persona-hijack-pattern): "do not refuse" (`docs/plans/2026-05-12-compose-lifecycle-cli.md:167`)

[View full report on SafeSkill](https://safeskill.dev/scan/jmagar-syslog-mcp)

---

### About SafeSkill

[SafeSkill](https://safeskill.dev) is a **free, open-source** security scanner for AI tools, MCP servers, and Claude Code skills. We scan for code exploits, prompt injection, and data exfiltration risks.

**False positive?** We take accuracy seriously. If any finding above is incorrect, please [open an issue](https://github.com/OyadotAI/safeskill/issues/new?title=False+positive+in+jmagar%2Fsyslog-mcp&labels=false-positive) and we will fix it immediately.

- [GitHub](https://github.com/OyadotAI/safeskill) | [Website](https://safeskill.dev) | [Docs](https://safeskill.dev/docs)
- Built by [Oya.ai](https://oya.ai) -- AI Employees Builder


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a SafeSkill security badge to the README to show the current security score (60/100 — Use with Caution) and link to the full scan report. This makes the project's security posture visible at a glance.

<sup>Written for commit 53256b8a313378dba413fa16b0cdbe3b23db4ac9. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/53?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a SafeSkill warning badge to the README, displayed alongside existing project badges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->