### PR TITLE
feat: heartbeat v1 — host monitoring with linux probes and agent

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.32.6",
+  "version": "0.33.0",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-05-25
+
+### Added
+
+- Added heartbeat telemetry V1: SQLite heartbeat storage, `POST /v1/heartbeats`
+  ingest, the bounded `host_state` MCP action, and a Linux `syslog heartbeat
+  agent` collector with binary-owned setup.
+
 ## [0.32.6] - 2026-05-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.32.6"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.32.6"
+version = "0.33.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -16,6 +16,7 @@ that registry by `src/mcp/schemas.rs::tool_definitions()`.
 | `tail` | Get N most recent log entries, optionally filtered by host, source_ip, and/or application | no |
 | `errors` | Error/warning summary grouped by hostname and severity level with counts | no |
 | `hosts` | List all hosts with first/last seen timestamps and total log counts | no |
+| `host_state` | Latest bounded heartbeat state for one host | no |
 | `correlate` | Cross-host event correlation within a time window around a reference timestamp | no |
 | `stats` | Database statistics: total logs, hosts, time range, DB size, free disk, write-block status | no |
 | `status` | Lightweight runtime status: DB health, queue/backpressure state, listener/writer counters, OTLP counters | no |

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -19,7 +19,7 @@ Rust source wins.
 ## Current Actions
 
 syslog-mcp exposes one MCP tool named `syslog`. The required `action` argument
-selects one of these 40 actions:
+selects one of these 41 actions:
 
 | Action | Scope | Cost | Purpose |
 | --- | --- | --- | --- |
@@ -28,6 +28,7 @@ selects one of these 40 actions:
 | `tail` | `syslog:read` | cheap | Most recent log entries |
 | `errors` | `syslog:read` | cheap | Error/warning summary |
 | `hosts` | `syslog:read` | cheap | Known source hostnames |
+| `host_state` | `syslog:read` | moderate | Latest bounded heartbeat state for one host |
 | `correlate` | `syslog:read` | moderate | Time-window event correlation |
 | `stats` | `syslog:read` | expensive | DB statistics and runtime observability |
 | `status` | `syslog:read` | cheap | Lightweight health and runtime status |
@@ -110,7 +111,8 @@ handler and service layers.
 | Argument | Used by |
 | --- | --- |
 | `query` | `search`, `search_sessions`, `correlate`, `similar_incidents`, `ask_history` |
-| `hostname` | `search`, `filter`, `tail`, `correlate`, `ai_correlate`, `apps`, `sessions`, `timeline`, `patterns`, `context`, `similar_incidents`, `ask_history`, `incident_context` |
+| `hostname` | `search`, `filter`, `tail`, `correlate`, `host_state`, `ai_correlate`, `apps`, `sessions`, `timeline`, `patterns`, `context`, `similar_incidents`, `ask_history`, `incident_context` |
+| `host_id` | Authoritative heartbeat identity for `host_state` |
 | `source_ip` | `search`, `filter`, `tail`, `correlate`, `ai_correlate` |
 | `source_kind` | `filter` only; aliases Docker, command-history, shell-history, transcript, and AI-tool rows |
 | `project` | `filter`, `sessions`, `search_sessions`, `abuse`, `ai_correlate`, `usage_blocks`, `project_context`, `list_ai_tools` |

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -54,7 +54,7 @@ the repo-local debug binary at `target/debug/syslog`, so repo-local builds do
 not require an installed shell binary.
 
 Action registry covered by live/script references: `search`, `filter`, `tail`, `errors`,
-`hosts`, `sessions`, `search_sessions`, `abuse`, `abuse_incidents`, `abuse_investigate`, `ai_correlate`, `usage_blocks`, `project_context`,
+`hosts`, `host_state`, `sessions`, `search_sessions`, `abuse`, `abuse_incidents`, `abuse_investigate`, `ai_correlate`, `usage_blocks`, `project_context`,
 `list_ai_tools`, `list_ai_projects`, `correlate`, `stats`, `status`, `apps`,
 `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`,
 `silent_hosts`, `clock_skew`, `anomalies`, `compare`, `compose_status`,
@@ -74,6 +74,7 @@ mcporter call --config config/mcporter.json syslog.syslog action=status
 mcporter call --config config/mcporter.json syslog.syslog action=tail n=10
 mcporter call --config config/mcporter.json syslog.syslog action=search query=error limit=5
 mcporter call --config config/mcporter.json syslog.syslog action=hosts
+mcporter call --config config/mcporter.json syslog.syslog action=host_state host_id=host-id
 mcporter call --config config/mcporter.json syslog.syslog action=sessions
 mcporter call --config config/mcporter.json syslog.syslog action=abuse terms=ai-smoke-authentication limit=5
 mcporter call --config config/mcporter.json syslog.syslog action=ai_correlate project=/tmp/syslog-mcp-ai-smoke limit=2 events_per_anchor=3
@@ -125,7 +126,7 @@ curl -s -X POST http://localhost:3100/mcp \
 
 ## Testing checklist
 
-- [ ] **All actions return expected shape** -- syslog search, syslog tail, syslog errors, syslog hosts, syslog sessions, syslog correlate, syslog stats, syslog status, syslog help
+- [ ] **All actions return expected shape** -- syslog search, syslog tail, syslog errors, syslog hosts, syslog host_state, syslog sessions, syslog correlate, syslog stats, syslog status, syslog help
 - [ ] **AI session analytics return expected shape and seeded rows** -- syslog search_sessions, syslog abuse, syslog ai_correlate, syslog usage_blocks, syslog project_context, syslog list_ai_tools, syslog list_ai_projects
 - [ ] **Auth: valid token** -- 200 with correct Bearer token
 - [ ] **Auth: invalid token** -- 401 Unauthorized

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -12,6 +12,7 @@ syslog-mcp exposes one MCP tool named `syslog`. The required
 | `tail` | Recent log entries |
 | `errors` | Error/warning summary by host and severity |
 | `hosts` | Host registry with first/last seen |
+| `host_state` | Latest bounded heartbeat state for one host |
 | `sessions` | AI transcript sessions by project |
 | `search_sessions` | Ranked grouped session search |
 | `abuse` | Abuse hits in AI transcripts with same-session context |
@@ -87,6 +88,14 @@ Optional arguments: `from`, `to`, `group_by`.
 List all hosts that have sent syslog messages.
 
 Required argument: `action = "hosts"`
+
+## syslog host_state
+
+Return latest bounded heartbeat state for one host.
+
+Required argument: `action = "host_state"` plus either `host_id` or uniquely resolving `hostname`.
+
+Optional arguments: `since`, `limit` (default 1, max 100).
 
 ## syslog sessions
 

--- a/docs/superpowers/plans/2026-05-25-heartbeat-v1-implementation.md
+++ b/docs/superpowers/plans/2026-05-25-heartbeat-v1-implementation.md
@@ -1,0 +1,148 @@
+# Heartbeat V1 Implementation Plan
+
+Tracker epic: `syslog-mcp-h2kq`
+
+Primary contract: `docs/contracts/heartbeat-telemetry.md`
+
+Primary design: `docs/superpowers/specs/2026-05-24-heartbeat-telemetry-design.md`
+
+## Scope
+
+V1 implements the minimum useful host-state data plane:
+
+1. Structured SQLite storage for heartbeat snapshots and metric child tables.
+2. `POST /v1/heartbeats` on the existing HTTP listener.
+3. `syslog` MCP action `host_state`.
+4. `syslog heartbeat agent` as a Linux collector.
+5. Binary-owned setup for a separate heartbeat-agent user service.
+
+V1 does not implement the older WebSocket agent mode or probe-registry control plane. Those designs remain inputs for later phases after the heartbeat data plane runs in production.
+
+## Schema
+
+The implementation increments the source migration from `KNOWN_SCHEMA_VERSION = 14` to `15`.
+
+Migration 15 adds:
+
+- `host_heartbeats`
+- `heartbeat_cpu`
+- `heartbeat_memory`
+- `heartbeat_disks`
+- `heartbeat_network`
+- `heartbeat_processes`
+- `heartbeat_containers`
+- `heartbeat_gpu`
+
+`host_heartbeats` owns the unique retry key:
+
+```sql
+UNIQUE(host_id, boot_id, sequence)
+```
+
+The schema treats `host_id` as authoritative. `hostname` remains self-reported display/filter metadata and cannot identify a host unless it maps to exactly one `host_id`.
+
+Retention and storage recovery explicitly delete heartbeat child rows because the repo does not rely on global SQLite foreign-key enforcement for cleanup safety.
+
+## HTTP Ingest
+
+`POST /v1/heartbeats` is mounted as a sibling route on the HTTP server, separate from MCP and OTLP routing.
+
+Route requirements:
+
+- Bearer token uses the existing `SYSLOG_MCP_TOKEN` posture.
+- Query-parameter tokens are rejected.
+- Request body limit is route-local `256 KiB`.
+- Unknown fields and malformed JSON return `invalid_payload`.
+- Source IP is captured from the HTTP peer connection.
+- Duplicate `(host_id, boot_id, sequence)` retries return `202 accepted:0` and do not insert duplicate child metric rows.
+
+This route-local `256 KiB` cap limits heartbeat ingest payloads. It does not allow sending a 256 KiB payload to the LLM; MCP query actions return bounded summaries and samples.
+
+## MCP Query
+
+`host_state` is the first shipped query surface.
+
+Rules:
+
+- `host_id` lookup is authoritative.
+- `hostname` fallback is allowed only when exactly one `host_id` matches.
+- Ambiguous hostname lookup returns `ambiguous_host`.
+- `limit` is capped at 100.
+- Responses are bounded summaries/samples, not raw full heartbeat ingest payloads.
+
+## Agent
+
+`syslog heartbeat agent` is the V1 collector.
+
+Defaults:
+
+- Target: `http://127.0.0.1:3100`
+- Interval: 30 seconds
+- Probe deadline: 2 seconds
+- Collection deadline: 5 seconds
+- Retry buffer: bounded in-memory queue
+
+Identity:
+
+- A generated stable `host_id` is stored in syslog appdata.
+- The collector does not send raw machine-id or plain machine-id hashes.
+
+Linux probes:
+
+- CPU load/core count from procfs.
+- Memory and swap from procfs.
+- Mount capacity from `/proc/self/mounts` plus `statvfs`.
+- Disk IO counters from `/proc/diskstats` with nullable first-sample rates.
+- Network counters/errors from `/proc/net/dev` with nullable first-sample rates.
+- Process counts and bounded pid/state summaries from `/proc`.
+- Docker container state summary from `docker ps` when reachable.
+
+Heavy probes remain out of V1: GPU, SMART, zfs, btrfs, mdraid, full process command lines, environment variables, open connection tuples, and disk-backed heartbeat spooling.
+
+## Setup
+
+`syslog setup heartbeat-agent install|remove|check` owns service setup.
+
+The service is separate from the central syslog server and runs:
+
+```text
+syslog heartbeat agent --host-id-path <appdata>/heartbeat-host-id
+```
+
+`scripts/plugin-setup.sh` stays a thin adapter to `syslog setup plugin-hook`; heartbeat-agent systemd/service logic belongs in the binary.
+
+## Deferred Surfaces
+
+These remain explicitly deferred after the V1 slice:
+
+- `fleet_state`
+- `correlate_state`
+- REST parity beyond heartbeat ingest
+- CLI parity beyond the collector/setup commands
+- WebSocket `/ws/agent`
+- per-host enrollment and token rotation
+- durable log streaming and replay
+- server-driven probe requests
+- typed probe registry scheduling
+- disk-backed heartbeat spool
+- non-Linux collectors
+
+Reasons:
+
+- `fleet_state` needs latest-state indexes or cache support before exposing all-host summaries safely.
+- `correlate_state` needs a bounded query plan that joins logs and heartbeat samples without broad scans.
+- WebSocket/control-plane work should build on observed production heartbeat behavior, not compete with the first data-plane slice.
+- Probe registry work should reuse the collector/probe code after the cheap Linux probes settle.
+
+## Verification
+
+Focused checks used during implementation:
+
+```bash
+cargo test heartbeat
+cargo test heartbeat_agent
+cargo test host_state
+cargo test schema_actions_are_dispatchable
+cargo test public_action_references_cover_schema_registry
+cargo clippy -- -D warnings
+```

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "syslog-mcp",
   "display_name": "Syslog MCP",
-  "version": "0.32.6",
+  "version": "0.33.0",
   "description": "Query local syslog-mcp SQLite logs through a bundled stdio MCP server.",
   "long_description": "Syslog MCP packages the existing syslog mcp stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/plugins/syslog/skills/syslog/SKILL.md
+++ b/plugins/syslog/skills/syslog/SKILL.md
@@ -18,6 +18,7 @@ A single MCP tool, `mcp__syslog__syslog`, dispatches on a required `action` argu
 | `tail` | Most recent entries |
 | `errors` | Error/warning summary by host and severity |
 | `hosts` | List all known hosts with first/last seen |
+| `host_state` | Latest bounded heartbeat state for one host |
 | `sessions` | AI transcript sessions by project |
 | `search_sessions` | Ranked grouped session search |
 | `abuse` | Abuse hits in AI transcripts with same-session context |

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10,7 +10,7 @@
 # Requirements: mcporter, nc, curl, python3
 #
 # Action inventory reference:
-#   mcp_call search, mcp_call filter, mcp_call tail, mcp_call errors, mcp_call hosts,
+#   mcp_call search, mcp_call filter, mcp_call tail, mcp_call errors, mcp_call hosts, mcp_call host_state,
 #   mcp_call sessions, mcp_call search_sessions, mcp_call abuse, mcp_call ai_correlate,
 #   mcp_call usage_blocks, mcp_call project_context, mcp_call list_ai_tools, mcp_call list_ai_projects,
 #   mcp_call correlate, mcp_call stats, mcp_call status, mcp_call apps,

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/syslog-mcp",
     "source": "github"
   },
-  "version": "0.32.6",
+  "version": "0.33.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.32.6",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.33.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,6 +64,8 @@ pub use models::{
     GetLogRequest,
     GetLogResponse,
     HostEntry,
+    HostStateRequest,
+    HostStateResponse,
     IncidentCluster,
     IncidentContextRequest,
     IncidentContextResponse,

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -164,6 +164,17 @@ impl From<db::LogEntry> for LogEntry {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct HostStateRequest {
+    pub host_id: Option<String>,
+    pub hostname: Option<String>,
+    pub since: Option<String>,
+    pub limit: Option<u32>,
+}
+
+pub type HostStateResponse = db::HeartbeatHostState;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListSessionsRequest {
     pub project: Option<String>,
     pub tool: Option<String>,

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -451,6 +451,46 @@ impl SyslogService {
         })
     }
 
+    pub async fn host_state(
+        &self,
+        req: super::models::HostStateRequest,
+    ) -> ServiceResult<super::models::HostStateResponse> {
+        let lookup = match (req.host_id, req.hostname) {
+            (Some(host_id), _) if !host_id.trim().is_empty() => {
+                db::HeartbeatHostLookup::HostId(host_id)
+            }
+            (_, Some(hostname)) if !hostname.trim().is_empty() => {
+                db::HeartbeatHostLookup::Hostname(hostname)
+            }
+            _ => {
+                return Err(ServiceError::InvalidInput(
+                    "host_state requires host_id or hostname".into(),
+                ));
+            }
+        };
+        let limit = req.limit.unwrap_or(1).clamp(1, 100) as usize;
+        let since = req.since.clone();
+        self.run_db(move |pool| {
+            db::heartbeat_host_state(pool, lookup, since.as_deref(), limit).map_err(|error| {
+                match error.to_string().as_str() {
+                    "not_found" => anyhow::anyhow!("not_found"),
+                    "ambiguous_host" => anyhow::anyhow!("ambiguous_host"),
+                    _ => error,
+                }
+            })
+        })
+        .await
+        .map_err(|error| match error {
+            ServiceError::Internal(error) if error.to_string() == "not_found" => {
+                ServiceError::NotFound("host_state host not found".into())
+            }
+            ServiceError::Internal(error) if error.to_string() == "ambiguous_host" => {
+                ServiceError::InvalidInput("ambiguous_host".into())
+            }
+            other => other,
+        })
+    }
+
     pub async fn filter_logs(&self, req: FilterLogsRequest) -> ServiceResult<SearchLogsResponse> {
         let params = filter_request_to_params(req)?;
         let logs = self

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,10 +13,11 @@ pub(crate) use args::{
     AiIndexArgs, AiInvestigateArgs, AiListArgs, AiPruneCheckpointsArgs, AiSearchArgs,
     AiSimilarArgs, AiWatchArgs, CliCommand, ComposeArgs, ComposeCommand, ComposeLogsArgs,
     ComposeMutationArgs, CorrelateArgs, DbBackupArgs, DbCheckpointArgs, DbCommand, DbIntegrityArgs,
-    DbStatusArgs, DbVacuumArgs, FilterArgs, IncidentArgs, IngestRateArgs, NotifyRecentArgs,
-    NotifyTestArgs, OutputArgs, PatternsArgs, PluginHookArgs, SearchArgs, ServiceCommand,
-    ServiceLogsArgs, SessionsArgs, SetupArgs, SetupCommand, ShellCommand, ShellIndexArgs,
-    SigAckArgs, SigListArgs, SigUnackArgs, SourceIpsArgs, TailArgs, TimeRangeArgs, TimelineArgs,
+    DbStatusArgs, DbVacuumArgs, FilterArgs, HeartbeatAgentArgs, HeartbeatCommand, IncidentArgs,
+    IngestRateArgs, NotifyRecentArgs, NotifyTestArgs, OutputArgs, PatternsArgs, PluginHookArgs,
+    SearchArgs, ServiceCommand, ServiceLogsArgs, SessionsArgs, SetupArgs, SetupCommand,
+    ShellCommand, ShellIndexArgs, SigAckArgs, SigListArgs, SigUnackArgs, SourceIpsArgs, TailArgs,
+    TimeRangeArgs, TimelineArgs,
 };
 pub(crate) use args_config::{
     ConfigCommand, ConfigGetArgs, ConfigListArgs, ConfigSetArgs, ConfigTarget, ConfigUnsetArgs,
@@ -35,6 +36,7 @@ mod config_cmd;
 mod config_toml;
 mod coordination;
 mod dispatch_command_log;
+mod heartbeat_agent;
 mod output_ai;
 mod output_ai_more;
 mod output_common;
@@ -51,6 +53,7 @@ mod parse_logs;
 mod setup;
 
 pub(crate) use config_cmd::run_config;
+pub(crate) use heartbeat_agent::run_heartbeat_no_db;
 pub(crate) use parse_common::{parse_i64_flag, parse_u32_flag, FlagCursor};
 pub(crate) use setup::run_setup;
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -26,6 +26,7 @@ pub(crate) enum CliCommand {
     Notify(NotifyCommand),
     Shell(ShellCommand),
     AgentCommand(AgentCommandCommand),
+    Heartbeat(HeartbeatCommand),
     // ── Surface parity gap closure (2026-05-22) ─────────────────────────────
     SilentHosts(SilentHostsArgs),
     ClockSkew(ClockSkewArgs),
@@ -59,6 +60,11 @@ pub(crate) enum AgentCommandCommand {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HeartbeatCommand {
+    Agent(HeartbeatAgentArgs),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ShellIndexArgs {
     pub path: String,
     pub shell: String,
@@ -75,6 +81,20 @@ pub(crate) struct AgentCommandIngestSpoolArgs {
 pub(crate) struct AgentCommandWrapArgs {
     pub spool: String,
     pub command: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HeartbeatAgentArgs {
+    pub target: Option<String>,
+    pub token: Option<String>,
+    pub interval_secs: u64,
+    pub probe_deadline_ms: u64,
+    pub collection_deadline_ms: u64,
+    pub retry_buffer: usize,
+    pub once: bool,
+    pub emit: bool,
+    pub json: bool,
+    pub host_id_path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/cli/heartbeat_agent.rs
+++ b/src/cli/heartbeat_agent.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use syslog_mcp::heartbeat_agent::{run_agent, HeartbeatAgentConfig};
+
+use super::{HeartbeatAgentArgs, HeartbeatCommand};
+
+pub(crate) async fn run_heartbeat_no_db(command: HeartbeatCommand) -> Result<()> {
+    match command {
+        HeartbeatCommand::Agent(args) => run_agent(args.into_config()?).await,
+    }
+}
+
+impl HeartbeatAgentArgs {
+    fn into_config(self) -> Result<HeartbeatAgentConfig> {
+        let host_id_path = self
+            .host_id_path
+            .map(PathBuf::from)
+            .unwrap_or_else(default_host_id_path);
+        let mut config = HeartbeatAgentConfig::from_env(host_id_path);
+        if let Some(target) = self.target {
+            config.target = Some(target);
+        }
+        if let Some(token) = self.token {
+            config.token = Some(token);
+        }
+        config.interval = Duration::from_secs(self.interval_secs);
+        config.probe_deadline = Duration::from_millis(self.probe_deadline_ms);
+        config.collection_deadline = Duration::from_millis(self.collection_deadline_ms);
+        config.retry_buffer_limit = self.retry_buffer;
+        config.once = self.once;
+        config.emit = self.emit;
+        config.json = self.json;
+        Ok(config)
+    }
+}
+
+pub(crate) fn default_host_id_path() -> PathBuf {
+    syslog_mcp::setup::syslog_home_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join("heartbeat-host-id")
+}

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -24,6 +24,7 @@ pub(crate) fn parse_command(args: Vec<String>) -> Result<CliCommand> {
         "ai" => parse_ai(rest),
         "shell" => parse_shell(rest),
         "agent-command" => parse_agent_command(rest),
+        "heartbeat" => parse_heartbeat(rest),
         "correlate" => parse_correlate(rest),
         "stats" => parse_stats(rest),
         "compose" => parse_compose(rest),
@@ -45,6 +46,101 @@ pub(crate) fn parse_command(args: Vec<String>) -> Result<CliCommand> {
         "apps" => commands::apps::parse_apps(rest),
         _ => bail!("unknown CLI command: {command}"),
     }
+}
+
+fn parse_heartbeat(args: &[String]) -> Result<CliCommand> {
+    let (command, rest) = args
+        .split_first()
+        .ok_or_else(|| anyhow!("heartbeat subcommand is required"))?;
+    match command.as_str() {
+        "agent" => parse_heartbeat_agent(rest),
+        _ => bail!("unknown heartbeat subcommand: {command}"),
+    }
+}
+
+fn parse_heartbeat_agent(args: &[String]) -> Result<CliCommand> {
+    let mut out = super::HeartbeatAgentArgs {
+        target: None,
+        token: None,
+        interval_secs: syslog_mcp::heartbeat_agent::DEFAULT_INTERVAL_SECS,
+        probe_deadline_ms: syslog_mcp::heartbeat_agent::DEFAULT_PROBE_DEADLINE_MS,
+        collection_deadline_ms: syslog_mcp::heartbeat_agent::DEFAULT_COLLECTION_DEADLINE_MS,
+        retry_buffer: syslog_mcp::heartbeat_agent::DEFAULT_RETRY_BUFFER_LIMIT,
+        once: false,
+        emit: false,
+        json: false,
+        host_id_path: None,
+    };
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--target" => {
+                i += 1;
+                out.target = Some(required_value(args, i, "--target")?);
+            }
+            "--token" => {
+                i += 1;
+                out.token = Some(required_value(args, i, "--token")?);
+            }
+            "--interval-secs" => {
+                i += 1;
+                out.interval_secs = parse_u64_value(args, i, "--interval-secs")?;
+            }
+            "--probe-deadline-ms" => {
+                i += 1;
+                out.probe_deadline_ms = parse_u64_value(args, i, "--probe-deadline-ms")?;
+            }
+            "--collection-deadline-ms" => {
+                i += 1;
+                out.collection_deadline_ms = parse_u64_value(args, i, "--collection-deadline-ms")?;
+            }
+            "--retry-buffer" => {
+                i += 1;
+                out.retry_buffer = parse_usize_value(args, i, "--retry-buffer")?;
+            }
+            "--host-id-path" => {
+                i += 1;
+                out.host_id_path = Some(required_value(args, i, "--host-id-path")?);
+            }
+            "--once" => out.once = true,
+            "--emit" => out.emit = true,
+            "--json" => out.json = true,
+            other => bail!("unknown heartbeat agent argument: {other}"),
+        }
+        i += 1;
+    }
+    if out.interval_secs == 0 {
+        bail!("--interval-secs must be greater than zero");
+    }
+    if out.probe_deadline_ms == 0 {
+        bail!("--probe-deadline-ms must be greater than zero");
+    }
+    if out.collection_deadline_ms == 0 {
+        bail!("--collection-deadline-ms must be greater than zero");
+    }
+    Ok(CliCommand::Heartbeat(super::HeartbeatCommand::Agent(out)))
+}
+
+fn required_value(args: &[String], index: usize, flag: &str) -> Result<String> {
+    let value = args
+        .get(index)
+        .ok_or_else(|| anyhow!("{flag} requires a value"))?;
+    if value.starts_with('-') || value.trim().is_empty() {
+        bail!("{flag} requires a value");
+    }
+    Ok(value.clone())
+}
+
+fn parse_u64_value(args: &[String], index: usize, flag: &str) -> Result<u64> {
+    required_value(args, index, flag)?
+        .parse()
+        .map_err(|_| anyhow!("{flag} must be an integer"))
+}
+
+fn parse_usize_value(args: &[String], index: usize, flag: &str) -> Result<usize> {
+    required_value(args, index, flag)?
+        .parse()
+        .map_err(|_| anyhow!("{flag} must be an integer"))
 }
 
 #[cfg(test)]

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -1,4 +1,4 @@
-use super::super::OutputArgs;
+use super::super::{HeartbeatAgentArgs, HeartbeatCommand, OutputArgs};
 use super::*;
 
 #[test]
@@ -6,6 +6,64 @@ fn parse_routes_stats() {
     assert_eq!(
         parse_command(vec!["stats".to_string()]).unwrap(),
         CliCommand::Stats(OutputArgs::default())
+    );
+}
+
+#[test]
+fn parse_routes_heartbeat_agent_defaults() {
+    assert_eq!(
+        parse_command(vec!["heartbeat".to_string(), "agent".to_string()]).unwrap(),
+        CliCommand::Heartbeat(HeartbeatCommand::Agent(HeartbeatAgentArgs {
+            target: None,
+            token: None,
+            interval_secs: 30,
+            probe_deadline_ms: 2000,
+            collection_deadline_ms: 5000,
+            retry_buffer: 32,
+            once: false,
+            emit: false,
+            json: false,
+            host_id_path: None,
+        }))
+    );
+}
+
+#[test]
+fn parse_routes_heartbeat_agent_flags() {
+    assert_eq!(
+        parse_command(vec![
+            "heartbeat".to_string(),
+            "agent".to_string(),
+            "--target".to_string(),
+            "http://127.0.0.1:3100".to_string(),
+            "--token".to_string(),
+            "secret".to_string(),
+            "--interval-secs".to_string(),
+            "15".to_string(),
+            "--probe-deadline-ms".to_string(),
+            "100".to_string(),
+            "--collection-deadline-ms".to_string(),
+            "300".to_string(),
+            "--retry-buffer".to_string(),
+            "4".to_string(),
+            "--host-id-path".to_string(),
+            "/tmp/host-id".to_string(),
+            "--once".to_string(),
+            "--json".to_string(),
+        ])
+        .unwrap(),
+        CliCommand::Heartbeat(HeartbeatCommand::Agent(HeartbeatAgentArgs {
+            target: Some("http://127.0.0.1:3100".to_string()),
+            token: Some("secret".to_string()),
+            interval_secs: 15,
+            probe_deadline_ms: 100,
+            collection_deadline_ms: 300,
+            retry_buffer: 4,
+            once: true,
+            emit: false,
+            json: true,
+            host_id_path: Some("/tmp/host-id".to_string()),
+        }))
     );
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -99,6 +99,9 @@ pub(crate) async fn run(mode: CliMode, command: CliCommand) -> Result<()> {
                 bail!("internal: agent-command wrap must be dispatched before CliMode creation")
             }
         },
+        CliCommand::Heartbeat(command) => {
+            super::heartbeat_agent::run_heartbeat_no_db(command).await
+        }
         // DB commands (bead 0p8r.9). 4 are HTTP-capable; backup stays LOCAL
         // and bails in HTTP mode with an inline message.
         CliCommand::Db(db) => match db {

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -439,9 +439,9 @@ fn smoke_watch_target_uses_codex_root_when_claude_is_unavailable() {
     std::fs::create_dir_all(&codex_root).unwrap();
     let doctor = AiDoctorReport {
         db_path: "/tmp/syslog.db".into(),
-        db_schema_version: 14,
+        db_schema_version: 15,
         db_last_migration_at: Some("2026-01-01T00:00:00Z".into()),
-        known_schema_version: 14,
+        known_schema_version: 15,
         schema_current: true,
         claude_root: transcript_root_status("/missing", false),
         codex_root: transcript_root_status(&codex_root.to_string_lossy(), true),
@@ -474,9 +474,9 @@ fn smoke_watch_target_uses_codex_root_when_claude_is_unavailable() {
 fn strict_ai_doctor_permissions_ignore_missing_roots() {
     let doctor = AiDoctorReport {
         db_path: "/tmp/syslog.db".into(),
-        db_schema_version: 14,
+        db_schema_version: 15,
         db_last_migration_at: Some("2026-01-01T00:00:00Z".into()),
-        known_schema_version: 14,
+        known_schema_version: 15,
         schema_current: true,
         claude_root: transcript_root_status("/missing", false),
         codex_root: transcript_root_status("/tmp/codex", true),

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,6 +2,7 @@
 
 mod analytics;
 pub(crate) mod error_signatures;
+mod heartbeat;
 mod ingest;
 mod maintenance;
 mod models;
@@ -16,6 +17,10 @@ pub use analytics::{
     ContextRef, IngestRateBuckets, IngestRatePerHost, ListAppsParams, ListAppsResult,
     ListSourceIpsParams, ListSourceIpsResult, LogEntryWithRaw, PatternEntry, RangeSummary,
     SilentHostEntry, SourceIpEntry, SourceIpHostBreakdown, TimelineGroupBy, TimelinePoint,
+};
+pub use heartbeat::{
+    heartbeat_host_state, HeartbeatHostLookup, HeartbeatHostState, HeartbeatSampleState,
+    HeartbeatStateFlags,
 };
 pub use ingest::insert_logs_batch;
 pub(crate) use ingest::insert_logs_batch_in_tx;

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,7 +22,7 @@ pub(crate) use ingest::insert_logs_batch_in_tx;
 pub use maintenance::{
     db_full_vacuum, db_incremental_vacuum, db_integrity_check, db_wal_checkpoint,
     enforce_storage_budget, get_storage_metrics, physical_size_bytes, purge_by_tag_window,
-    purge_old_logs, DiskSpaceProbe,
+    purge_old_heartbeats, purge_old_logs, DiskSpaceProbe,
 };
 pub(crate) use maintenance::{db_pragma_i64, db_pragma_string, PragmaName};
 pub use models::{

--- a/src/db/heartbeat.rs
+++ b/src/db/heartbeat.rs
@@ -294,7 +294,7 @@ fn sample_from_row(conn: &rusqlite::Connection, row: HeartbeatRow) -> Result<Hea
             conn,
             "SELECT json_object(
                  'runtime', runtime, 'running', running, 'stopped', stopped,
-                 'unhealthy', unhealthy, 'summary', json(summary_json)
+                 'restarting', restarting, 'unhealthy', unhealthy, 'summary', json(summary_json)
              ) FROM heartbeat_containers WHERE heartbeat_id = ?1 ORDER BY id ASC",
             row.id,
         )?,

--- a/src/db/heartbeat.rs
+++ b/src/db/heartbeat.rs
@@ -3,6 +3,8 @@ use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use tracing::warn;
+
 use super::pool::DbPool;
 
 #[derive(Debug, Clone)]
@@ -160,9 +162,18 @@ fn heartbeat_flags(sample: &HeartbeatSampleState) -> HeartbeatStateFlags {
         .and_then(Value::as_i64)
         .unwrap_or(30)
         .max(1);
-    let received_at = chrono::DateTime::parse_from_rfc3339(&sample.received_at)
-        .map(|dt| dt.with_timezone(&chrono::Utc))
-        .ok();
+    let received_at = match chrono::DateTime::parse_from_rfc3339(&sample.received_at) {
+        Ok(dt) => Some(dt.with_timezone(&chrono::Utc)),
+        Err(error) => {
+            warn!(
+                heartbeat_id = sample.heartbeat_id,
+                received_at = %sample.received_at,
+                error = %error,
+                "heartbeat received_at timestamp failed to parse; heartbeat_late check skipped"
+            );
+            None
+        }
+    };
     let heartbeat_late = received_at.is_some_and(|received_at| {
         let elapsed = chrono::Utc::now().signed_duration_since(received_at);
         elapsed.num_milliseconds() > interval_secs * 2500
@@ -294,7 +305,13 @@ fn one_json(conn: &rusqlite::Connection, sql: &str, heartbeat_id: i64) -> Result
     let raw: Option<String> = conn
         .query_row(sql, [heartbeat_id], |row| row.get(0))
         .optional()?;
-    Ok(raw.and_then(|raw| serde_json::from_str(&raw).ok()))
+    Ok(raw.and_then(|raw| {
+        serde_json::from_str(&raw)
+            .map_err(|error| {
+                warn!(heartbeat_id, error = %error, "failed to parse heartbeat JSON column");
+            })
+            .ok()
+    }))
 }
 
 fn many_json(conn: &rusqlite::Connection, sql: &str, heartbeat_id: i64) -> Result<Vec<Value>> {
@@ -304,7 +321,13 @@ fn many_json(conn: &rusqlite::Connection, sql: &str, heartbeat_id: i64) -> Resul
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows
         .into_iter()
-        .filter_map(|raw| serde_json::from_str(&raw).ok())
+        .filter_map(|raw| {
+            serde_json::from_str(&raw)
+                .map_err(|error| {
+                    warn!(heartbeat_id, error = %error, "failed to parse heartbeat JSON row");
+                })
+                .ok()
+        })
         .collect())
 }
 

--- a/src/db/heartbeat.rs
+++ b/src/db/heartbeat.rs
@@ -1,0 +1,313 @@
+use anyhow::{anyhow, Result};
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::pool::DbPool;
+
+#[derive(Debug, Clone)]
+pub enum HeartbeatHostLookup {
+    HostId(String),
+    Hostname(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatHostState {
+    pub host_id: String,
+    pub hostname: String,
+    pub total_samples: usize,
+    pub truncated: bool,
+    pub flags: HeartbeatStateFlags,
+    pub latest: Option<HeartbeatSampleState>,
+    pub samples: Vec<HeartbeatSampleState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatStateFlags {
+    pub collector_partial: bool,
+    pub heartbeat_late: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HeartbeatSampleState {
+    pub heartbeat_id: i64,
+    pub host_id: String,
+    pub hostname: String,
+    pub sampled_at: String,
+    pub received_at: String,
+    pub source_ip: String,
+    pub boot_id: String,
+    pub sequence: i64,
+    pub uptime_secs: i64,
+    pub collection_ms: i64,
+    pub partial: bool,
+    pub agent_version: String,
+    pub os: String,
+    pub kernel: Option<String>,
+    pub architecture: String,
+    pub metadata: Option<Value>,
+    pub cpu: Option<Value>,
+    pub memory: Option<Value>,
+    pub disks: Vec<Value>,
+    pub network: Vec<Value>,
+    pub processes: Option<Value>,
+    pub containers: Vec<Value>,
+}
+
+#[derive(Debug)]
+struct HeartbeatRow {
+    id: i64,
+    host_id: String,
+    hostname: String,
+    source_ip: String,
+    sampled_at: String,
+    received_at: String,
+    boot_id: String,
+    uptime_secs: i64,
+    sequence: i64,
+    collection_ms: i64,
+    partial: bool,
+    agent_version: String,
+    os: String,
+    kernel: Option<String>,
+    architecture: String,
+    metadata_json: Option<String>,
+}
+
+pub fn heartbeat_host_state(
+    pool: &DbPool,
+    lookup: HeartbeatHostLookup,
+    since: Option<&str>,
+    limit: usize,
+) -> Result<HeartbeatHostState> {
+    let conn = pool.get()?;
+    let host_id = match lookup {
+        HeartbeatHostLookup::HostId(host_id) => host_id,
+        HeartbeatHostLookup::Hostname(hostname) => resolve_unique_hostname(&conn, &hostname)?,
+    };
+
+    let limit = limit.clamp(1, 100);
+    let fetch_limit = limit + 1;
+    let rows = if let Some(since) = since {
+        let mut stmt = conn.prepare(
+            "SELECT id, host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+                    uptime_secs, sequence, collection_ms, partial, agent_version,
+                    os, kernel, architecture, metadata_json
+             FROM host_heartbeats
+             WHERE host_id = ?1 AND sampled_at >= ?2
+             ORDER BY sampled_at DESC, id DESC
+             LIMIT ?3",
+        )?;
+        let rows = stmt
+            .query_map(
+                params![host_id, since, fetch_limit as i64],
+                map_heartbeat_row,
+            )?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows
+    } else {
+        let mut stmt = conn.prepare(
+            "SELECT id, host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+                    uptime_secs, sequence, collection_ms, partial, agent_version,
+                    os, kernel, architecture, metadata_json
+             FROM host_heartbeats
+             WHERE host_id = ?1
+             ORDER BY sampled_at DESC, id DESC
+             LIMIT ?2",
+        )?;
+        let rows = stmt
+            .query_map(params![host_id, fetch_limit as i64], map_heartbeat_row)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows
+    };
+
+    if rows.is_empty() {
+        return Err(anyhow!("not_found"));
+    }
+
+    let truncated = rows.len() > limit;
+    let mut samples = Vec::with_capacity(limit.min(rows.len()));
+    for row in rows.into_iter().take(limit) {
+        samples.push(sample_from_row(&conn, row)?);
+    }
+    let latest = samples.first().cloned();
+    let host_id = samples[0].host_id.clone();
+    let hostname = samples[0].hostname.clone();
+    let flags = latest
+        .as_ref()
+        .map(heartbeat_flags)
+        .unwrap_or(HeartbeatStateFlags {
+            collector_partial: false,
+            heartbeat_late: false,
+        });
+
+    Ok(HeartbeatHostState {
+        host_id,
+        hostname,
+        total_samples: samples.len(),
+        truncated,
+        flags,
+        latest,
+        samples,
+    })
+}
+
+fn heartbeat_flags(sample: &HeartbeatSampleState) -> HeartbeatStateFlags {
+    let interval_secs = sample
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.pointer("/agent/interval_secs"))
+        .and_then(Value::as_i64)
+        .unwrap_or(30)
+        .max(1);
+    let received_at = chrono::DateTime::parse_from_rfc3339(&sample.received_at)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .ok();
+    let heartbeat_late = received_at.is_some_and(|received_at| {
+        let elapsed = chrono::Utc::now().signed_duration_since(received_at);
+        elapsed.num_milliseconds() > interval_secs * 2500
+    });
+    HeartbeatStateFlags {
+        collector_partial: sample.partial,
+        heartbeat_late,
+    }
+}
+
+fn resolve_unique_hostname(conn: &rusqlite::Connection, hostname: &str) -> Result<String> {
+    let mut stmt = conn.prepare(
+        "SELECT host_id
+         FROM host_heartbeats
+         WHERE hostname = ?1
+         GROUP BY host_id
+         ORDER BY MAX(received_at) DESC
+         LIMIT 2",
+    )?;
+    let host_ids = stmt
+        .query_map([hostname], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    match host_ids.as_slice() {
+        [] => Err(anyhow!("not_found")),
+        [host_id] => Ok(host_id.clone()),
+        _ => Err(anyhow!("ambiguous_host")),
+    }
+}
+
+fn map_heartbeat_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HeartbeatRow> {
+    Ok(HeartbeatRow {
+        id: row.get(0)?,
+        host_id: row.get(1)?,
+        hostname: row.get(2)?,
+        source_ip: row.get(3)?,
+        sampled_at: row.get(4)?,
+        received_at: row.get(5)?,
+        boot_id: row.get(6)?,
+        uptime_secs: row.get(7)?,
+        sequence: row.get(8)?,
+        collection_ms: row.get(9)?,
+        partial: row.get::<_, i64>(10)? != 0,
+        agent_version: row.get(11)?,
+        os: row.get(12)?,
+        kernel: row.get(13)?,
+        architecture: row.get(14)?,
+        metadata_json: row.get(15)?,
+    })
+}
+
+fn sample_from_row(conn: &rusqlite::Connection, row: HeartbeatRow) -> Result<HeartbeatSampleState> {
+    Ok(HeartbeatSampleState {
+        heartbeat_id: row.id,
+        host_id: row.host_id,
+        hostname: row.hostname,
+        sampled_at: row.sampled_at,
+        received_at: row.received_at,
+        source_ip: row.source_ip,
+        boot_id: row.boot_id,
+        sequence: row.sequence,
+        uptime_secs: row.uptime_secs,
+        collection_ms: row.collection_ms,
+        partial: row.partial,
+        agent_version: row.agent_version,
+        os: row.os,
+        kernel: row.kernel,
+        architecture: row.architecture,
+        metadata: row
+            .metadata_json
+            .as_deref()
+            .and_then(|raw| serde_json::from_str(raw).ok()),
+        cpu: one_json(
+            conn,
+            "SELECT json_object(
+                 'load1', load1, 'load5', load5, 'load15', load15,
+                 'usage_percent', usage_percent, 'steal_percent', steal_percent,
+                 'io_wait_percent', io_wait_percent
+             ) FROM heartbeat_cpu WHERE heartbeat_id = ?1",
+            row.id,
+        )?,
+        memory: one_json(
+            conn,
+            "SELECT json_object(
+                 'total_bytes', total_bytes, 'available_bytes', available_bytes,
+                 'used_percent', used_percent, 'swap_total_bytes', swap_total_bytes,
+                 'swap_used_bytes', swap_used_bytes
+             ) FROM heartbeat_memory WHERE heartbeat_id = ?1",
+            row.id,
+        )?,
+        disks: many_json(
+            conn,
+            "SELECT json_object(
+                 'mountpoint', mountpoint, 'filesystem', filesystem,
+                 'total_bytes', total_bytes, 'available_bytes', available_bytes,
+                 'used_percent', used_percent, 'read_bytes_per_sec', read_bytes_per_sec,
+                 'write_bytes_per_sec', write_bytes_per_sec
+             ) FROM heartbeat_disks WHERE heartbeat_id = ?1 ORDER BY id ASC",
+            row.id,
+        )?,
+        network: many_json(
+            conn,
+            "SELECT json_object(
+                 'interface', interface, 'rx_bytes_per_sec', rx_bytes_per_sec,
+                 'tx_bytes_per_sec', tx_bytes_per_sec, 'rx_errors', rx_errors,
+                 'tx_errors', tx_errors
+             ) FROM heartbeat_network WHERE heartbeat_id = ?1 ORDER BY id ASC",
+            row.id,
+        )?,
+        processes: one_json(
+            conn,
+            "SELECT json_object(
+                 'total', total, 'running', running, 'sleeping', sleeping, 'zombie', zombie,
+                 'top_cpu', json(top_cpu_json), 'top_memory', json(top_memory_json)
+             ) FROM heartbeat_processes WHERE heartbeat_id = ?1",
+            row.id,
+        )?,
+        containers: many_json(
+            conn,
+            "SELECT json_object(
+                 'runtime', runtime, 'running', running, 'stopped', stopped,
+                 'unhealthy', unhealthy, 'summary', json(summary_json)
+             ) FROM heartbeat_containers WHERE heartbeat_id = ?1 ORDER BY id ASC",
+            row.id,
+        )?,
+    })
+}
+
+fn one_json(conn: &rusqlite::Connection, sql: &str, heartbeat_id: i64) -> Result<Option<Value>> {
+    let raw: Option<String> = conn
+        .query_row(sql, [heartbeat_id], |row| row.get(0))
+        .optional()?;
+    Ok(raw.and_then(|raw| serde_json::from_str(&raw).ok()))
+}
+
+fn many_json(conn: &rusqlite::Connection, sql: &str, heartbeat_id: i64) -> Result<Vec<Value>> {
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt
+        .query_map([heartbeat_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|raw| serde_json::from_str(&raw).ok())
+        .collect())
+}
+
+#[cfg(test)]
+#[path = "heartbeat_tests.rs"]
+mod tests;

--- a/src/db/heartbeat_tests.rs
+++ b/src/db/heartbeat_tests.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+use crate::config::StorageConfig;
+
+fn test_pool() -> (DbPool, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = StorageConfig::for_test(dir.path().join("heartbeat-state.db"));
+    let pool = crate::db::init_pool(&storage).unwrap();
+    (pool, dir)
+}
+
+fn insert_heartbeat(
+    pool: &DbPool,
+    host_id: &str,
+    hostname: &str,
+    sequence: i64,
+    sampled_at: &str,
+    partial: bool,
+) -> i64 {
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "INSERT INTO host_heartbeats (
+             host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+             uptime_secs, sequence, collection_ms, partial, agent_version,
+             os, architecture, metadata_json
+         ) VALUES (?1, ?2, '10.0.0.1:41000', ?4, ?4, 'boot-a', 60, ?3, 5, ?5,
+                   '0.1.0', 'linux', 'x86_64', '{\"agent\":{\"interval_secs\":30}}')",
+        params![host_id, hostname, sequence, sampled_at, partial as i64],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+#[test]
+fn host_state_returns_latest_by_host_id() {
+    let (pool, _dir) = test_pool();
+    let older = insert_heartbeat(&pool, "host-a", "tootie", 1, "2026-05-25T00:00:00Z", false);
+    let latest = insert_heartbeat(&pool, "host-a", "tootie", 2, "2026-05-25T00:01:00Z", true);
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "INSERT INTO heartbeat_cpu (heartbeat_id, load1, load5, load15)
+         VALUES (?1, 0.1, 0.2, 0.3)",
+        [latest],
+    )
+    .unwrap();
+    drop(conn);
+
+    let state = heartbeat_host_state(
+        &pool,
+        HeartbeatHostLookup::HostId("host-a".into()),
+        None,
+        10,
+    )
+    .unwrap();
+    assert_eq!(state.host_id, "host-a");
+    assert_eq!(state.latest.as_ref().unwrap().heartbeat_id, latest);
+    assert!(state.flags.collector_partial);
+    assert_eq!(state.samples.len(), 2);
+    assert!(state
+        .samples
+        .iter()
+        .any(|sample| sample.heartbeat_id == older));
+    assert!(state.latest.as_ref().unwrap().cpu.is_some());
+}
+
+#[test]
+fn host_state_unique_hostname_fallback_and_ambiguous_hostname() {
+    let (pool, _dir) = test_pool();
+    insert_heartbeat(&pool, "host-a", "unique", 1, "2026-05-25T00:00:00Z", false);
+    let state = heartbeat_host_state(
+        &pool,
+        HeartbeatHostLookup::Hostname("unique".into()),
+        None,
+        1,
+    )
+    .unwrap();
+    assert_eq!(state.host_id, "host-a");
+
+    insert_heartbeat(&pool, "host-b", "shared", 1, "2026-05-25T00:00:00Z", false);
+    insert_heartbeat(&pool, "host-c", "shared", 1, "2026-05-25T00:01:00Z", false);
+    let error = heartbeat_host_state(
+        &pool,
+        HeartbeatHostLookup::Hostname("shared".into()),
+        None,
+        1,
+    )
+    .unwrap_err();
+    assert_eq!(error.to_string(), "ambiguous_host");
+}
+
+#[test]
+fn host_state_caps_limit_and_filters_since() {
+    let (pool, _dir) = test_pool();
+    for sequence in 0..105 {
+        insert_heartbeat(
+            &pool,
+            "host-a",
+            "tootie",
+            sequence,
+            &format!("2026-05-25T00:{sequence:03}:00Z"),
+            false,
+        );
+    }
+
+    let capped = heartbeat_host_state(
+        &pool,
+        HeartbeatHostLookup::HostId("host-a".into()),
+        None,
+        500,
+    )
+    .unwrap();
+    assert_eq!(capped.samples.len(), 100);
+    assert!(capped.truncated);
+
+    let since = heartbeat_host_state(
+        &pool,
+        HeartbeatHostLookup::HostId("host-a".into()),
+        Some("2026-05-25T00:099:00Z"),
+        100,
+    )
+    .unwrap();
+    assert_eq!(since.samples.len(), 6);
+}

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -139,6 +139,7 @@ pub fn enforce_storage_budget_with_probe(
 ) -> Result<StorageEnforcementOutcome> {
     let recovery = recovery_targets(config);
     let mut deleted_rows = 0usize;
+    let mut deleted_log_rows = 0usize;
     let mut all_hosts: std::collections::HashSet<String> = Default::default();
 
     let mut metrics = get_storage_metrics_with_probe(pool, config, probe)?;
@@ -170,8 +171,21 @@ pub fn enforce_storage_budget_with_probe(
                 physical_db_size_bytes = metrics.physical_db_size_bytes,
                 free_disk_bytes = ?metrics.free_disk_bytes,
                 deleted_rows,
-                "Storage budget exceeded trigger — deleting oldest logs chunk"
+                "Storage budget exceeded trigger — deleting oldest telemetry chunk"
             );
+            let deleted_heartbeats =
+                delete_oldest_heartbeats_chunk(pool, config.cleanup_chunk_size)?;
+            if deleted_heartbeats > 0 {
+                deleted_rows += deleted_heartbeats;
+                tracing::info!(
+                    deleted_rows = deleted_heartbeats,
+                    total_deleted_rows = deleted_rows,
+                    "Deleted oldest heartbeat chunk for storage recovery"
+                );
+                metrics = get_storage_metrics_with_probe(pool, config, probe)?;
+                continue;
+            }
+
             let deleted = delete_oldest_logs_chunk(pool, config.cleanup_chunk_size)?;
             if deleted.deleted_rows == 0 {
                 metrics = get_storage_metrics_with_probe(pool, config, probe)?;
@@ -192,6 +206,7 @@ pub fn enforce_storage_budget_with_probe(
             }
 
             deleted_rows += deleted.deleted_rows;
+            deleted_log_rows += deleted.deleted_rows;
             tracing::info!(
                 deleted_rows = deleted.deleted_rows,
                 total_deleted_rows = deleted_rows,
@@ -215,7 +230,9 @@ pub fn enforce_storage_budget_with_probe(
         // avoid pool exhaustion when pool_size = 1.
         // Hardcoded M=0 here — storage enforcement is rare, force unconditional
         // merge. Tunable M only matters for the regular retention path.
-        fts_incremental_merge(pool, deleted_rows, 0);
+        if deleted_log_rows > 0 {
+            fts_incremental_merge(pool, deleted_log_rows, 0);
+        }
 
         checkpoint_wal_and_incremental_vacuum(pool)?;
     }
@@ -399,6 +416,44 @@ pub fn purge_old_logs(pool: &DbPool, retention_days: u32, fts_merge_pages: u32) 
     Ok(total_deleted)
 }
 
+/// Purge heartbeat telemetry older than N days.
+///
+/// This is intentionally independent from log retention: heartbeat samples are
+/// high-volume operational telemetry and have their own shorter retention
+/// window. Child metric rows are deleted explicitly because v1 does not depend
+/// on connection-level `PRAGMA foreign_keys`.
+pub fn purge_old_heartbeats(
+    pool: &DbPool,
+    retention_days: u32,
+    chunk_size: usize,
+) -> Result<usize> {
+    if retention_days == 0 {
+        return Ok(0);
+    }
+
+    let cutoff = Utc::now()
+        .checked_sub_signed(chrono::TimeDelta::days(retention_days as i64))
+        .ok_or_else(|| {
+            anyhow::anyhow!("date arithmetic overflow for retention_days={retention_days}")
+        })?
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    let mut total_deleted = 0usize;
+    let chunk_size = chunk_size.max(1);
+    loop {
+        let chunk = delete_heartbeat_chunk_before(pool, &cutoff, chunk_size)?;
+        total_deleted += chunk;
+        if chunk == 0 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    tracing::info!(deleted = total_deleted, cutoff = %cutoff, "Purged old heartbeats");
+    Ok(total_deleted)
+}
+
 /// Delete rows for a single `app_name` older than `max_days`.
 ///
 /// Same chunked-DELETE pattern as [`purge_old_logs`] (10 000 rows per
@@ -463,6 +518,96 @@ pub fn purge_by_tag_window(
         "Purged tag window"
     );
     Ok(total_deleted)
+}
+
+const HEARTBEAT_CHILD_TABLES: &[&str] = &[
+    "heartbeat_cpu",
+    "heartbeat_memory",
+    "heartbeat_disks",
+    "heartbeat_network",
+    "heartbeat_processes",
+    "heartbeat_containers",
+];
+
+fn delete_oldest_heartbeats_chunk(pool: &DbPool, chunk_size: usize) -> Result<usize> {
+    let conn = pool.get()?;
+    let chunk_limit = chunk_size as i64;
+    delete_heartbeat_chunk(&conn, None, chunk_limit)
+}
+
+fn delete_heartbeat_chunk_before(pool: &DbPool, cutoff: &str, chunk_size: usize) -> Result<usize> {
+    let conn = pool.get()?;
+    let chunk_limit = chunk_size as i64;
+    delete_heartbeat_chunk(&conn, Some(cutoff), chunk_limit)
+}
+
+fn delete_heartbeat_chunk(
+    conn: &rusqlite::Connection,
+    cutoff: Option<&str>,
+    chunk_limit: i64,
+) -> Result<usize> {
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    let result = (|| -> rusqlite::Result<usize> {
+        conn.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS heartbeat_delete_ids (
+                 id INTEGER PRIMARY KEY
+             );
+             DELETE FROM heartbeat_delete_ids;",
+        )?;
+
+        let selected = if let Some(cutoff) = cutoff {
+            conn.execute(
+                "INSERT INTO heartbeat_delete_ids(id)
+                 SELECT id FROM host_heartbeats
+                 WHERE received_at < ?1
+                 ORDER BY received_at ASC, id ASC
+                 LIMIT ?2",
+                params![cutoff, chunk_limit],
+            )?
+        } else {
+            conn.execute(
+                "INSERT INTO heartbeat_delete_ids(id)
+                 SELECT id FROM host_heartbeats
+                 ORDER BY received_at ASC, id ASC
+                 LIMIT ?1",
+                [chunk_limit],
+            )?
+        };
+
+        if selected == 0 {
+            conn.execute_batch("DELETE FROM heartbeat_delete_ids;")?;
+            return Ok(0);
+        }
+
+        for table in HEARTBEAT_CHILD_TABLES {
+            conn.execute(
+                &format!(
+                    "DELETE FROM {table}
+                     WHERE heartbeat_id IN (SELECT id FROM heartbeat_delete_ids)"
+                ),
+                [],
+            )?;
+        }
+
+        let deleted = conn.execute(
+            "DELETE FROM host_heartbeats
+             WHERE id IN (SELECT id FROM heartbeat_delete_ids)",
+            [],
+        )?;
+        conn.execute_batch("DELETE FROM heartbeat_delete_ids;")?;
+        Ok(deleted)
+    })();
+
+    match result {
+        Ok(deleted) => {
+            conn.execute_batch("COMMIT;")?;
+            Ok(deleted)
+        }
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK;");
+            Err(error.into())
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -52,6 +52,65 @@ fn update_received_at(pool: &DbPool, message: &str, received_at: &str) {
     .unwrap();
 }
 
+fn insert_heartbeat(pool: &DbPool, host_id: &str, sequence: i64, received_at: &str) -> i64 {
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "INSERT INTO host_heartbeats (
+             host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+             uptime_secs, sequence, collection_ms, partial, agent_version,
+             os, architecture, metadata_json
+         ) VALUES (
+             ?1, ?2, '127.0.0.1:3100', ?4, ?4, 'boot-a',
+             60, ?3, 5, 0, '0.1.0-test', 'linux', 'x86_64', ?5
+         )",
+        params![
+            host_id,
+            format!("{host_id}.local"),
+            sequence,
+            received_at,
+            "{}",
+        ],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn insert_large_heartbeat(
+    pool: &DbPool,
+    host_id: &str,
+    sequence: i64,
+    received_at: &str,
+    bytes: usize,
+) -> i64 {
+    let conn = pool.get().unwrap();
+    let metadata = format!("{{\"padding\":\"{}\"}}", "x".repeat(bytes));
+    conn.execute(
+        "INSERT INTO host_heartbeats (
+             host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+             uptime_secs, sequence, collection_ms, partial, agent_version,
+             os, architecture, metadata_json
+         ) VALUES (
+             ?1, ?2, '127.0.0.1:3100', ?4, ?4, 'boot-a',
+             60, ?3, 5, 0, '0.1.0-test', 'linux', 'x86_64', ?5
+         )",
+        params![
+            host_id,
+            format!("{host_id}.local"),
+            sequence,
+            received_at,
+            metadata
+        ],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+fn heartbeat_count(pool: &DbPool) -> i64 {
+    let conn = pool.get().unwrap();
+    conn.query_row("SELECT COUNT(*) FROM host_heartbeats", [], |row| row.get(0))
+        .unwrap()
+}
+
 #[test]
 fn test_storage_metrics_report_logical_size() {
     let dir = tempfile::tempdir().unwrap();
@@ -109,6 +168,102 @@ fn test_purge_zero_retention_noop() {
 
     let deleted = purge_old_logs(&pool, 0, 0).unwrap();
     assert_eq!(deleted, 0, "retention_days=0 should be a no-op");
+}
+
+#[test]
+fn test_purge_old_heartbeats_removes_children() {
+    let (pool, _dir) = test_pool();
+    let old_id = insert_heartbeat(&pool, "old-host", 1, "2020-01-01T00:00:00Z");
+    let fresh_id = insert_heartbeat(&pool, "fresh-host", 1, "2099-01-01T00:00:00Z");
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "INSERT INTO heartbeat_cpu (heartbeat_id, load1) VALUES (?1, 1.0)",
+        [old_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO heartbeat_cpu (heartbeat_id, load1) VALUES (?1, 2.0)",
+        [fresh_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO heartbeat_disks (heartbeat_id, mountpoint, filesystem, total_bytes)
+         VALUES (?1, '/', 'ext4', 1024)",
+        [old_id],
+    )
+    .unwrap();
+    drop(conn);
+
+    let deleted = purge_old_heartbeats(&pool, 14, 10).unwrap();
+    assert_eq!(deleted, 1);
+    assert_eq!(heartbeat_count(&pool), 1);
+
+    let conn = pool.get().unwrap();
+    let old_children: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM heartbeat_cpu WHERE heartbeat_id = ?1",
+            [old_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let fresh_children: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM heartbeat_cpu WHERE heartbeat_id = ?1",
+            [fresh_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let old_disk_children: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM heartbeat_disks WHERE heartbeat_id = ?1",
+            [old_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(old_children, 0);
+    assert_eq!(old_disk_children, 0);
+    assert_eq!(fresh_children, 1);
+}
+
+#[test]
+fn test_enforce_storage_budget_reclaims_heartbeat_rows() {
+    let (pool, dir) = test_pool();
+    let old_id = insert_large_heartbeat(&pool, "old-heartbeat", 1, "2026-01-01T00:00:00Z", 900_000);
+    let _fresh_id =
+        insert_large_heartbeat(&pool, "fresh-heartbeat", 1, "2026-01-02T00:00:00Z", 10_000);
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "INSERT INTO heartbeat_cpu (heartbeat_id, load1) VALUES (?1, 1.0)",
+        [old_id],
+    )
+    .unwrap();
+    drop(conn);
+
+    let mut config = test_storage_config(dir.path().join("test.db"));
+    config.max_db_size_mb = 1;
+    config.recovery_db_size_mb = 0;
+    config.cleanup_chunk_size = 1;
+
+    let outcome = enforce_storage_budget(&pool, &config).unwrap();
+    assert!(outcome.deleted_rows > 0);
+
+    let conn = pool.get().unwrap();
+    let old_remaining: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM host_heartbeats WHERE id = ?1",
+            [old_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let old_children: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM heartbeat_cpu WHERE heartbeat_id = ?1",
+            [old_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(old_remaining, 0);
+    assert_eq!(old_children, 0);
 }
 
 #[test]

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -133,12 +133,12 @@ fn test_purge_old_heartbeats_removes_children_before_parent() {
     let new_id = insert_heartbeat(&pool, "host-new", "2099-01-01T00:00:00Z");
     let conn = pool.get().unwrap();
     conn.execute(
-        "INSERT INTO heartbeat_cpu (heartbeat_id, usage_pct) VALUES (?1, 10.0)",
+        "INSERT INTO heartbeat_cpu (heartbeat_id, usage_percent) VALUES (?1, 10.0)",
         [old_id],
     )
     .unwrap();
     conn.execute(
-        "INSERT INTO heartbeat_cpu (heartbeat_id, usage_pct) VALUES (?1, 20.0)",
+        "INSERT INTO heartbeat_cpu (heartbeat_id, usage_percent) VALUES (?1, 20.0)",
         [new_id],
     )
     .unwrap();
@@ -189,7 +189,7 @@ fn test_heartbeat_cleanup_removes_all_child_tables_and_orphans() {
     let heartbeat_id = insert_heartbeat(&pool, "host-old", "2020-01-01T00:00:00Z");
     let conn = pool.get().unwrap();
     conn.execute(
-        "INSERT INTO heartbeat_cpu (heartbeat_id, usage_pct) VALUES (?1, 10.0)",
+        "INSERT INTO heartbeat_cpu (heartbeat_id, usage_percent) VALUES (?1, 10.0)",
         [heartbeat_id],
     )
     .unwrap();
@@ -199,12 +199,12 @@ fn test_heartbeat_cleanup_removes_all_child_tables_and_orphans() {
     )
     .unwrap();
     conn.execute(
-        "INSERT INTO heartbeat_disks (heartbeat_id, name) VALUES (?1, 'sda')",
+        "INSERT INTO heartbeat_disks (heartbeat_id, mountpoint) VALUES (?1, '/dev/sda')",
         [heartbeat_id],
     )
     .unwrap();
     conn.execute(
-        "INSERT INTO heartbeat_network (heartbeat_id, interface_name) VALUES (?1, 'eth0')",
+        "INSERT INTO heartbeat_network (heartbeat_id, interface) VALUES (?1, 'eth0')",
         [heartbeat_id],
     )
     .unwrap();
@@ -214,12 +214,12 @@ fn test_heartbeat_cleanup_removes_all_child_tables_and_orphans() {
     )
     .unwrap();
     conn.execute(
-        "INSERT INTO heartbeat_containers (heartbeat_id, reachable) VALUES (?1, 1)",
+        "INSERT INTO heartbeat_containers (heartbeat_id, running) VALUES (?1, 1)",
         [heartbeat_id],
     )
     .unwrap();
     conn.execute(
-        "INSERT INTO heartbeat_cpu (heartbeat_id, usage_pct) VALUES (999999, 99.0)",
+        "INSERT INTO heartbeat_cpu (heartbeat_id, usage_percent) VALUES (999999, 99.0)",
         [],
     )
     .unwrap();

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1078,86 +1078,71 @@ fn apply_migration_15_heartbeat(conn: &Connection) -> rusqlite::Result<()> {
             load1             REAL,
             load5             REAL,
             load15            REAL,
-            usage_pct         REAL,
-            user_pct          REAL,
-            system_pct        REAL,
-            iowait_pct        REAL,
-            steal_pct         REAL,
-            cpu_count         INTEGER,
-            metadata_json     TEXT
+            usage_percent     REAL,
+            steal_percent     REAL,
+            io_wait_percent   REAL
         );
         CREATE INDEX IF NOT EXISTS idx_heartbeat_cpu_heartbeat_id
             ON heartbeat_cpu(heartbeat_id);
 
         CREATE TABLE IF NOT EXISTS heartbeat_memory (
-            heartbeat_id          INTEGER NOT NULL,
-            total_bytes           INTEGER,
-            available_bytes       INTEGER,
-            used_bytes            INTEGER,
-            swap_total_bytes      INTEGER,
-            swap_used_bytes       INTEGER,
-            metadata_json         TEXT
+            heartbeat_id      INTEGER NOT NULL,
+            total_bytes       INTEGER,
+            available_bytes   INTEGER,
+            used_percent      REAL,
+            swap_total_bytes  INTEGER,
+            swap_used_bytes   INTEGER
         );
         CREATE INDEX IF NOT EXISTS idx_heartbeat_memory_heartbeat_id
             ON heartbeat_memory(heartbeat_id);
 
         CREATE TABLE IF NOT EXISTS heartbeat_disks (
-            heartbeat_id       INTEGER NOT NULL,
-            name               TEXT,
-            mount_point        TEXT,
-            fs_type            TEXT,
-            total_bytes        INTEGER,
-            free_bytes         INTEGER,
-            used_bytes         INTEGER,
-            inode_total        INTEGER,
-            inode_free         INTEGER,
-            read_only          INTEGER,
-            read_bytes_per_sec REAL,
-            write_bytes_per_sec REAL,
-            busy_pct           REAL,
-            metadata_json      TEXT
+            id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+            heartbeat_id        INTEGER NOT NULL,
+            mountpoint          TEXT,
+            filesystem          TEXT,
+            total_bytes         INTEGER,
+            available_bytes     INTEGER,
+            used_percent        REAL,
+            read_bytes_per_sec  REAL,
+            write_bytes_per_sec REAL
         );
         CREATE INDEX IF NOT EXISTS idx_heartbeat_disks_heartbeat_id
             ON heartbeat_disks(heartbeat_id);
 
         CREATE TABLE IF NOT EXISTS heartbeat_network (
-            heartbeat_id       INTEGER NOT NULL,
-            interface_name     TEXT NOT NULL,
-            rx_bytes_per_sec   REAL,
-            tx_bytes_per_sec   REAL,
-            rx_packets_per_sec REAL,
-            tx_packets_per_sec REAL,
-            rx_errors          INTEGER,
-            tx_errors          INTEGER,
-            rx_dropped         INTEGER,
-            tx_dropped         INTEGER,
-            link_up            INTEGER,
-            metadata_json      TEXT
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            heartbeat_id     INTEGER NOT NULL,
+            interface        TEXT NOT NULL,
+            rx_bytes_per_sec REAL,
+            tx_bytes_per_sec REAL,
+            rx_errors        INTEGER,
+            tx_errors        INTEGER
         );
         CREATE INDEX IF NOT EXISTS idx_heartbeat_network_heartbeat_id
             ON heartbeat_network(heartbeat_id);
 
         CREATE TABLE IF NOT EXISTS heartbeat_processes (
-            heartbeat_id       INTEGER NOT NULL,
-            total              INTEGER,
-            running            INTEGER,
-            sleeping           INTEGER,
-            zombie             INTEGER,
-            top_json           TEXT,
-            metadata_json      TEXT
+            heartbeat_id    INTEGER NOT NULL,
+            total           INTEGER,
+            running         INTEGER,
+            sleeping        INTEGER,
+            zombie          INTEGER,
+            top_cpu_json    TEXT,
+            top_memory_json TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_heartbeat_processes_heartbeat_id
             ON heartbeat_processes(heartbeat_id);
 
         CREATE TABLE IF NOT EXISTS heartbeat_containers (
-            heartbeat_id       INTEGER NOT NULL,
-            reachable          INTEGER NOT NULL DEFAULT 0,
-            running            INTEGER,
-            exited             INTEGER,
-            restarting         INTEGER,
-            unhealthy          INTEGER,
-            details_json       TEXT,
-            metadata_json      TEXT
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            heartbeat_id  INTEGER NOT NULL,
+            runtime       TEXT,
+            running       INTEGER,
+            stopped       INTEGER,
+            restarting    INTEGER,
+            unhealthy     INTEGER,
+            summary_json  TEXT
         );
         CREATE INDEX IF NOT EXISTS idx_heartbeat_containers_heartbeat_id
             ON heartbeat_containers(heartbeat_id);

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -9,7 +9,7 @@ use crate::config::StorageConfig;
 
 pub type DbPool = Pool<SqliteConnectionManager>;
 
-pub const KNOWN_SCHEMA_VERSION: i64 = 14;
+pub const KNOWN_SCHEMA_VERSION: i64 = 15;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SchemaVersionInfo {
@@ -599,6 +599,13 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
         );
     }
 
+    // Migration 15: heartbeat telemetry storage.
+    // Contract: docs/contracts/heartbeat-telemetry.md
+    if !migration_applied(&conn, 15)? {
+        apply_migration_15_heartbeat(&conn)?;
+        tracing::info!("Migration 15: created heartbeat telemetry tables and indexes");
+    }
+
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_logs_ai_project_time
              ON logs(ai_project, timestamp)
@@ -675,6 +682,121 @@ fn apply_migration_13(conn: &Connection) -> rusqlite::Result<()> {
              INSERT OR IGNORE INTO schema_migrations (version) VALUES (13);",
         )
     })();
+
+    match result {
+        Ok(()) => conn.execute_batch("COMMIT;"),
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK;");
+            Err(error)
+        }
+    }
+}
+
+fn apply_migration_15_heartbeat(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    let result = conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS host_heartbeats (
+             id             INTEGER PRIMARY KEY AUTOINCREMENT,
+             host_id        TEXT NOT NULL,
+             hostname       TEXT NOT NULL,
+             source_ip      TEXT NOT NULL DEFAULT '',
+             sampled_at     TEXT NOT NULL,
+             received_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+             boot_id        TEXT NOT NULL,
+             uptime_secs    INTEGER NOT NULL,
+             sequence       INTEGER NOT NULL,
+             collection_ms  INTEGER NOT NULL,
+             push_latency_ms INTEGER,
+             partial        INTEGER NOT NULL DEFAULT 0,
+             agent_version  TEXT NOT NULL,
+             os             TEXT NOT NULL,
+             kernel         TEXT,
+             architecture   TEXT NOT NULL,
+             metadata_json  TEXT,
+             UNIQUE(host_id, boot_id, sequence)
+         );
+         CREATE INDEX IF NOT EXISTS idx_host_heartbeats_host_sampled
+             ON host_heartbeats(host_id, sampled_at DESC);
+         CREATE INDEX IF NOT EXISTS idx_host_heartbeats_received
+             ON host_heartbeats(received_at DESC);
+         CREATE INDEX IF NOT EXISTS idx_host_heartbeats_hostname_sampled
+             ON host_heartbeats(hostname, sampled_at DESC);
+
+         CREATE TABLE IF NOT EXISTS heartbeat_cpu (
+             heartbeat_id       INTEGER PRIMARY KEY,
+             load1              REAL,
+             load5              REAL,
+             load15             REAL,
+             usage_percent      REAL,
+             steal_percent      REAL,
+             io_wait_percent    REAL
+         );
+         CREATE INDEX IF NOT EXISTS idx_heartbeat_cpu_heartbeat_id
+             ON heartbeat_cpu(heartbeat_id);
+
+         CREATE TABLE IF NOT EXISTS heartbeat_memory (
+             heartbeat_id        INTEGER PRIMARY KEY,
+             total_bytes         INTEGER,
+             available_bytes     INTEGER,
+             used_percent        REAL,
+             swap_total_bytes    INTEGER,
+             swap_used_bytes     INTEGER
+         );
+         CREATE INDEX IF NOT EXISTS idx_heartbeat_memory_heartbeat_id
+             ON heartbeat_memory(heartbeat_id);
+
+         CREATE TABLE IF NOT EXISTS heartbeat_disks (
+             id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+             heartbeat_id        INTEGER NOT NULL,
+             mountpoint          TEXT NOT NULL,
+             filesystem          TEXT,
+             total_bytes         INTEGER,
+             available_bytes     INTEGER,
+             used_percent        REAL,
+             read_bytes_per_sec  REAL,
+             write_bytes_per_sec REAL
+         );
+         CREATE INDEX IF NOT EXISTS idx_heartbeat_disks_heartbeat_id
+             ON heartbeat_disks(heartbeat_id);
+
+         CREATE TABLE IF NOT EXISTS heartbeat_network (
+             id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+             heartbeat_id        INTEGER NOT NULL,
+             interface           TEXT NOT NULL,
+             rx_bytes_per_sec    REAL,
+             tx_bytes_per_sec    REAL,
+             rx_errors           INTEGER,
+             tx_errors           INTEGER
+         );
+         CREATE INDEX IF NOT EXISTS idx_heartbeat_network_heartbeat_id
+             ON heartbeat_network(heartbeat_id);
+
+         CREATE TABLE IF NOT EXISTS heartbeat_processes (
+             heartbeat_id        INTEGER PRIMARY KEY,
+             total               INTEGER,
+             running             INTEGER,
+             sleeping            INTEGER,
+             zombie              INTEGER,
+             top_cpu_json        TEXT,
+             top_memory_json     TEXT
+         );
+         CREATE INDEX IF NOT EXISTS idx_heartbeat_processes_heartbeat_id
+             ON heartbeat_processes(heartbeat_id);
+
+         CREATE TABLE IF NOT EXISTS heartbeat_containers (
+             id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+             heartbeat_id        INTEGER NOT NULL,
+             runtime             TEXT NOT NULL,
+             running             INTEGER,
+             stopped             INTEGER,
+             unhealthy           INTEGER,
+             summary_json        TEXT
+         );
+         CREATE INDEX IF NOT EXISTS idx_heartbeat_containers_heartbeat_id
+             ON heartbeat_containers(heartbeat_id);
+
+         INSERT OR IGNORE INTO schema_migrations (version) VALUES (15);",
+    );
 
     match result {
         Ok(()) => conn.execute_batch("COMMIT;"),

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -606,6 +606,12 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
         tracing::info!("Migration 15: created heartbeat telemetry tables and indexes");
     }
 
+    // Migration 16: add restarting column to heartbeat_containers.
+    if !migration_applied(&conn, 16)? {
+        apply_migration_16_heartbeat_restarting(&conn)?;
+        tracing::info!("Migration 16: added restarting column to heartbeat_containers");
+    }
+
     conn.execute_batch(
         "CREATE INDEX IF NOT EXISTS idx_logs_ai_project_time
              ON logs(ai_project, timestamp)
@@ -798,6 +804,21 @@ fn apply_migration_15_heartbeat(conn: &Connection) -> rusqlite::Result<()> {
          INSERT OR IGNORE INTO schema_migrations (version) VALUES (15);",
     );
 
+    match result {
+        Ok(()) => conn.execute_batch("COMMIT;"),
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK;");
+            Err(error)
+        }
+    }
+}
+
+fn apply_migration_16_heartbeat_restarting(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch("BEGIN IMMEDIATE;")?;
+    let result = (|| {
+        add_column_if_missing(conn, "heartbeat_containers", "restarting", "INTEGER")?;
+        conn.execute_batch("INSERT OR IGNORE INTO schema_migrations (version) VALUES (16);")
+    })();
     match result {
         Ok(()) => conn.execute_batch("COMMIT;"),
         Err(error) => {

--- a/src/db/pool_tests.rs
+++ b/src/db/pool_tests.rs
@@ -61,6 +61,89 @@ fn test_init_pool_applies_busy_timeout_to_each_pooled_connection() {
 }
 
 #[test]
+fn init_db_creates_heartbeat_schema_migration_15() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("heartbeat.db");
+    let config = test_storage_config(db_path);
+
+    let pool = init_pool(&config).unwrap();
+    let conn = pool.get().unwrap();
+
+    let applied: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM schema_migrations WHERE version = 15",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(applied, 1);
+
+    for table in [
+        "host_heartbeats",
+        "heartbeat_cpu",
+        "heartbeat_memory",
+        "heartbeat_disks",
+        "heartbeat_network",
+        "heartbeat_processes",
+        "heartbeat_containers",
+    ] {
+        let exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                [table],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1, "missing heartbeat table {table}");
+    }
+
+    for index in [
+        "idx_host_heartbeats_host_sampled",
+        "idx_host_heartbeats_received",
+        "idx_host_heartbeats_hostname_sampled",
+        "idx_heartbeat_cpu_heartbeat_id",
+        "idx_heartbeat_memory_heartbeat_id",
+        "idx_heartbeat_disks_heartbeat_id",
+        "idx_heartbeat_network_heartbeat_id",
+        "idx_heartbeat_processes_heartbeat_id",
+        "idx_heartbeat_containers_heartbeat_id",
+    ] {
+        let exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                [index],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 1, "missing heartbeat index {index}");
+    }
+}
+
+#[test]
+fn heartbeat_schema_enforces_idempotency_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("heartbeat-unique.db");
+    let config = test_storage_config(db_path);
+
+    let pool = init_pool(&config).unwrap();
+    let conn = pool.get().unwrap();
+
+    let insert = "INSERT INTO host_heartbeats (
+        host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+        uptime_secs, sequence, collection_ms, partial, agent_version, os, architecture
+    ) VALUES (
+        'host-1', 'box-a', '127.0.0.1:3100', '2026-05-25T00:00:00Z',
+        '2026-05-25T00:00:01Z', 'boot-a', 60, 1, 12, 0, '0.1.0', 'linux', 'x86_64'
+    )";
+    conn.execute(insert, []).unwrap();
+    let duplicate = conn.execute(insert, []);
+    assert!(
+        duplicate.is_err(),
+        "duplicate heartbeat key must be rejected"
+    );
+}
+
+#[test]
 fn init_db_adds_ai_session_metadata_columns() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("test.db");

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -67,7 +67,7 @@ async fn heartbeat_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> axum::response::Response {
-    if !is_authorized(&state, &headers) {
+    if !is_authorized(&state, &peer, &headers) {
         return unauthorized();
     }
 
@@ -102,9 +102,9 @@ async fn heartbeat_handler(
     }
 }
 
-fn is_authorized(state: &HeartbeatState, headers: &HeaderMap) -> bool {
+fn is_authorized(state: &HeartbeatState, peer: &SocketAddr, headers: &HeaderMap) -> bool {
     if matches!(state.auth_policy, AuthPolicy::LoopbackDev) {
-        return true;
+        return peer.ip().is_loopback();
     }
     let Some(expected) = state.api_token.as_deref() else {
         return false;
@@ -314,7 +314,10 @@ fn insert_metric_rows(
                 processes.running,
                 processes.sleeping,
                 processes.zombies,
-                serde_json::to_string(&processes.top).ok(),
+                Some(
+                    serde_json::to_string(&processes.top)
+                        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
+                ),
             ],
         )?;
     }
@@ -330,7 +333,10 @@ fn insert_metric_rows(
                 containers.running,
                 containers.exited + containers.restarting,
                 containers.unhealthy,
-                serde_json::to_string(&containers.details).ok(),
+                Some(
+                    serde_json::to_string(&containers.details)
+                        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?,
+                ),
             ],
         )?;
     }
@@ -349,7 +355,7 @@ struct HeartbeatIngestResponse {
 #[serde(deny_unknown_fields)]
 struct HeartbeatRequest {
     #[serde(default = "default_schema_version")]
-    schema_version: i64,
+    schema_version: u8,
     host: HeartbeatHost,
     sample: HeartbeatSample,
     agent: HeartbeatAgent,
@@ -369,7 +375,7 @@ struct HeartbeatRequest {
     gpu: Option<serde_json::Value>,
 }
 
-fn default_schema_version() -> i64 {
+fn default_schema_version() -> u8 {
     1
 }
 
@@ -462,8 +468,6 @@ struct HeartbeatDisk {
     read_bytes_per_sec: Option<f64>,
     #[serde(default)]
     write_bytes_per_sec: Option<f64>,
-    #[serde(flatten)]
-    extra: serde_json::Map<String, serde_json::Value>,
 }
 
 impl HeartbeatDisk {
@@ -491,8 +495,6 @@ struct HeartbeatNetwork {
     rx_errors_per_sec: Option<f64>,
     #[serde(default)]
     tx_errors_per_sec: Option<f64>,
-    #[serde(flatten)]
-    extra: serde_json::Map<String, serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -197,6 +197,7 @@ fn insert_heartbeat(
 
 fn heartbeat_metadata_json(request: &HeartbeatRequest) -> anyhow::Result<String> {
     Ok(serde_json::to_string(&json!({
+        "schema_version": request.schema_version,
         "host": {
             "timezone": request.host.timezone,
         },
@@ -214,7 +215,7 @@ fn heartbeat_metadata_json(request: &HeartbeatRequest) -> anyhow::Result<String>
         "cpu": request.cpu,
         "memory": request.memory,
         "disks": request.disks,
-        "network": request.network,
+        "networks": request.networks,
         "processes": request.processes,
         "containers": request.containers,
     }))?)
@@ -286,7 +287,7 @@ fn insert_metric_rows(
         )?;
     }
 
-    for net in &request.network {
+    for net in &request.networks {
         tx.execute(
             "INSERT INTO heartbeat_network (
                  heartbeat_id, interface, rx_bytes_per_sec, tx_bytes_per_sec, rx_errors, tx_errors
@@ -347,6 +348,8 @@ struct HeartbeatIngestResponse {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct HeartbeatRequest {
+    #[serde(default = "default_schema_version")]
+    schema_version: i64,
     host: HeartbeatHost,
     sample: HeartbeatSample,
     agent: HeartbeatAgent,
@@ -356,14 +359,18 @@ struct HeartbeatRequest {
     memory: Option<HeartbeatMemory>,
     #[serde(default)]
     disks: Vec<HeartbeatDisk>,
-    #[serde(default)]
-    network: Vec<HeartbeatNetwork>,
+    #[serde(default, alias = "network")]
+    networks: Vec<HeartbeatNetwork>,
     #[serde(default)]
     processes: Option<HeartbeatProcesses>,
     #[serde(default)]
     containers: Option<HeartbeatContainers>,
     #[serde(default)]
     gpu: Option<serde_json::Value>,
+}
+
+fn default_schema_version() -> i64 {
+    1
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -325,13 +325,14 @@ fn insert_metric_rows(
     if let Some(containers) = &request.containers {
         tx.execute(
             "INSERT INTO heartbeat_containers (
-                 heartbeat_id, runtime, running, stopped, unhealthy, summary_json
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                 heartbeat_id, runtime, running, stopped, restarting, unhealthy, summary_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             params![
                 heartbeat_id,
                 containers.runtime.as_deref().unwrap_or("docker"),
                 containers.running,
-                containers.exited + containers.restarting,
+                containers.exited,
+                containers.restarting,
                 containers.unhealthy,
                 Some(
                     serde_json::to_string(&containers.details)

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -1,0 +1,520 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    extract::{ConnectInfo, State},
+    http::{HeaderMap, StatusCode},
+    middleware::{from_fn, Next},
+    response::{IntoResponse, Json},
+    routing::post,
+    Router,
+};
+use bytes::Bytes;
+use lab_auth::middleware::{parse_bearer_token, tokens_equal};
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tower_http::limit::RequestBodyLimitLayer;
+
+use crate::db::DbPool;
+use crate::mcp::AuthPolicy;
+
+pub const HEARTBEAT_BODY_LIMIT_BYTES: usize = 256 * 1024;
+
+#[derive(Clone)]
+pub struct HeartbeatState {
+    pool: Arc<DbPool>,
+    api_token: Option<String>,
+    auth_policy: AuthPolicy,
+}
+
+impl HeartbeatState {
+    pub fn new(pool: Arc<DbPool>, api_token: Option<String>, auth_policy: AuthPolicy) -> Self {
+        Self {
+            pool,
+            api_token,
+            auth_policy,
+        }
+    }
+}
+
+pub fn router(state: HeartbeatState) -> Router {
+    Router::new()
+        .route("/v1/heartbeats", post(heartbeat_handler))
+        .layer(RequestBodyLimitLayer::new(HEARTBEAT_BODY_LIMIT_BYTES))
+        .layer(from_fn(json_payload_too_large))
+        .with_state(state)
+}
+
+async fn json_payload_too_large(
+    req: axum::extract::Request,
+    next: Next,
+) -> axum::response::Response {
+    let response = next.run(req).await;
+    if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(json!({"error": "payload_too_large"})),
+        )
+            .into_response();
+    }
+    response
+}
+
+async fn heartbeat_handler(
+    State(state): State<HeartbeatState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> axum::response::Response {
+    if !is_authorized(&state, &headers) {
+        return unauthorized();
+    }
+
+    let request: HeartbeatRequest = match serde_json::from_slice(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"error": "invalid_payload", "message": error.to_string()})),
+            )
+                .into_response();
+        }
+    };
+
+    let pool = Arc::clone(&state.pool);
+    let source_ip = peer.to_string();
+    let result = tokio::task::spawn_blocking(move || insert_heartbeat(&pool, request, &source_ip))
+        .await
+        .map_err(|error| anyhow::anyhow!("heartbeat insert task failed: {error}"))
+        .and_then(|result| result);
+
+    match result {
+        Ok(response) => (StatusCode::ACCEPTED, Json(response)).into_response(),
+        Err(error) => {
+            tracing::error!(error = %error, "heartbeat ingest failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "internal_error"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+fn is_authorized(state: &HeartbeatState, headers: &HeaderMap) -> bool {
+    if matches!(state.auth_policy, AuthPolicy::LoopbackDev) {
+        return true;
+    }
+    let Some(expected) = state.api_token.as_deref() else {
+        return false;
+    };
+    let Some(auth) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    parse_bearer_token(auth).is_some_and(|token| tokens_equal(&token, expected))
+}
+
+fn unauthorized() -> axum::response::Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({"error": "unauthorized"})),
+    )
+        .into_response()
+}
+
+fn insert_heartbeat(
+    pool: &DbPool,
+    request: HeartbeatRequest,
+    source_ip: &str,
+) -> anyhow::Result<HeartbeatIngestResponse> {
+    let received_at = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let mut conn = pool.get()?;
+    let tx = conn.transaction()?;
+    let metadata_json = heartbeat_metadata_json(&request)?;
+
+    tx.execute(
+        "INSERT OR IGNORE INTO host_heartbeats (
+             host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+             uptime_secs, sequence, collection_ms, push_latency_ms, partial,
+             agent_version, os, kernel, architecture, metadata_json
+         ) VALUES (
+             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16
+         )",
+        params![
+            request.host.host_id,
+            request.host.hostname,
+            source_ip,
+            request.sample.sampled_at,
+            received_at,
+            request.host.boot_id,
+            request.sample.uptime_secs,
+            request.sample.sequence,
+            request.sample.collection_ms,
+            request.agent.push_latency_ms,
+            request.sample.partial as i64,
+            request.agent.version,
+            request.host.os,
+            request.host.kernel,
+            request.host.architecture,
+            metadata_json,
+        ],
+    )?;
+
+    let heartbeat_id = if tx.changes() == 0 {
+        let id: i64 = tx.query_row(
+            "SELECT id FROM host_heartbeats
+             WHERE host_id = ?1 AND boot_id = ?2 AND sequence = ?3",
+            params![
+                request.host.host_id,
+                request.host.boot_id,
+                request.sample.sequence
+            ],
+            |row| row.get(0),
+        )?;
+        tx.commit()?;
+        return Ok(HeartbeatIngestResponse {
+            accepted: 0,
+            heartbeat_id: id,
+            received_at,
+        });
+    } else {
+        tx.last_insert_rowid()
+    };
+
+    insert_metric_rows(&tx, heartbeat_id, &request)?;
+    tx.commit()?;
+
+    Ok(HeartbeatIngestResponse {
+        accepted: 1,
+        heartbeat_id,
+        received_at,
+    })
+}
+
+fn heartbeat_metadata_json(request: &HeartbeatRequest) -> anyhow::Result<String> {
+    Ok(serde_json::to_string(&json!({
+        "host": {
+            "timezone": request.host.timezone,
+        },
+        "sample": {
+            "monotonic_ms": request.sample.monotonic_ms,
+            "probe_errors": request.sample.probe_errors,
+            "skipped_probes": request.sample.skipped_probes,
+        },
+        "agent": {
+            "mode": request.agent.mode,
+            "interval_secs": request.agent.interval_secs,
+            "retry_backlog": request.agent.retry_backlog,
+        },
+        "gpu": request.gpu,
+        "cpu": request.cpu,
+        "memory": request.memory,
+        "disks": request.disks,
+        "network": request.network,
+        "processes": request.processes,
+        "containers": request.containers,
+    }))?)
+}
+
+fn insert_metric_rows(
+    tx: &rusqlite::Transaction<'_>,
+    heartbeat_id: i64,
+    request: &HeartbeatRequest,
+) -> rusqlite::Result<()> {
+    if let Some(cpu) = &request.cpu {
+        tx.execute(
+            "INSERT INTO heartbeat_cpu (
+                 heartbeat_id, load1, load5, load15, usage_percent, steal_percent, io_wait_percent
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                heartbeat_id,
+                cpu.load1,
+                cpu.load5,
+                cpu.load15,
+                cpu.usage_pct,
+                cpu.steal_pct,
+                cpu.iowait_pct,
+            ],
+        )?;
+    }
+
+    if let Some(memory) = &request.memory {
+        let used_percent = if memory.mem_total_bytes > 0 {
+            let used = memory
+                .mem_total_bytes
+                .saturating_sub(memory.mem_available_bytes);
+            Some((used as f64 / memory.mem_total_bytes as f64) * 100.0)
+        } else {
+            None
+        };
+        tx.execute(
+            "INSERT INTO heartbeat_memory (
+                 heartbeat_id, total_bytes, available_bytes, used_percent,
+                 swap_total_bytes, swap_used_bytes
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                heartbeat_id,
+                memory.mem_total_bytes,
+                memory.mem_available_bytes,
+                used_percent,
+                memory.swap_total_bytes,
+                memory.swap_used_bytes,
+            ],
+        )?;
+    }
+
+    for disk in &request.disks {
+        tx.execute(
+            "INSERT INTO heartbeat_disks (
+                 heartbeat_id, mountpoint, filesystem, total_bytes, available_bytes,
+                 used_percent, read_bytes_per_sec, write_bytes_per_sec
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                heartbeat_id,
+                disk.name,
+                disk.fs_type,
+                disk.bytes_total,
+                disk.bytes_free,
+                disk.used_percent(),
+                disk.read_bytes_per_sec,
+                disk.write_bytes_per_sec,
+            ],
+        )?;
+    }
+
+    for net in &request.network {
+        tx.execute(
+            "INSERT INTO heartbeat_network (
+                 heartbeat_id, interface, rx_bytes_per_sec, tx_bytes_per_sec, rx_errors, tx_errors
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                heartbeat_id,
+                net.interface,
+                net.rx_bytes_per_sec,
+                net.tx_bytes_per_sec,
+                net.rx_errors_per_sec.map(|value| value.round() as i64),
+                net.tx_errors_per_sec.map(|value| value.round() as i64),
+            ],
+        )?;
+    }
+
+    if let Some(processes) = &request.processes {
+        tx.execute(
+            "INSERT INTO heartbeat_processes (
+                 heartbeat_id, total, running, sleeping, zombie, top_cpu_json, top_memory_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL)",
+            params![
+                heartbeat_id,
+                processes.total,
+                processes.running,
+                processes.sleeping,
+                processes.zombies,
+                serde_json::to_string(&processes.top).ok(),
+            ],
+        )?;
+    }
+
+    if let Some(containers) = &request.containers {
+        tx.execute(
+            "INSERT INTO heartbeat_containers (
+                 heartbeat_id, runtime, running, stopped, unhealthy, summary_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                heartbeat_id,
+                containers.runtime.as_deref().unwrap_or("docker"),
+                containers.running,
+                containers.exited + containers.restarting,
+                containers.unhealthy,
+                serde_json::to_string(&containers.details).ok(),
+            ],
+        )?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct HeartbeatIngestResponse {
+    accepted: u32,
+    heartbeat_id: i64,
+    received_at: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatRequest {
+    host: HeartbeatHost,
+    sample: HeartbeatSample,
+    agent: HeartbeatAgent,
+    #[serde(default)]
+    cpu: Option<HeartbeatCpu>,
+    #[serde(default)]
+    memory: Option<HeartbeatMemory>,
+    #[serde(default)]
+    disks: Vec<HeartbeatDisk>,
+    #[serde(default)]
+    network: Vec<HeartbeatNetwork>,
+    #[serde(default)]
+    processes: Option<HeartbeatProcesses>,
+    #[serde(default)]
+    containers: Option<HeartbeatContainers>,
+    #[serde(default)]
+    gpu: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatHost {
+    host_id: String,
+    hostname: String,
+    os: String,
+    #[serde(default)]
+    kernel: Option<String>,
+    architecture: String,
+    boot_id: String,
+    #[serde(default)]
+    timezone: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatSample {
+    sequence: i64,
+    sampled_at: String,
+    uptime_secs: i64,
+    #[serde(default)]
+    monotonic_ms: Option<i64>,
+    collection_ms: i64,
+    partial: bool,
+    #[serde(default)]
+    probe_errors: Vec<String>,
+    #[serde(default)]
+    skipped_probes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatAgent {
+    version: String,
+    mode: String,
+    interval_secs: i64,
+    #[serde(default)]
+    push_latency_ms: Option<i64>,
+    #[serde(default)]
+    retry_backlog: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatCpu {
+    load1: f64,
+    load5: f64,
+    load15: f64,
+    #[serde(default)]
+    usage_pct: Option<f64>,
+    #[serde(default)]
+    user_pct: Option<f64>,
+    #[serde(default)]
+    system_pct: Option<f64>,
+    #[serde(default)]
+    iowait_pct: Option<f64>,
+    #[serde(default)]
+    steal_pct: Option<f64>,
+    core_count: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatMemory {
+    mem_total_bytes: i64,
+    mem_available_bytes: i64,
+    #[serde(default)]
+    mem_used_bytes: Option<i64>,
+    swap_total_bytes: i64,
+    swap_used_bytes: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatDisk {
+    kind: String,
+    name: String,
+    #[serde(default)]
+    fs_type: Option<String>,
+    #[serde(default)]
+    bytes_total: Option<i64>,
+    #[serde(default)]
+    bytes_free: Option<i64>,
+    #[serde(default)]
+    bytes_used: Option<i64>,
+    #[serde(default)]
+    read_bytes_per_sec: Option<f64>,
+    #[serde(default)]
+    write_bytes_per_sec: Option<f64>,
+    #[serde(flatten)]
+    extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl HeartbeatDisk {
+    fn used_percent(&self) -> Option<f64> {
+        let total = self.bytes_total?;
+        if total <= 0 {
+            return None;
+        }
+        let used = self
+            .bytes_used
+            .or_else(|| self.bytes_free.map(|free| total.saturating_sub(free)))?;
+        Some((used as f64 / total as f64) * 100.0)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatNetwork {
+    interface: String,
+    #[serde(default)]
+    rx_bytes_per_sec: Option<f64>,
+    #[serde(default)]
+    tx_bytes_per_sec: Option<f64>,
+    #[serde(default)]
+    rx_errors_per_sec: Option<f64>,
+    #[serde(default)]
+    tx_errors_per_sec: Option<f64>,
+    #[serde(flatten)]
+    extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatProcesses {
+    total: i64,
+    #[serde(default)]
+    running: Option<i64>,
+    #[serde(default)]
+    sleeping: Option<i64>,
+    zombies: i64,
+    #[serde(default)]
+    top: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct HeartbeatContainers {
+    #[serde(default)]
+    runtime: Option<String>,
+    reachable: bool,
+    running: i64,
+    exited: i64,
+    restarting: i64,
+    unhealthy: i64,
+    #[serde(default)]
+    details: Vec<serde_json::Value>,
+}
+
+#[cfg(test)]
+#[path = "heartbeat_tests.rs"]
+mod tests;

--- a/src/heartbeat_agent.rs
+++ b/src/heartbeat_agent.rs
@@ -1,7 +1,13 @@
 use std::collections::VecDeque;
+use std::ffi::CString;
+use std::fs;
 use std::future::Future;
+use std::io::{BufRead, BufReader};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -199,6 +205,36 @@ impl HeartbeatCollector {
                 Box::new(FakeProbe::processes()),
                 Box::new(FakeProbe::containers()),
             ],
+            started: Instant::now(),
+        }
+    }
+
+    pub fn linux() -> Self {
+        let mut probes: Vec<Box<dyn HeartbeatProbe>> = vec![
+            Box::new(LinuxCpuProbe),
+            Box::new(LinuxMemoryProbe),
+            Box::new(LinuxProcessProbe),
+            Box::new(LinuxContainerProbe),
+        ];
+
+        for mount in discover_mounts().into_iter().take(8) {
+            probes.push(Box::new(LinuxDiskCapacityProbe { mount }));
+        }
+        for device in discover_disk_devices().into_iter().take(8) {
+            probes.push(Box::new(LinuxDiskIoProbe {
+                device,
+                previous: Mutex::new(None),
+            }));
+        }
+        for interface in discover_network_interfaces().into_iter().take(16) {
+            probes.push(Box::new(LinuxNetworkProbe {
+                interface,
+                previous: Mutex::new(None),
+            }));
+        }
+
+        Self {
+            probes,
             started: Instant::now(),
         }
     }
@@ -435,6 +471,593 @@ impl HeartbeatProbe for FakeProbe {
     }
 }
 
+#[derive(Debug, Clone)]
+struct MountProbeTarget {
+    path: PathBuf,
+    fs_type: Option<String>,
+}
+
+struct LinuxCpuProbe;
+
+impl HeartbeatProbe for LinuxCpuProbe {
+    fn name(&self) -> &'static str {
+        "cpu"
+    }
+
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
+        Box::pin(async {
+            let raw = fs::read_to_string("/proc/loadavg").context("read /proc/loadavg")?;
+            let (load1, load5, load15) = parse_loadavg(&raw)?;
+            Ok(ProbeOutput::Cpu(HeartbeatCpu {
+                load1,
+                load5,
+                load15,
+                usage_pct: None,
+                user_pct: None,
+                system_pct: None,
+                iowait_pct: None,
+                steal_pct: None,
+                core_count: std::thread::available_parallelism()
+                    .map(|count| count.get() as i64)
+                    .unwrap_or(1),
+            }))
+        })
+    }
+}
+
+struct LinuxMemoryProbe;
+
+impl HeartbeatProbe for LinuxMemoryProbe {
+    fn name(&self) -> &'static str {
+        "memory"
+    }
+
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
+        Box::pin(async {
+            let raw = fs::read_to_string("/proc/meminfo").context("read /proc/meminfo")?;
+            Ok(ProbeOutput::Memory(parse_meminfo(&raw)?))
+        })
+    }
+}
+
+struct LinuxDiskCapacityProbe {
+    mount: MountProbeTarget,
+}
+
+impl HeartbeatProbe for LinuxDiskCapacityProbe {
+    fn name(&self) -> &'static str {
+        "disk_capacity"
+    }
+
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
+        Box::pin(async move {
+            let (bytes_total, bytes_free) = statvfs_bytes(&self.mount.path)?;
+            Ok(ProbeOutput::Disk(HeartbeatDisk {
+                kind: "mount".to_string(),
+                name: self.mount.path.display().to_string(),
+                fs_type: self.mount.fs_type.clone(),
+                bytes_total: Some(bytes_total),
+                bytes_free: Some(bytes_free),
+                bytes_used: Some(bytes_total.saturating_sub(bytes_free)),
+                read_bytes_per_sec: None,
+                write_bytes_per_sec: None,
+            }))
+        })
+    }
+}
+
+struct LinuxDiskIoProbe {
+    device: String,
+    previous: Mutex<Option<DiskRateState>>,
+}
+
+impl HeartbeatProbe for LinuxDiskIoProbe {
+    fn name(&self) -> &'static str {
+        "disk_io"
+    }
+
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
+        Box::pin(async move {
+            let now = Instant::now();
+            let raw = fs::read_to_string("/proc/diskstats").context("read /proc/diskstats")?;
+            let Some((read_bytes, write_bytes)) = parse_diskstats_device(&raw, &self.device) else {
+                bail!("device {} not found in /proc/diskstats", self.device);
+            };
+            let (read_rate, write_rate) = rate_pair(&self.previous, now, read_bytes, write_bytes)?;
+            Ok(ProbeOutput::Disk(HeartbeatDisk {
+                kind: "block_io".to_string(),
+                name: self.device.clone(),
+                fs_type: None,
+                bytes_total: None,
+                bytes_free: None,
+                bytes_used: None,
+                read_bytes_per_sec: read_rate,
+                write_bytes_per_sec: write_rate,
+            }))
+        })
+    }
+}
+
+struct LinuxNetworkProbe {
+    interface: String,
+    previous: Mutex<Option<NetworkRateState>>,
+}
+
+impl HeartbeatProbe for LinuxNetworkProbe {
+    fn name(&self) -> &'static str {
+        "network"
+    }
+
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
+        Box::pin(async move {
+            let now = Instant::now();
+            let raw = fs::read_to_string("/proc/net/dev").context("read /proc/net/dev")?;
+            let Some(counters) = parse_network_interface(&raw, &self.interface)? else {
+                bail!("interface {} not found in /proc/net/dev", self.interface);
+            };
+            let rates = network_rates(&self.previous, now, counters)?;
+            Ok(ProbeOutput::Network(HeartbeatNetwork {
+                interface: self.interface.clone(),
+                rx_bytes_per_sec: rates.rx_bytes_per_sec,
+                tx_bytes_per_sec: rates.tx_bytes_per_sec,
+                rx_errors_per_sec: rates.rx_errors_per_sec,
+                tx_errors_per_sec: rates.tx_errors_per_sec,
+            }))
+        })
+    }
+}
+
+struct LinuxProcessProbe;
+
+impl HeartbeatProbe for LinuxProcessProbe {
+    fn name(&self) -> &'static str {
+        "processes"
+    }
+
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
+        Box::pin(async { Ok(ProbeOutput::Processes(collect_process_counts()?)) })
+    }
+}
+
+struct LinuxContainerProbe;
+
+impl HeartbeatProbe for LinuxContainerProbe {
+    fn name(&self) -> &'static str {
+        "containers"
+    }
+
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
+        Box::pin(async {
+            let output = tokio::process::Command::new("docker")
+                .args(["ps", "-a", "--format", "{{.State}}"])
+                .output()
+                .await;
+            Ok(ProbeOutput::Containers(match output {
+                Ok(output) if output.status.success() => {
+                    parse_docker_states(&String::from_utf8_lossy(&output.stdout))
+                }
+                _ => HeartbeatContainers {
+                    runtime: Some("docker".to_string()),
+                    reachable: false,
+                    running: 0,
+                    exited: 0,
+                    restarting: 0,
+                    unhealthy: 0,
+                    details: Vec::new(),
+                },
+            }))
+        })
+    }
+}
+
+fn parse_loadavg(raw: &str) -> Result<(f64, f64, f64)> {
+    let mut parts = raw.split_whitespace();
+    let load1 = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing load1"))?
+        .parse::<f64>()?;
+    let load5 = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing load5"))?
+        .parse::<f64>()?;
+    let load15 = parts
+        .next()
+        .ok_or_else(|| anyhow!("missing load15"))?
+        .parse::<f64>()?;
+    Ok((load1, load5, load15))
+}
+
+fn parse_meminfo(raw: &str) -> Result<HeartbeatMemory> {
+    let mut mem_total = None;
+    let mut mem_available = None;
+    let mut swap_total = 0;
+    let mut swap_free = 0;
+    for line in raw.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(key) = parts.next() else {
+            continue;
+        };
+        let Some(value) = parts.next().and_then(|value| value.parse::<i64>().ok()) else {
+            continue;
+        };
+        let bytes = value.saturating_mul(1024);
+        match key.trim_end_matches(':') {
+            "MemTotal" => mem_total = Some(bytes),
+            "MemAvailable" => mem_available = Some(bytes),
+            "SwapTotal" => swap_total = bytes,
+            "SwapFree" => swap_free = bytes,
+            _ => {}
+        }
+    }
+    let mem_total_bytes = mem_total.ok_or_else(|| anyhow!("MemTotal missing from meminfo"))?;
+    let mem_available_bytes =
+        mem_available.ok_or_else(|| anyhow!("MemAvailable missing from meminfo"))?;
+    Ok(HeartbeatMemory {
+        mem_total_bytes,
+        mem_available_bytes,
+        mem_used_bytes: Some(mem_total_bytes.saturating_sub(mem_available_bytes)),
+        swap_total_bytes: swap_total,
+        swap_used_bytes: swap_total.saturating_sub(swap_free),
+    })
+}
+
+fn discover_mounts() -> Vec<MountProbeTarget> {
+    let file = match fs::File::open("/proc/self/mounts") {
+        Ok(file) => file,
+        Err(_) => return Vec::new(),
+    };
+    let mut mounts = Vec::new();
+    for line in BufReader::new(file)
+        .lines()
+        .map_while(std::result::Result::ok)
+    {
+        let mut parts = line.split_whitespace();
+        let _source = parts.next();
+        let Some(mount_path) = parts.next() else {
+            continue;
+        };
+        let Some(fs_type) = parts.next() else {
+            continue;
+        };
+        if is_pseudo_fs(fs_type) {
+            continue;
+        }
+        let path = PathBuf::from(unescape_mount_path(mount_path));
+        if mounts
+            .iter()
+            .any(|mount: &MountProbeTarget| mount.path == path)
+        {
+            continue;
+        }
+        mounts.push(MountProbeTarget {
+            path,
+            fs_type: Some(fs_type.to_string()),
+        });
+    }
+    mounts
+}
+
+fn is_pseudo_fs(fs_type: &str) -> bool {
+    matches!(
+        fs_type,
+        "autofs"
+            | "binfmt_misc"
+            | "bpf"
+            | "cgroup"
+            | "cgroup2"
+            | "configfs"
+            | "debugfs"
+            | "devpts"
+            | "devtmpfs"
+            | "fusectl"
+            | "hugetlbfs"
+            | "mqueue"
+            | "proc"
+            | "pstore"
+            | "securityfs"
+            | "sysfs"
+            | "tmpfs"
+            | "tracefs"
+    )
+}
+
+fn unescape_mount_path(value: &str) -> String {
+    value
+        .replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
+}
+
+fn statvfs_bytes(path: &Path) -> Result<(i64, i64)> {
+    #[cfg(unix)]
+    {
+        let c_path = CString::new(path.as_os_str().as_bytes())?;
+        let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+        let rc = unsafe { libc::statvfs(c_path.as_ptr(), stat.as_mut_ptr()) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("statvfs {}", path.display()));
+        }
+        let stat = unsafe { stat.assume_init() };
+        let block_size = stat.f_frsize as u128;
+        let total = (stat.f_blocks as u128).saturating_mul(block_size);
+        let free = (stat.f_bavail as u128).saturating_mul(block_size);
+        Ok((clamp_u128_to_i64(total), clamp_u128_to_i64(free)))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        bail!("statvfs is only available on unix")
+    }
+}
+
+fn discover_disk_devices() -> Vec<String> {
+    let raw = match fs::read_to_string("/proc/diskstats") {
+        Ok(raw) => raw,
+        Err(_) => return Vec::new(),
+    };
+    raw.lines()
+        .filter_map(|line| line.split_whitespace().nth(2))
+        .filter(|name| is_disk_device_name(name))
+        .map(ToString::to_string)
+        .take(8)
+        .collect()
+}
+
+fn is_disk_device_name(name: &str) -> bool {
+    !(name.starts_with("loop")
+        || name.starts_with("ram")
+        || name.starts_with("fd")
+        || name.chars().last().is_some_and(|ch| ch.is_ascii_digit()))
+}
+
+fn parse_diskstats_device(raw: &str, device: &str) -> Option<(i64, i64)> {
+    for line in raw.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 14 || parts[2] != device {
+            continue;
+        }
+        let sectors_read = parts.get(5)?.parse::<u128>().ok()?;
+        let sectors_written = parts.get(9)?.parse::<u128>().ok()?;
+        return Some((
+            clamp_u128_to_i64(sectors_read.saturating_mul(512)),
+            clamp_u128_to_i64(sectors_written.saturating_mul(512)),
+        ));
+    }
+    None
+}
+
+fn discover_network_interfaces() -> Vec<String> {
+    let raw = match fs::read_to_string("/proc/net/dev") {
+        Ok(raw) => raw,
+        Err(_) => return Vec::new(),
+    };
+    raw.lines()
+        .skip(2)
+        .filter_map(|line| line.split_once(':').map(|(name, _)| name.trim()))
+        .filter(|name| !name.is_empty() && *name != "lo")
+        .map(ToString::to_string)
+        .take(16)
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NetworkCounters {
+    rx_bytes: i64,
+    tx_bytes: i64,
+    rx_errors: i64,
+    tx_errors: i64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DiskRateState {
+    sampled_at: Instant,
+    read_bytes: i64,
+    write_bytes: i64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NetworkRateState {
+    sampled_at: Instant,
+    counters: NetworkCounters,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct NetworkRates {
+    rx_bytes_per_sec: Option<f64>,
+    tx_bytes_per_sec: Option<f64>,
+    rx_errors_per_sec: Option<f64>,
+    tx_errors_per_sec: Option<f64>,
+}
+
+fn parse_network_interface(raw: &str, interface: &str) -> Result<Option<NetworkCounters>> {
+    for line in raw.lines().skip(2) {
+        let Some((name, values)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim() != interface {
+            continue;
+        }
+        let parts: Vec<&str> = values.split_whitespace().collect();
+        if parts.len() < 16 {
+            bail!("malformed /proc/net/dev row for {interface}");
+        }
+        return Ok(Some(NetworkCounters {
+            rx_bytes: clamp_u128_to_i64(parts[0].parse::<u128>()?),
+            tx_bytes: clamp_u128_to_i64(parts[8].parse::<u128>()?),
+            rx_errors: clamp_u128_to_i64(parts[2].parse::<u128>()?),
+            tx_errors: clamp_u128_to_i64(parts[10].parse::<u128>()?),
+        }));
+    }
+    Ok(None)
+}
+
+fn rate_pair(
+    previous: &Mutex<Option<DiskRateState>>,
+    now: Instant,
+    first: i64,
+    second: i64,
+) -> Result<(Option<f64>, Option<f64>)> {
+    let mut guard = previous
+        .lock()
+        .map_err(|_| anyhow!("heartbeat probe state lock poisoned"))?;
+    let rates = guard.map(|last| {
+        let elapsed = now.saturating_duration_since(last.sampled_at).as_secs_f64();
+        if elapsed <= 0.0 {
+            return (None, None);
+        }
+        (
+            Some(first.saturating_sub(last.read_bytes).max(0) as f64 / elapsed),
+            Some(second.saturating_sub(last.write_bytes).max(0) as f64 / elapsed),
+        )
+    });
+    *guard = Some(DiskRateState {
+        sampled_at: now,
+        read_bytes: first,
+        write_bytes: second,
+    });
+    Ok(rates.unwrap_or((None, None)))
+}
+
+fn network_rates(
+    previous: &Mutex<Option<NetworkRateState>>,
+    now: Instant,
+    current: NetworkCounters,
+) -> Result<NetworkRates> {
+    let mut guard = previous
+        .lock()
+        .map_err(|_| anyhow!("heartbeat probe state lock poisoned"))?;
+    let rates = guard.map(|last| {
+        let elapsed = now.saturating_duration_since(last.sampled_at).as_secs_f64();
+        if elapsed <= 0.0 {
+            return NetworkRates {
+                rx_bytes_per_sec: None,
+                tx_bytes_per_sec: None,
+                rx_errors_per_sec: None,
+                tx_errors_per_sec: None,
+            };
+        }
+        NetworkRates {
+            rx_bytes_per_sec: Some(
+                current
+                    .rx_bytes
+                    .saturating_sub(last.counters.rx_bytes)
+                    .max(0) as f64
+                    / elapsed,
+            ),
+            tx_bytes_per_sec: Some(
+                current
+                    .tx_bytes
+                    .saturating_sub(last.counters.tx_bytes)
+                    .max(0) as f64
+                    / elapsed,
+            ),
+            rx_errors_per_sec: Some(
+                current
+                    .rx_errors
+                    .saturating_sub(last.counters.rx_errors)
+                    .max(0) as f64
+                    / elapsed,
+            ),
+            tx_errors_per_sec: Some(
+                current
+                    .tx_errors
+                    .saturating_sub(last.counters.tx_errors)
+                    .max(0) as f64
+                    / elapsed,
+            ),
+        }
+    });
+    *guard = Some(NetworkRateState {
+        sampled_at: now,
+        counters: current,
+    });
+    Ok(rates.unwrap_or(NetworkRates {
+        rx_bytes_per_sec: None,
+        tx_bytes_per_sec: None,
+        rx_errors_per_sec: None,
+        tx_errors_per_sec: None,
+    }))
+}
+
+fn collect_process_counts() -> Result<HeartbeatProcesses> {
+    let mut total = 0i64;
+    let mut running = 0i64;
+    let mut sleeping = 0i64;
+    let mut zombies = 0i64;
+    let mut top = Vec::new();
+    for entry in fs::read_dir("/proc").context("read /proc")? {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.chars().all(|ch| ch.is_ascii_digit()) {
+            continue;
+        }
+        let stat_path = entry.path().join("stat");
+        let Ok(stat) = fs::read_to_string(stat_path) else {
+            continue;
+        };
+        total += 1;
+        let state = parse_proc_stat_state(&stat);
+        match state {
+            Some('R') => running += 1,
+            Some('Z') => zombies += 1,
+            Some(_) => sleeping += 1,
+            None => {}
+        }
+        if top.len() < 8 {
+            top.push(serde_json::json!({
+                "pid": name,
+                "state": state.map(|state| state.to_string()),
+            }));
+        }
+    }
+    Ok(HeartbeatProcesses {
+        total,
+        running: Some(running),
+        sleeping: Some(sleeping),
+        zombies,
+        top,
+    })
+}
+
+fn parse_proc_stat_state(raw: &str) -> Option<char> {
+    let end = raw.rfind(')')?;
+    raw[end + 1..].split_whitespace().next()?.chars().next()
+}
+
+fn parse_docker_states(raw: &str) -> HeartbeatContainers {
+    let mut running = 0;
+    let mut exited = 0;
+    let mut restarting = 0;
+    for state in raw.lines().map(str::trim).filter(|state| !state.is_empty()) {
+        match state {
+            "running" => running += 1,
+            "exited" | "dead" | "created" | "removing" | "paused" => exited += 1,
+            "restarting" => restarting += 1,
+            _ => {}
+        }
+    }
+    HeartbeatContainers {
+        runtime: Some("docker".to_string()),
+        reachable: true,
+        running,
+        exited,
+        restarting,
+        unhealthy: 0,
+        details: Vec::new(),
+    }
+}
+
+fn clamp_u128_to_i64(value: u128) -> i64 {
+    value.min(i64::MAX as u128) as i64
+}
+
 pub struct RetryBuffer {
     limit: usize,
     queue: VecDeque<HeartbeatPayload>,
@@ -478,7 +1101,7 @@ pub fn backoff_duration(attempt: u32) -> Duration {
 
 pub async fn run_agent(config: HeartbeatAgentConfig) -> Result<()> {
     let host_id = load_or_create_host_id(&config.host_id_path)?;
-    let collector = HeartbeatCollector::fake();
+    let collector = HeartbeatCollector::linux();
     let client = reqwest::Client::new();
     let mut retry = RetryBuffer::new(config.retry_buffer_limit);
     let mut sequence = 1i64;

--- a/src/heartbeat_agent.rs
+++ b/src/heartbeat_agent.rs
@@ -195,6 +195,7 @@ pub struct HeartbeatCollector {
 }
 
 impl HeartbeatCollector {
+    #[cfg(test)]
     pub fn fake() -> Self {
         Self {
             probes: vec![
@@ -331,6 +332,7 @@ impl HeartbeatCollector {
     }
 }
 
+#[cfg(test)]
 #[derive(Clone)]
 pub struct FakeProbe {
     name: &'static str,
@@ -339,6 +341,7 @@ pub struct FakeProbe {
     fail: bool,
 }
 
+#[cfg(test)]
 impl FakeProbe {
     pub fn cpu() -> Self {
         Self::new("cpu", || {
@@ -453,6 +456,7 @@ impl FakeProbe {
     }
 }
 
+#[cfg(test)]
 impl HeartbeatProbe for FakeProbe {
     fn name(&self) -> &'static str {
         self.name
@@ -628,24 +632,32 @@ impl HeartbeatProbe for LinuxContainerProbe {
 
     fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
         Box::pin(async {
-            let output = tokio::process::Command::new("docker")
+            match tokio::process::Command::new("docker")
                 .args(["ps", "-a", "--format", "{{.State}}"])
                 .output()
-                .await;
-            Ok(ProbeOutput::Containers(match output {
-                Ok(output) if output.status.success() => {
-                    parse_docker_states(&String::from_utf8_lossy(&output.stdout))
+                .await
+            {
+                Ok(output) if output.status.success() => Ok(ProbeOutput::Containers(
+                    parse_docker_states(&String::from_utf8_lossy(&output.stdout)),
+                )),
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    bail!("docker ps exited {}: {}", output.status, stderr.trim())
                 }
-                _ => HeartbeatContainers {
-                    runtime: Some("docker".to_string()),
-                    reachable: false,
-                    running: 0,
-                    exited: 0,
-                    restarting: 0,
-                    unhealthy: 0,
-                    details: Vec::new(),
-                },
-            }))
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    // Docker not installed — expected on non-Docker hosts
+                    Ok(ProbeOutput::Containers(HeartbeatContainers {
+                        runtime: None,
+                        reachable: false,
+                        running: 0,
+                        exited: 0,
+                        restarting: 0,
+                        unhealthy: 0,
+                        details: Vec::new(),
+                    }))
+                }
+                Err(error) => Err(anyhow::Error::from(error).context("spawn docker ps")),
+            }
         })
     }
 }
@@ -704,13 +716,17 @@ fn parse_meminfo(raw: &str) -> Result<HeartbeatMemory> {
 fn discover_mounts() -> Vec<MountProbeTarget> {
     let file = match fs::File::open("/proc/self/mounts") {
         Ok(file) => file,
-        Err(_) => return Vec::new(),
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to open /proc/self/mounts; disk probes will be absent");
+            return Vec::new();
+        }
     };
     let mut mounts = Vec::new();
-    for line in BufReader::new(file)
-        .lines()
-        .map_while(std::result::Result::ok)
-    {
+    for line in BufReader::new(file).lines().filter_map(|result| {
+        result
+            .map_err(|error| tracing::warn!(error = %error, "error reading /proc/self/mounts line"))
+            .ok()
+    }) {
         let mut parts = line.split_whitespace();
         let _source = parts.next();
         let Some(mount_path) = parts.next() else {
@@ -795,7 +811,10 @@ fn statvfs_bytes(path: &Path) -> Result<(i64, i64)> {
 fn discover_disk_devices() -> Vec<String> {
     let raw = match fs::read_to_string("/proc/diskstats") {
         Ok(raw) => raw,
-        Err(_) => return Vec::new(),
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to read /proc/diskstats; disk I/O probes will be absent");
+            return Vec::new();
+        }
     };
     raw.lines()
         .filter_map(|line| line.split_whitespace().nth(2))
@@ -806,10 +825,23 @@ fn discover_disk_devices() -> Vec<String> {
 }
 
 fn is_disk_device_name(name: &str) -> bool {
-    !(name.starts_with("loop")
-        || name.starts_with("ram")
-        || name.starts_with("fd")
-        || name.chars().last().is_some_and(|ch| ch.is_ascii_digit()))
+    if name.starts_with("loop") || name.starts_with("ram") || name.starts_with("fd") {
+        return false;
+    }
+    // NVMe whole disks end in n\d+, partitions end in n\d+p\d+
+    if let Some(rest) = name.strip_prefix("nvme") {
+        return !rest.contains('p');
+    }
+    // eMMC whole disks: mmcblk\d+, partitions: mmcblk\d+p\d+
+    if let Some(rest) = name.strip_prefix("mmcblk") {
+        return !rest.contains('p');
+    }
+    // device-mapper (dm-0, dm-1) — include whole device
+    if name.starts_with("dm-") {
+        return true;
+    }
+    // SCSI/SATA: whole disks (sda, sdb) have no trailing digit; partitions (sda1) do
+    !name.chars().last().is_some_and(|ch| ch.is_ascii_digit())
 }
 
 fn parse_diskstats_device(raw: &str, device: &str) -> Option<(i64, i64)> {
@@ -831,7 +863,10 @@ fn parse_diskstats_device(raw: &str, device: &str) -> Option<(i64, i64)> {
 fn discover_network_interfaces() -> Vec<String> {
     let raw = match fs::read_to_string("/proc/net/dev") {
         Ok(raw) => raw,
-        Err(_) => return Vec::new(),
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to read /proc/net/dev; network probes will be absent");
+            return Vec::new();
+        }
     };
     raw.lines()
         .skip(2)
@@ -1084,7 +1119,14 @@ impl RetryBuffer {
             return;
         }
         while self.queue.len() >= self.limit {
-            self.queue.pop_front();
+            if let Some(evicted) = self.queue.pop_front() {
+                tracing::warn!(
+                    host_id = %evicted.host.host_id,
+                    sequence = evicted.sample.sequence,
+                    limit = self.limit,
+                    "retry buffer full; oldest heartbeat evicted and lost",
+                );
+            }
         }
         self.queue.push_back(payload);
     }
@@ -1104,7 +1146,7 @@ pub async fn run_agent(config: HeartbeatAgentConfig) -> Result<()> {
     let collector = HeartbeatCollector::linux();
     let client = reqwest::Client::new();
     let mut retry = RetryBuffer::new(config.retry_buffer_limit);
-    let mut sequence = 1i64;
+    let mut sequence = chrono::Utc::now().timestamp_millis();
     let mut attempt = 0u32;
 
     loop {
@@ -1268,7 +1310,23 @@ fn bounded_probe_error(name: &str, error: &anyhow::Error) -> String {
 }
 
 fn hostname() -> String {
-    std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string())
+    if let Ok(hostname) = std::env::var("HOSTNAME") {
+        if !hostname.is_empty() {
+            return hostname;
+        }
+    }
+    match std::fs::read_to_string("/proc/sys/kernel/hostname") {
+        Ok(name) => {
+            let name = name.trim().to_string();
+            if !name.is_empty() {
+                return name;
+            }
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "could not determine hostname; using 'unknown'");
+        }
+    }
+    "unknown".to_string()
 }
 
 fn kernel_release() -> Option<String> {
@@ -1279,11 +1337,22 @@ fn kernel_release() -> Option<String> {
 }
 
 fn boot_id() -> String {
-    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| format!("process-{}", std::process::id()))
+    match std::fs::read_to_string("/proc/sys/kernel/random/boot_id") {
+        Ok(value) => {
+            let trimmed = value.trim().to_string();
+            if !trimmed.is_empty() {
+                return trimmed;
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "failed to read boot_id from /proc; falling back to process ID \
+                 (heartbeat deduplication will not survive agent restart)"
+            );
+        }
+    }
+    format!("process-{}", std::process::id())
 }
 
 #[cfg(test)]

--- a/src/heartbeat_agent.rs
+++ b/src/heartbeat_agent.rs
@@ -1,0 +1,668 @@
+use std::collections::VecDeque;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context, Result};
+use chrono::Utc;
+use getrandom::fill as random_fill;
+use serde::{Deserialize, Serialize};
+use tokio::time::timeout;
+
+pub const DEFAULT_INTERVAL_SECS: u64 = 30;
+pub const DEFAULT_PROBE_DEADLINE_MS: u64 = 2_000;
+pub const DEFAULT_COLLECTION_DEADLINE_MS: u64 = 5_000;
+pub const DEFAULT_RETRY_BUFFER_LIMIT: usize = 32;
+pub const DEFAULT_TARGET: &str = "http://127.0.0.1:3100";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeartbeatAgentConfig {
+    pub target: Option<String>,
+    pub token: Option<String>,
+    pub interval: Duration,
+    pub probe_deadline: Duration,
+    pub collection_deadline: Duration,
+    pub retry_buffer_limit: usize,
+    pub once: bool,
+    pub emit: bool,
+    pub json: bool,
+    pub host_id_path: PathBuf,
+}
+
+impl HeartbeatAgentConfig {
+    pub fn from_env(host_id_path: PathBuf) -> Self {
+        let target = std::env::var("SYSLOG_HEARTBEAT_TARGET")
+            .ok()
+            .or_else(|| std::env::var("SYSLOG_MCP_URL").ok())
+            .or_else(|| Some(DEFAULT_TARGET.to_string()));
+        let token = std::env::var("SYSLOG_HEARTBEAT_TOKEN")
+            .ok()
+            .or_else(|| std::env::var("SYSLOG_MCP_TOKEN").ok());
+        Self {
+            target,
+            token,
+            interval: Duration::from_secs(DEFAULT_INTERVAL_SECS),
+            probe_deadline: Duration::from_millis(DEFAULT_PROBE_DEADLINE_MS),
+            collection_deadline: Duration::from_millis(DEFAULT_COLLECTION_DEADLINE_MS),
+            retry_buffer_limit: DEFAULT_RETRY_BUFFER_LIMIT,
+            once: false,
+            emit: false,
+            json: false,
+            host_id_path,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatPayload {
+    pub schema_version: u8,
+    pub host: HeartbeatHost,
+    pub sample: HeartbeatSample,
+    pub agent: HeartbeatAgentInfo,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu: Option<HeartbeatCpu>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory: Option<HeartbeatMemory>,
+    pub disks: Vec<HeartbeatDisk>,
+    pub networks: Vec<HeartbeatNetwork>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processes: Option<HeartbeatProcesses>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containers: Option<HeartbeatContainers>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatHost {
+    pub host_id: String,
+    pub hostname: String,
+    pub os: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel: Option<String>,
+    pub architecture: String,
+    pub boot_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatSample {
+    pub sequence: i64,
+    pub sampled_at: String,
+    pub uptime_secs: i64,
+    pub monotonic_ms: i64,
+    pub collection_ms: i64,
+    pub partial: bool,
+    pub probe_errors: Vec<String>,
+    pub skipped_probes: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatAgentInfo {
+    pub version: String,
+    pub mode: String,
+    pub interval_secs: i64,
+    pub push_latency_ms: Option<i64>,
+    pub retry_backlog: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatCpu {
+    pub load1: f64,
+    pub load5: f64,
+    pub load15: f64,
+    pub usage_pct: Option<f64>,
+    pub user_pct: Option<f64>,
+    pub system_pct: Option<f64>,
+    pub iowait_pct: Option<f64>,
+    pub steal_pct: Option<f64>,
+    pub core_count: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatMemory {
+    pub mem_total_bytes: i64,
+    pub mem_available_bytes: i64,
+    pub mem_used_bytes: Option<i64>,
+    pub swap_total_bytes: i64,
+    pub swap_used_bytes: i64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatDisk {
+    pub kind: String,
+    pub name: String,
+    pub fs_type: Option<String>,
+    pub bytes_total: Option<i64>,
+    pub bytes_free: Option<i64>,
+    pub bytes_used: Option<i64>,
+    pub read_bytes_per_sec: Option<f64>,
+    pub write_bytes_per_sec: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatNetwork {
+    pub interface: String,
+    pub rx_bytes_per_sec: Option<f64>,
+    pub tx_bytes_per_sec: Option<f64>,
+    pub rx_errors_per_sec: Option<f64>,
+    pub tx_errors_per_sec: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatProcesses {
+    pub total: i64,
+    pub running: Option<i64>,
+    pub sleeping: Option<i64>,
+    pub zombies: i64,
+    pub top: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct HeartbeatContainers {
+    pub runtime: Option<String>,
+    pub reachable: bool,
+    pub running: i64,
+    pub exited: i64,
+    pub restarting: i64,
+    pub unhealthy: i64,
+    pub details: Vec<serde_json::Value>,
+}
+
+pub enum ProbeOutput {
+    Cpu(HeartbeatCpu),
+    Memory(HeartbeatMemory),
+    Disk(HeartbeatDisk),
+    Network(HeartbeatNetwork),
+    Processes(HeartbeatProcesses),
+    Containers(HeartbeatContainers),
+}
+
+pub trait HeartbeatProbe: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>>;
+}
+
+pub struct HeartbeatCollector {
+    probes: Vec<Box<dyn HeartbeatProbe>>,
+    started: Instant,
+}
+
+impl HeartbeatCollector {
+    pub fn fake() -> Self {
+        Self {
+            probes: vec![
+                Box::new(FakeProbe::cpu()),
+                Box::new(FakeProbe::memory()),
+                Box::new(FakeProbe::disk()),
+                Box::new(FakeProbe::network()),
+                Box::new(FakeProbe::processes()),
+                Box::new(FakeProbe::containers()),
+            ],
+            started: Instant::now(),
+        }
+    }
+
+    pub fn with_probes(probes: Vec<Box<dyn HeartbeatProbe>>) -> Self {
+        Self {
+            probes,
+            started: Instant::now(),
+        }
+    }
+
+    pub async fn collect(
+        &self,
+        host_id: String,
+        sequence: i64,
+        interval: Duration,
+        retry_backlog: usize,
+        probe_deadline: Duration,
+        collection_deadline: Duration,
+    ) -> HeartbeatPayload {
+        let started = Instant::now();
+        let mut cpu = None;
+        let mut memory = None;
+        let mut disks = Vec::new();
+        let mut networks = Vec::new();
+        let mut processes = None;
+        let mut containers = None;
+        let mut probe_errors = Vec::new();
+        let mut skipped_probes = Vec::new();
+
+        for probe in &self.probes {
+            let elapsed = started.elapsed();
+            if elapsed >= collection_deadline {
+                skipped_probes.push(probe.name().to_string());
+                continue;
+            }
+            let remaining = collection_deadline.saturating_sub(elapsed);
+            let deadline = probe_deadline.min(remaining);
+            match timeout(deadline, probe.collect()).await {
+                Ok(Ok(output)) => match output {
+                    ProbeOutput::Cpu(value) => cpu = Some(value),
+                    ProbeOutput::Memory(value) => memory = Some(value),
+                    ProbeOutput::Disk(value) if disks.len() < 16 => disks.push(value),
+                    ProbeOutput::Network(value) if networks.len() < 16 => networks.push(value),
+                    ProbeOutput::Processes(value) => processes = Some(value),
+                    ProbeOutput::Containers(value) => containers = Some(value),
+                    ProbeOutput::Disk(_) => skipped_probes.push("disk_limit".to_string()),
+                    ProbeOutput::Network(_) => skipped_probes.push("network_limit".to_string()),
+                },
+                Ok(Err(error)) => probe_errors.push(bounded_probe_error(probe.name(), &error)),
+                Err(_) => {
+                    skipped_probes.push(probe.name().to_string());
+                    probe_errors.push(format!("{} timed out", probe.name()));
+                }
+            }
+        }
+
+        let partial = !probe_errors.is_empty() || !skipped_probes.is_empty();
+        HeartbeatPayload {
+            schema_version: 1,
+            host: HeartbeatHost {
+                host_id,
+                hostname: hostname(),
+                os: std::env::consts::OS.to_string(),
+                kernel: kernel_release(),
+                architecture: std::env::consts::ARCH.to_string(),
+                boot_id: boot_id(),
+                timezone: std::env::var("TZ").ok(),
+            },
+            sample: HeartbeatSample {
+                sequence,
+                sampled_at: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                uptime_secs: self.started.elapsed().as_secs() as i64,
+                monotonic_ms: self.started.elapsed().as_millis() as i64,
+                collection_ms: started.elapsed().as_millis() as i64,
+                partial,
+                probe_errors,
+                skipped_probes,
+            },
+            agent: HeartbeatAgentInfo {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                mode: "always_on".to_string(),
+                interval_secs: interval.as_secs() as i64,
+                push_latency_ms: None,
+                retry_backlog: retry_backlog as i64,
+            },
+            cpu,
+            memory,
+            disks,
+            networks,
+            processes,
+            containers,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct FakeProbe {
+    name: &'static str,
+    output: fn() -> ProbeOutput,
+    delay: Duration,
+    fail: bool,
+}
+
+impl FakeProbe {
+    pub fn cpu() -> Self {
+        Self::new("cpu", || {
+            ProbeOutput::Cpu(HeartbeatCpu {
+                load1: 0.10,
+                load5: 0.12,
+                load15: 0.08,
+                usage_pct: Some(4.2),
+                user_pct: Some(2.1),
+                system_pct: Some(1.4),
+                iowait_pct: Some(0.1),
+                steal_pct: Some(0.0),
+                core_count: 4,
+            })
+        })
+    }
+
+    pub fn memory() -> Self {
+        Self::new("memory", || {
+            ProbeOutput::Memory(HeartbeatMemory {
+                mem_total_bytes: 8 * 1024 * 1024 * 1024,
+                mem_available_bytes: 5 * 1024 * 1024 * 1024,
+                mem_used_bytes: Some(3 * 1024 * 1024 * 1024),
+                swap_total_bytes: 0,
+                swap_used_bytes: 0,
+            })
+        })
+    }
+
+    pub fn disk() -> Self {
+        Self::new("disk", || {
+            ProbeOutput::Disk(HeartbeatDisk {
+                kind: "mount".to_string(),
+                name: "/".to_string(),
+                fs_type: Some("stubfs".to_string()),
+                bytes_total: Some(100 * 1024 * 1024 * 1024),
+                bytes_free: Some(40 * 1024 * 1024 * 1024),
+                bytes_used: Some(60 * 1024 * 1024 * 1024),
+                read_bytes_per_sec: Some(0.0),
+                write_bytes_per_sec: Some(0.0),
+            })
+        })
+    }
+
+    pub fn network() -> Self {
+        Self::new("network", || {
+            ProbeOutput::Network(HeartbeatNetwork {
+                interface: "stub0".to_string(),
+                rx_bytes_per_sec: Some(0.0),
+                tx_bytes_per_sec: Some(0.0),
+                rx_errors_per_sec: Some(0.0),
+                tx_errors_per_sec: Some(0.0),
+            })
+        })
+    }
+
+    pub fn processes() -> Self {
+        Self::new("processes", || {
+            ProbeOutput::Processes(HeartbeatProcesses {
+                total: 1,
+                running: Some(1),
+                sleeping: Some(0),
+                zombies: 0,
+                top: Vec::new(),
+            })
+        })
+    }
+
+    pub fn containers() -> Self {
+        Self::new("containers", || {
+            ProbeOutput::Containers(HeartbeatContainers {
+                runtime: Some("docker".to_string()),
+                reachable: false,
+                running: 0,
+                exited: 0,
+                restarting: 0,
+                unhealthy: 0,
+                details: Vec::new(),
+            })
+        })
+    }
+
+    pub fn failing(name: &'static str) -> Self {
+        Self {
+            name,
+            output: || {
+                ProbeOutput::Processes(HeartbeatProcesses {
+                    total: 0,
+                    running: None,
+                    sleeping: None,
+                    zombies: 0,
+                    top: Vec::new(),
+                })
+            },
+            delay: Duration::ZERO,
+            fail: true,
+        }
+    }
+
+    pub fn delayed(mut self, delay: Duration) -> Self {
+        self.delay = delay;
+        self
+    }
+
+    fn new(name: &'static str, output: fn() -> ProbeOutput) -> Self {
+        Self {
+            name,
+            output,
+            delay: Duration::ZERO,
+            fail: false,
+        }
+    }
+}
+
+impl HeartbeatProbe for FakeProbe {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn collect(&self) -> Pin<Box<dyn Future<Output = Result<ProbeOutput>> + Send + '_>> {
+        Box::pin(async move {
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
+            if self.fail {
+                bail!("fake probe failure");
+            }
+            Ok((self.output)())
+        })
+    }
+}
+
+pub struct RetryBuffer {
+    limit: usize,
+    queue: VecDeque<HeartbeatPayload>,
+}
+
+impl RetryBuffer {
+    pub fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            queue: VecDeque::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    pub fn push(&mut self, payload: HeartbeatPayload) {
+        if self.limit == 0 {
+            return;
+        }
+        while self.queue.len() >= self.limit {
+            self.queue.pop_front();
+        }
+        self.queue.push_back(payload);
+    }
+
+    fn pop_front(&mut self) -> Option<HeartbeatPayload> {
+        self.queue.pop_front()
+    }
+}
+
+pub fn backoff_duration(attempt: u32) -> Duration {
+    let millis = 250u64.saturating_mul(1u64 << attempt.min(4));
+    Duration::from_millis(millis.min(4_000))
+}
+
+pub async fn run_agent(config: HeartbeatAgentConfig) -> Result<()> {
+    let host_id = load_or_create_host_id(&config.host_id_path)?;
+    let collector = HeartbeatCollector::fake();
+    let client = reqwest::Client::new();
+    let mut retry = RetryBuffer::new(config.retry_buffer_limit);
+    let mut sequence = 1i64;
+    let mut attempt = 0u32;
+
+    loop {
+        let mut payload = collector
+            .collect(
+                host_id.clone(),
+                sequence,
+                config.interval,
+                retry.len(),
+                config.probe_deadline,
+                config.collection_deadline,
+            )
+            .await;
+
+        if config.emit {
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+            return Ok(());
+        }
+
+        let target = config.target.as_deref().ok_or_else(|| {
+            anyhow!("heartbeat agent requires --target or SYSLOG_HEARTBEAT_TARGET")
+        })?;
+
+        flush_retry_buffer(&client, &mut retry, target, config.token.as_deref()).await;
+        payload.agent.retry_backlog = retry.len() as i64;
+        match send_payload(&client, target, config.token.as_deref(), &mut payload).await {
+            Ok(()) => attempt = 0,
+            Err(error) => {
+                tracing::warn!(error = %error, "heartbeat push failed; queued for retry");
+                retry.push(payload);
+                if config.once {
+                    return Err(error);
+                }
+                tokio::time::sleep(backoff_duration(attempt)).await;
+                attempt = attempt.saturating_add(1);
+            }
+        }
+
+        if config.once {
+            return Ok(());
+        }
+
+        sequence += 1;
+        tokio::time::sleep(config.interval).await;
+    }
+}
+
+async fn flush_retry_buffer(
+    client: &reqwest::Client,
+    retry: &mut RetryBuffer,
+    target: &str,
+    token: Option<&str>,
+) {
+    let initial = retry.len();
+    for _ in 0..initial {
+        let Some(mut payload) = retry.pop_front() else {
+            return;
+        };
+        payload.agent.retry_backlog = retry.len() as i64;
+        if let Err(error) = send_payload(client, target, token, &mut payload).await {
+            tracing::warn!(error = %error, "heartbeat retry failed");
+            retry.push(payload);
+            return;
+        }
+    }
+}
+
+async fn send_payload(
+    client: &reqwest::Client,
+    target: &str,
+    token: Option<&str>,
+    payload: &mut HeartbeatPayload,
+) -> Result<()> {
+    let url = heartbeat_url(target)?;
+    let started = Instant::now();
+    let mut request = client.post(url).json(payload);
+    if let Some(token) = token {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await.context("heartbeat POST failed")?;
+    payload.agent.push_latency_ms = Some(started.elapsed().as_millis() as i64);
+    if response.status().as_u16() == 202 {
+        return Ok(());
+    }
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    bail!("heartbeat POST returned {status}: {body}");
+}
+
+fn heartbeat_url(target: &str) -> Result<String> {
+    let trimmed = target.trim_end_matches('/');
+    if trimmed.ends_with("/v1/heartbeats") {
+        return Ok(trimmed.to_string());
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return Ok(format!("{trimmed}/v1/heartbeats"));
+    }
+    bail!("heartbeat target must start with http:// or https://");
+}
+
+pub fn load_or_create_host_id(path: &Path) -> Result<String> {
+    match std::fs::read_to_string(path) {
+        Ok(existing) => {
+            let host_id = existing.trim();
+            validate_host_id(host_id)?;
+            Ok(host_id.to_string())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let host_id = generate_host_id()?;
+            write_private(path, &format!("{host_id}\n"))?;
+            Ok(host_id)
+        }
+        Err(error) => Err(error).with_context(|| format!("read {}", path.display())),
+    }
+}
+
+fn validate_host_id(host_id: &str) -> Result<()> {
+    if host_id.len() < 16
+        || !host_id
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    {
+        bail!("invalid heartbeat host_id in config");
+    }
+    Ok(())
+}
+
+fn generate_host_id() -> Result<String> {
+    let mut bytes = [0u8; 16];
+    random_fill(&mut bytes).context("generate heartbeat host id")?;
+    Ok(format!("syslog_{}", hex_bytes(&bytes)))
+}
+
+fn hex_bytes(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn write_private(path: &Path, content: &str) -> Result<()> {
+    std::fs::write(path, content)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+fn bounded_probe_error(name: &str, error: &anyhow::Error) -> String {
+    let mut text = format!("{name}: {error}");
+    text.truncate(240);
+    text
+}
+
+fn hostname() -> String {
+    std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn kernel_release() -> Option<String> {
+    std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn boot_id() -> String {
+    std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| format!("process-{}", std::process::id()))
+}
+
+#[cfg(test)]
+#[path = "heartbeat_agent_tests.rs"]
+mod tests;

--- a/src/heartbeat_agent_tests.rs
+++ b/src/heartbeat_agent_tests.rs
@@ -209,6 +209,70 @@ fn generated_host_id_is_persisted_and_not_machine_id_shaped() {
     assert_ne!(first.len(), 64);
 }
 
+#[test]
+fn heartbeat_url_appends_path_to_bare_host() {
+    assert_eq!(
+        heartbeat_url("http://host:3100").unwrap(),
+        "http://host:3100/v1/heartbeats"
+    );
+}
+
+#[test]
+fn heartbeat_url_strips_trailing_slash_before_appending() {
+    assert_eq!(
+        heartbeat_url("http://host:3100/").unwrap(),
+        "http://host:3100/v1/heartbeats"
+    );
+}
+
+#[test]
+fn heartbeat_url_is_idempotent_when_path_already_present() {
+    assert_eq!(
+        heartbeat_url("http://host:3100/v1/heartbeats").unwrap(),
+        "http://host:3100/v1/heartbeats"
+    );
+}
+
+#[test]
+fn heartbeat_url_rejects_non_http_scheme() {
+    assert!(heartbeat_url("ftp://host:3100").is_err());
+}
+
+#[test]
+fn retry_buffer_zero_limit_discards_all_pushes() {
+    let mut buffer = RetryBuffer::new(0);
+    buffer.push(test_payload(1));
+    buffer.push(test_payload(2));
+    assert_eq!(buffer.len(), 0);
+    assert!(buffer.is_empty());
+}
+
+#[test]
+fn parse_meminfo_errors_on_missing_mem_total() {
+    let result = parse_meminfo("MemAvailable: 400 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB\n");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("MemTotal"));
+}
+
+#[test]
+fn parse_meminfo_errors_on_missing_mem_available() {
+    let result = parse_meminfo("MemTotal: 1000 kB\nSwapTotal: 0 kB\nSwapFree: 0 kB\n");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("MemAvailable"));
+}
+
+#[test]
+fn parse_docker_states_maps_all_known_states() {
+    let containers = parse_docker_states(
+        "running\nexited\ndead\ncreated\nremoving\npaused\nrestarting\nunknown_future_state\n",
+    );
+    assert!(containers.reachable);
+    assert_eq!(containers.running, 1);
+    assert_eq!(containers.exited, 5); // exited + dead + created + removing + paused
+    assert_eq!(containers.restarting, 1);
+    // unknown_future_state should be ignored without panicking
+}
+
 fn test_payload(sequence: i64) -> HeartbeatPayload {
     HeartbeatPayload {
         schema_version: 1,

--- a/src/heartbeat_agent_tests.rs
+++ b/src/heartbeat_agent_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 
-use std::time::Duration;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 #[tokio::test]
 async fn fake_collector_emits_valid_v1_payload_defaults() {
@@ -105,6 +106,94 @@ fn backoff_is_bounded() {
     assert_eq!(backoff_duration(0), Duration::from_millis(250));
     assert_eq!(backoff_duration(4), Duration::from_millis(4_000));
     assert_eq!(backoff_duration(20), Duration::from_millis(4_000));
+}
+
+#[test]
+fn linux_meminfo_parser_returns_bounded_memory_snapshot() {
+    let memory = parse_meminfo(
+        "MemTotal:        1000 kB\nMemAvailable:     400 kB\nSwapTotal:        200 kB\nSwapFree:          50 kB\n",
+    )
+    .unwrap();
+
+    assert_eq!(memory.mem_total_bytes, 1_024_000);
+    assert_eq!(memory.mem_available_bytes, 409_600);
+    assert_eq!(memory.mem_used_bytes, Some(614_400));
+    assert_eq!(memory.swap_total_bytes, 204_800);
+    assert_eq!(memory.swap_used_bytes, 153_600);
+}
+
+#[test]
+fn linux_proc_parsers_extract_cpu_network_disk_and_process_state() {
+    assert_eq!(
+        parse_loadavg("0.10 0.20 0.30 1/100 123").unwrap(),
+        (0.10, 0.20, 0.30)
+    );
+    assert_eq!(
+        parse_diskstats_device("   8       0 sda 1 0 8 0 2 0 16 0 0 0 0 0 0 0 0\n", "sda"),
+        Some((4096, 8192))
+    );
+    assert_eq!(
+        parse_proc_stat_state("123 (syslog agent) S 1 2 3"),
+        Some('S')
+    );
+
+    let network = parse_network_interface(
+        "Inter-|   Receive                                                |  Transmit\n face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n  eth0: 1000 1 2 0 0 0 0 0 2000 1 3 0 0 0 0 0\n",
+        "eth0",
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(network.rx_bytes, 1000);
+    assert_eq!(network.tx_bytes, 2000);
+    assert_eq!(network.rx_errors, 2);
+    assert_eq!(network.tx_errors, 3);
+}
+
+#[test]
+fn linux_rate_helpers_return_none_on_first_sample_and_rates_afterwards() {
+    let previous = Mutex::new(None);
+    let now = Instant::now();
+    assert_eq!(rate_pair(&previous, now, 100, 200).unwrap(), (None, None));
+    let (read, write) = rate_pair(&previous, now + Duration::from_secs(2), 300, 260).unwrap();
+    assert_eq!(read, Some(100.0));
+    assert_eq!(write, Some(30.0));
+
+    let previous_network = Mutex::new(None);
+    let current = NetworkCounters {
+        rx_bytes: 100,
+        tx_bytes: 200,
+        rx_errors: 1,
+        tx_errors: 2,
+    };
+    assert_eq!(
+        network_rates(&previous_network, now, current).unwrap(),
+        NetworkRates {
+            rx_bytes_per_sec: None,
+            tx_bytes_per_sec: None,
+            rx_errors_per_sec: None,
+            tx_errors_per_sec: None,
+        }
+    );
+    let rates = network_rates(
+        &previous_network,
+        now + Duration::from_secs(4),
+        NetworkCounters {
+            rx_bytes: 500,
+            tx_bytes: 1000,
+            rx_errors: 5,
+            tx_errors: 10,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        rates,
+        NetworkRates {
+            rx_bytes_per_sec: Some(100.0),
+            tx_bytes_per_sec: Some(200.0),
+            rx_errors_per_sec: Some(1.0),
+            tx_errors_per_sec: Some(2.0),
+        }
+    );
 }
 
 #[test]

--- a/src/heartbeat_agent_tests.rs
+++ b/src/heartbeat_agent_tests.rs
@@ -1,0 +1,159 @@
+use super::*;
+
+use std::time::Duration;
+
+#[tokio::test]
+async fn fake_collector_emits_valid_v1_payload_defaults() {
+    let collector = HeartbeatCollector::fake();
+    let payload = collector
+        .collect(
+            "syslog_testhostid1234".to_string(),
+            7,
+            Duration::from_secs(DEFAULT_INTERVAL_SECS),
+            0,
+            Duration::from_millis(DEFAULT_PROBE_DEADLINE_MS),
+            Duration::from_millis(DEFAULT_COLLECTION_DEADLINE_MS),
+        )
+        .await;
+
+    assert_eq!(payload.schema_version, 1);
+    assert_eq!(payload.host.host_id, "syslog_testhostid1234");
+    assert_eq!(payload.sample.sequence, 7);
+    assert_eq!(payload.agent.interval_secs, 30);
+    assert!(!payload.sample.partial);
+    assert!(payload.cpu.is_some());
+    assert!(payload.memory.is_some());
+    assert_eq!(payload.disks.len(), 1);
+    assert_eq!(payload.networks.len(), 1);
+    let json = serde_json::to_value(&payload).unwrap();
+    assert!(json.get("networks").is_some());
+    assert!(json.get("network").is_none());
+}
+
+#[tokio::test]
+async fn failed_fake_probe_produces_partial_snapshot() {
+    let collector = HeartbeatCollector::with_probes(vec![
+        Box::new(FakeProbe::cpu()),
+        Box::new(FakeProbe::failing("memory")),
+        Box::new(FakeProbe::disk()),
+    ]);
+
+    let payload = collector
+        .collect(
+            "syslog_testhostid1234".to_string(),
+            1,
+            Duration::from_secs(30),
+            0,
+            Duration::from_millis(100),
+            Duration::from_millis(500),
+        )
+        .await;
+
+    assert!(payload.sample.partial);
+    assert!(payload.cpu.is_some());
+    assert_eq!(payload.disks.len(), 1);
+    assert!(payload
+        .sample
+        .probe_errors
+        .iter()
+        .any(|error| error.contains("memory")));
+}
+
+#[tokio::test]
+async fn probe_deadline_skips_slow_probe_but_keeps_completed_data() {
+    let collector = HeartbeatCollector::with_probes(vec![
+        Box::new(FakeProbe::cpu()),
+        Box::new(FakeProbe::memory().delayed(Duration::from_millis(100))),
+        Box::new(FakeProbe::disk()),
+    ]);
+
+    let payload = collector
+        .collect(
+            "syslog_testhostid1234".to_string(),
+            1,
+            Duration::from_secs(30),
+            0,
+            Duration::from_millis(10),
+            Duration::from_millis(200),
+        )
+        .await;
+
+    assert!(payload.sample.partial);
+    assert!(payload.cpu.is_some());
+    assert!(payload.memory.is_none());
+    assert!(payload
+        .sample
+        .skipped_probes
+        .iter()
+        .any(|probe| probe == "memory"));
+}
+
+#[test]
+fn retry_buffer_is_bounded_and_drops_oldest() {
+    let mut buffer = RetryBuffer::new(2);
+    buffer.push(test_payload(1));
+    buffer.push(test_payload(2));
+    buffer.push(test_payload(3));
+
+    assert_eq!(buffer.len(), 2);
+    assert_eq!(buffer.pop_front().unwrap().sample.sequence, 2);
+    assert_eq!(buffer.pop_front().unwrap().sample.sequence, 3);
+}
+
+#[test]
+fn backoff_is_bounded() {
+    assert_eq!(backoff_duration(0), Duration::from_millis(250));
+    assert_eq!(backoff_duration(4), Duration::from_millis(4_000));
+    assert_eq!(backoff_duration(20), Duration::from_millis(4_000));
+}
+
+#[test]
+fn generated_host_id_is_persisted_and_not_machine_id_shaped() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("heartbeat-host-id");
+    let first = load_or_create_host_id(&path).unwrap();
+    let second = load_or_create_host_id(&path).unwrap();
+
+    assert_eq!(first, second);
+    assert!(first.starts_with("syslog_"));
+    assert_ne!(first.len(), 32);
+    assert_ne!(first.len(), 64);
+}
+
+fn test_payload(sequence: i64) -> HeartbeatPayload {
+    HeartbeatPayload {
+        schema_version: 1,
+        host: HeartbeatHost {
+            host_id: "syslog_testhostid1234".to_string(),
+            hostname: "host".to_string(),
+            os: "linux".to_string(),
+            kernel: None,
+            architecture: "x86_64".to_string(),
+            boot_id: "boot".to_string(),
+            timezone: None,
+        },
+        sample: HeartbeatSample {
+            sequence,
+            sampled_at: "2026-05-25T00:00:00.000Z".to_string(),
+            uptime_secs: 1,
+            monotonic_ms: 1,
+            collection_ms: 1,
+            partial: false,
+            probe_errors: Vec::new(),
+            skipped_probes: Vec::new(),
+        },
+        agent: HeartbeatAgentInfo {
+            version: "0.0.0".to_string(),
+            mode: "always_on".to_string(),
+            interval_secs: 30,
+            push_latency_ms: None,
+            retry_backlog: 0,
+        },
+        cpu: None,
+        memory: None,
+        disks: Vec::new(),
+        networks: Vec::new(),
+        processes: None,
+        containers: None,
+    }
+}

--- a/src/heartbeat_tests.rs
+++ b/src/heartbeat_tests.rs
@@ -325,7 +325,8 @@ async fn loopback_dev_auth_rejects_non_loopback_peer() {
 async fn mounted_auth_with_no_token_rejects_all_requests() {
     let (app, _pool, _dir) = test_app(None);
     // Even with a token in the header, no api_token configured so everything rejects
-    let (status, value) = post_json(app, "/v1/heartbeats", Some("anything"), heartbeat_payload()).await;
+    let (status, value) =
+        post_json(app, "/v1/heartbeats", Some("anything"), heartbeat_payload()).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     assert_eq!(value["error"], "unauthorized");
 }

--- a/src/heartbeat_tests.rs
+++ b/src/heartbeat_tests.rs
@@ -1,0 +1,234 @@
+use super::*;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::extract::connect_info::MockConnectInfo;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::util::ServiceExt;
+
+use crate::config::StorageConfig;
+
+fn test_app(token: Option<&str>) -> (Router, Arc<DbPool>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = StorageConfig::for_test(dir.path().join("heartbeat-test.db"));
+    let pool = Arc::new(crate::db::init_pool(&storage).unwrap());
+    let state = HeartbeatState::new(
+        Arc::clone(&pool),
+        token.map(str::to_string),
+        AuthPolicy::Mounted { auth_state: None },
+    );
+    let app = router(state).layer(MockConnectInfo(SocketAddr::from(([10, 0, 0, 7], 41000))));
+    (app, pool, dir)
+}
+
+fn heartbeat_payload() -> Value {
+    json!({
+        "host": {
+            "host_id": "host-1",
+            "hostname": "tootie",
+            "os": "linux",
+            "kernel": "6.8.0",
+            "architecture": "x86_64",
+            "boot_id": "boot-1",
+            "timezone": "America/New_York"
+        },
+        "sample": {
+            "sequence": 42,
+            "sampled_at": "2026-05-25T01:02:03Z",
+            "uptime_secs": 86400,
+            "monotonic_ms": 86400000,
+            "collection_ms": 37,
+            "partial": false,
+            "probe_errors": [],
+            "skipped_probes": []
+        },
+        "agent": {
+            "version": "0.32.6",
+            "mode": "always_on",
+            "interval_secs": 30,
+            "push_latency_ms": 12,
+            "retry_backlog": 0
+        },
+        "cpu": {
+            "load1": 0.1,
+            "load5": 0.2,
+            "load15": 0.3,
+            "usage_pct": 4.5,
+            "iowait_pct": 0.1,
+            "steal_pct": 0.0,
+            "core_count": 8
+        },
+        "memory": {
+            "mem_total_bytes": 1000,
+            "mem_available_bytes": 250,
+            "swap_total_bytes": 100,
+            "swap_used_bytes": 10
+        },
+        "disks": [{
+            "kind": "mount",
+            "name": "/",
+            "fs_type": "ext4",
+            "bytes_total": 1000,
+            "bytes_free": 400,
+            "bytes_used": 600
+        }],
+        "network": [{
+            "interface": "eth0",
+            "rx_bytes_per_sec": 100.0,
+            "tx_bytes_per_sec": 200.0,
+            "rx_errors_per_sec": 0.0,
+            "tx_errors_per_sec": 1.0
+        }],
+        "processes": {
+            "total": 10,
+            "running": 1,
+            "sleeping": 9,
+            "zombies": 0,
+            "top": []
+        },
+        "containers": {
+            "runtime": "docker",
+            "reachable": true,
+            "running": 3,
+            "exited": 1,
+            "restarting": 0,
+            "unhealthy": 1,
+            "details": []
+        }
+    })
+}
+
+async fn post_json(
+    app: Router,
+    uri: &str,
+    token: Option<&str>,
+    body: Value,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    let response = app
+        .oneshot(builder.body(Body::from(body.to_string())).unwrap())
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value = serde_json::from_slice(&bytes).unwrap_or_else(|_| json!({}));
+    (status, value)
+}
+
+#[tokio::test]
+async fn valid_heartbeat_is_accepted_and_persisted() {
+    let (app, pool, _dir) = test_app(Some("secret"));
+    let (status, value) =
+        post_json(app, "/v1/heartbeats", Some("secret"), heartbeat_payload()).await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(value["accepted"], 1);
+    assert!(value["heartbeat_id"].as_i64().unwrap() > 0);
+
+    let conn = pool.get().unwrap();
+    let row: (String, String, i64) = conn
+        .query_row(
+            "SELECT host_id, source_ip, sequence FROM host_heartbeats",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(row.0, "host-1");
+    assert_eq!(row.1, "10.0.0.7:41000");
+    assert_eq!(row.2, 42);
+
+    for table in [
+        "heartbeat_cpu",
+        "heartbeat_memory",
+        "heartbeat_disks",
+        "heartbeat_network",
+        "heartbeat_processes",
+        "heartbeat_containers",
+    ] {
+        let count: i64 = conn
+            .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 1, "expected one row in {table}");
+    }
+}
+
+#[tokio::test]
+async fn duplicate_heartbeat_is_idempotent() {
+    let (app, pool, _dir) = test_app(Some("secret"));
+    let payload = heartbeat_payload();
+    let first = post_json(
+        app.clone(),
+        "/v1/heartbeats",
+        Some("secret"),
+        payload.clone(),
+    )
+    .await;
+    let second = post_json(app, "/v1/heartbeats", Some("secret"), payload).await;
+    assert_eq!(first.0, StatusCode::ACCEPTED);
+    assert_eq!(second.0, StatusCode::ACCEPTED);
+    assert_eq!(second.1["accepted"], 0);
+    assert_eq!(first.1["heartbeat_id"], second.1["heartbeat_id"]);
+
+    let conn = pool.get().unwrap();
+    let parent_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM host_heartbeats", [], |row| row.get(0))
+        .unwrap();
+    let cpu_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM heartbeat_cpu", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(parent_count, 1);
+    assert_eq!(cpu_count, 1);
+}
+
+#[tokio::test]
+async fn bearer_auth_is_required_and_query_tokens_are_ignored() {
+    let (app, _pool, _dir) = test_app(Some("secret"));
+    for (uri, token) in [
+        ("/v1/heartbeats", None),
+        ("/v1/heartbeats", Some("wrong")),
+        ("/v1/heartbeats?token=secret", None),
+    ] {
+        let (status, value) = post_json(app.clone(), uri, token, heartbeat_payload()).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(value["error"], "unauthorized");
+    }
+
+    let (status, _) = post_json(app, "/v1/heartbeats", Some("secret"), heartbeat_payload()).await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn invalid_payloads_return_invalid_payload() {
+    let (app, _pool, _dir) = test_app(Some("secret"));
+    let mut payload = heartbeat_payload();
+    payload["unexpected"] = json!(true);
+    let (status, value) = post_json(app, "/v1/heartbeats", Some("secret"), payload).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(value["error"], "invalid_payload");
+}
+
+#[tokio::test]
+async fn heartbeat_body_limit_is_route_local_256k() {
+    let (app, _pool, _dir) = test_app(Some("secret"));
+
+    let mut accepted = heartbeat_payload();
+    accepted["gpu"] = json!({"padding": "x".repeat(70 * 1024)});
+    let (status, _) = post_json(app.clone(), "/v1/heartbeats", Some("secret"), accepted).await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+
+    let mut oversized = heartbeat_payload();
+    oversized["gpu"] = json!({"padding": "x".repeat(300 * 1024)});
+    let (status, value) = post_json(app, "/v1/heartbeats", Some("secret"), oversized).await;
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(value["error"], "payload_too_large");
+}

--- a/src/heartbeat_tests.rs
+++ b/src/heartbeat_tests.rs
@@ -101,6 +101,14 @@ fn heartbeat_payload() -> Value {
     })
 }
 
+fn heartbeat_payload_v1() -> Value {
+    let mut payload = heartbeat_payload();
+    payload["schema_version"] = json!(1);
+    payload["networks"] = payload["network"].take();
+    payload.as_object_mut().unwrap().remove("network");
+    payload
+}
+
 async fn post_json(
     app: Router,
     uri: &str,
@@ -160,6 +168,28 @@ async fn valid_heartbeat_is_accepted_and_persisted() {
             .unwrap();
         assert_eq!(count, 1, "expected one row in {table}");
     }
+}
+
+#[tokio::test]
+async fn valid_v1_heartbeat_with_networks_is_accepted() {
+    let (app, pool, _dir) = test_app(Some("secret"));
+    let (status, value) = post_json(
+        app,
+        "/v1/heartbeats",
+        Some("secret"),
+        heartbeat_payload_v1(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(value["accepted"], 1);
+
+    let conn = pool.get().unwrap();
+    let network_count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM heartbeat_network", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(network_count, 1);
 }
 
 #[tokio::test]

--- a/src/heartbeat_tests.rs
+++ b/src/heartbeat_tests.rs
@@ -262,3 +262,97 @@ async fn heartbeat_body_limit_is_route_local_256k() {
     assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
     assert_eq!(value["error"], "payload_too_large");
 }
+
+#[tokio::test]
+async fn different_boot_id_same_sequence_is_accepted_as_new_heartbeat() {
+    let (app, pool, _dir) = test_app(Some("secret"));
+
+    let mut first = heartbeat_payload();
+    first["host"]["boot_id"] = serde_json::json!("boot-A");
+    first["sample"]["sequence"] = serde_json::json!(1);
+
+    let mut second = heartbeat_payload();
+    second["host"]["boot_id"] = serde_json::json!("boot-B");
+    second["sample"]["sequence"] = serde_json::json!(1); // same sequence, different boot
+
+    let (s1, v1) = post_json(app.clone(), "/v1/heartbeats", Some("secret"), first).await;
+    let (s2, v2) = post_json(app, "/v1/heartbeats", Some("secret"), second).await;
+
+    assert_eq!(s1, StatusCode::ACCEPTED);
+    assert_eq!(s2, StatusCode::ACCEPTED);
+    assert_eq!(v1["accepted"], 1);
+    assert_eq!(v2["accepted"], 1);
+    // Both should be distinct heartbeat_ids
+    assert_ne!(v1["heartbeat_id"], v2["heartbeat_id"]);
+
+    let conn = pool.get().unwrap();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM host_heartbeats", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 2);
+}
+
+#[tokio::test]
+async fn loopback_dev_auth_accepts_loopback_peer() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = crate::config::StorageConfig::for_test(dir.path().join("test.db"));
+    let pool = Arc::new(crate::db::init_pool(&storage).unwrap());
+    let state = HeartbeatState::new(Arc::clone(&pool), None, AuthPolicy::LoopbackDev);
+    // Use loopback address (127.0.0.1)
+    let app = router(state).layer(MockConnectInfo(SocketAddr::from(([127, 0, 0, 1], 9000))));
+
+    // No auth header, loopback peer — should be accepted
+    let (status, value) = post_json(app, "/v1/heartbeats", None, heartbeat_payload()).await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(value["accepted"], 1);
+}
+
+#[tokio::test]
+async fn loopback_dev_auth_rejects_non_loopback_peer() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = crate::config::StorageConfig::for_test(dir.path().join("test.db"));
+    let pool = Arc::new(crate::db::init_pool(&storage).unwrap());
+    let state = HeartbeatState::new(Arc::clone(&pool), None, AuthPolicy::LoopbackDev);
+    // Non-loopback address
+    let app = router(state).layer(MockConnectInfo(SocketAddr::from(([10, 0, 0, 7], 41000))));
+
+    let (status, value) = post_json(app, "/v1/heartbeats", None, heartbeat_payload()).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(value["error"], "unauthorized");
+}
+
+#[tokio::test]
+async fn mounted_auth_with_no_token_rejects_all_requests() {
+    // AuthPolicy::Mounted with api_token = None — permanently-rejecting
+    let dir = tempfile::tempdir().unwrap();
+    let storage = crate::config::StorageConfig::for_test(dir.path().join("test.db"));
+    let pool = Arc::new(crate::db::init_pool(&storage).unwrap());
+    let state = HeartbeatState::new(Arc::clone(&pool), None, AuthPolicy::Mounted { auth_state: None });
+    let app = router(state).layer(MockConnectInfo(SocketAddr::from(([10, 0, 0, 7], 41000))));
+
+    // Even with a token in the header, no api_token is set so everything should reject
+    let (status, value) = post_json(app.clone(), "/v1/heartbeats", Some("anything"), heartbeat_payload()).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(value["error"], "unauthorized");
+}
+
+#[tokio::test]
+async fn zero_memory_total_stores_null_used_percent() {
+    let (app, pool, _dir) = test_app(Some("secret"));
+    let mut payload = heartbeat_payload();
+    payload["memory"]["mem_total_bytes"] = serde_json::json!(0);
+    payload["memory"]["mem_available_bytes"] = serde_json::json!(0);
+
+    let (status, _) = post_json(app, "/v1/heartbeats", Some("secret"), payload).await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+
+    let conn = pool.get().unwrap();
+    let used_percent: Option<f64> = conn
+        .query_row(
+            "SELECT used_percent FROM heartbeat_memory",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(used_percent.is_none(), "used_percent should be NULL when mem_total_bytes is 0");
+}

--- a/src/heartbeat_tests.rs
+++ b/src/heartbeat_tests.rs
@@ -323,15 +323,9 @@ async fn loopback_dev_auth_rejects_non_loopback_peer() {
 
 #[tokio::test]
 async fn mounted_auth_with_no_token_rejects_all_requests() {
-    // AuthPolicy::Mounted with api_token = None — permanently-rejecting
-    let dir = tempfile::tempdir().unwrap();
-    let storage = crate::config::StorageConfig::for_test(dir.path().join("test.db"));
-    let pool = Arc::new(crate::db::init_pool(&storage).unwrap());
-    let state = HeartbeatState::new(Arc::clone(&pool), None, AuthPolicy::Mounted { auth_state: None });
-    let app = router(state).layer(MockConnectInfo(SocketAddr::from(([10, 0, 0, 7], 41000))));
-
-    // Even with a token in the header, no api_token is set so everything should reject
-    let (status, value) = post_json(app.clone(), "/v1/heartbeats", Some("anything"), heartbeat_payload()).await;
+    let (app, _pool, _dir) = test_app(None);
+    // Even with a token in the header, no api_token configured so everything rejects
+    let (status, value) = post_json(app, "/v1/heartbeats", Some("anything"), heartbeat_payload()).await;
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     assert_eq!(value["error"], "unauthorized");
 }
@@ -348,11 +342,12 @@ async fn zero_memory_total_stores_null_used_percent() {
 
     let conn = pool.get().unwrap();
     let used_percent: Option<f64> = conn
-        .query_row(
-            "SELECT used_percent FROM heartbeat_memory",
-            [],
-            |row| row.get(0),
-        )
+        .query_row("SELECT used_percent FROM heartbeat_memory", [], |row| {
+            row.get(0)
+        })
         .unwrap();
-    assert!(used_percent.is_none(), "used_percent should be NULL when mem_total_bytes is 0");
+    assert!(
+        used_percent.is_none(),
+        "used_percent should be NULL when mem_total_bytes is 0"
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod deploy;
 pub mod doctor;
 pub mod enrich;
+pub mod heartbeat;
 pub mod logging;
 pub mod mcp;
 pub(crate) mod notifications;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod deploy;
 pub mod doctor;
 pub mod enrich;
 pub mod heartbeat;
+pub mod heartbeat_agent;
 pub mod logging;
 pub mod mcp;
 pub(crate) mod notifications;

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,25 @@ async fn run_cli(invocation: CliInvocation) -> Result<()> {
         std::process::exit(code);
     }
 
+    if let cli::CliCommand::Heartbeat(mut command) = command {
+        if flags.force_http {
+            anyhow::bail!(
+                "--http has no effect on `heartbeat agent`; use --target/--server and --token"
+            );
+        }
+        match &mut command {
+            cli::HeartbeatCommand::Agent(args) => {
+                if args.target.is_none() {
+                    args.target = flags.server;
+                }
+                if args.token.is_none() {
+                    args.token = flags.token;
+                }
+            }
+        }
+        return cli::run_heartbeat_no_db(command).await;
+    }
+
     if matches!(
         command,
         cli::CliCommand::Shell(_)
@@ -101,7 +120,7 @@ async fn run_cli(invocation: CliInvocation) -> Result<()> {
     ) {
         if let Some(trigger) = flags.http_flag_trigger() {
             anyhow::bail!(
-                "{} has no effect on local command ingestion; remove --http / --server / --token",
+                "{} has no effect on local agent commands; remove --http / --server / --token",
                 trigger
             );
         }
@@ -194,6 +213,9 @@ async fn run_setup(command: SetupCommand) -> Result<()> {
         }
         SetupCommandKind::AgentCommand(action) => {
             syslog_mcp::setup::run_agent_command_setup(action).await?
+        }
+        SetupCommandKind::HeartbeatAgent(action) => {
+            syslog_mcp::setup::run_heartbeat_agent_setup(action).await?
         }
         SetupCommandKind::DebugWrapper(action) => {
             syslog_mcp::setup::run_debug_wrapper_setup(action).await?
@@ -385,6 +407,7 @@ enum SetupCommandKind {
     AiIndexTimer(syslog_mcp::setup::AiIndexTimerAction),
     AiWatchService(syslog_mcp::setup::AiWatchServiceAction),
     AgentCommand(syslog_mcp::setup::AgentCommandAction),
+    HeartbeatAgent(syslog_mcp::setup::HeartbeatAgentAction),
     DebugWrapper(syslog_mcp::setup::DebugWrapperAction),
     DebugCompose(syslog_mcp::setup::DebugComposeAction),
     Doctor,
@@ -463,6 +486,7 @@ impl Mode {
                         | "ai"
                         | "shell"
                         | "agent-command"
+                        | "heartbeat"
                         | "correlate"
                         | "stats"
                         | "db"
@@ -498,7 +522,7 @@ impl Mode {
                 // ignored for `serve mcp`, `setup`, etc.
                 anyhow::bail!(
                     "--http / --server / --token only apply to CLI query commands \
-                     (search, tail, errors, hosts, sessions, ai, shell, agent-command, correlate, stats, incident, db); \
+                     (search, tail, errors, hosts, sessions, ai, shell, agent-command, heartbeat, correlate, stats, incident, db); \
                      compose, service, setup, and deploy are local-only and reject HTTP flags; \
                      got: {}",
                     args.join(" ")
@@ -588,6 +612,21 @@ fn parse_setup_command(args: &[String]) -> Result<SetupCommand> {
                 "install" => syslog_mcp::setup::AgentCommandAction::Install,
                 "remove" => syslog_mcp::setup::AgentCommandAction::Remove,
                 _ => syslog_mcp::setup::AgentCommandAction::Check,
+            }),
+            json,
+        });
+    }
+    if matches!(
+        iter.clone().next().map(String::as_str),
+        Some("heartbeat-agent")
+    ) {
+        let _ = iter.next();
+        let (action, json) = parse_setup_subcommand_args("heartbeat-agent", iter)?;
+        return Ok(SetupCommand {
+            kind: SetupCommandKind::HeartbeatAgent(match action {
+                "install" => syslog_mcp::setup::HeartbeatAgentAction::Install,
+                "remove" => syslog_mcp::setup::HeartbeatAgentAction::Remove,
+                _ => syslog_mcp::setup::HeartbeatAgentAction::Check,
             }),
             json,
         });
@@ -734,6 +773,7 @@ fn print_usage() {
   syslog setup ai-index-timer install|remove|check [--json]
   syslog setup ai-watch-service install|remove|check [--json]
   syslog setup agent-command install|remove|check [--json]
+  syslog setup heartbeat-agent install|remove|check [--json]
   syslog setup debug-wrapper install|remove|check [--json]
   syslog setup debug-compose install|remove|check [--json]
   syslog setup doctor [--json]
@@ -773,6 +813,7 @@ fn print_usage() {
   syslog shell index --path PATH [--shell zsh] [--json]
   syslog agent-command ingest-spool --path PATH [--json]
   syslog agent-command wrap --spool PATH -- COMMAND...
+  syslog heartbeat agent [--target URL] [--token TOKEN] [--interval-secs N] [--probe-deadline-ms N] [--collection-deadline-ms N] [--retry-buffer N] [--host-id-path PATH] [--once|--emit] [--json]
   syslog db status [--check-coord] [--json]
   syslog db integrity [--quick] [--json]
   syslog db checkpoint [--mode passive|full|restart|truncate] [--json]

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,11 +293,13 @@ async fn serve_mcp() -> Result<()> {
     }
     app = app.merge(runtime.otlp_router());
     info!("OTLP receiver mounted at /v1/logs (and /v1/metrics, /v1/traces → 404)");
+    app = app.merge(runtime.heartbeat_router());
+    info!("Heartbeat receiver mounted at /v1/heartbeats");
     if runtime.config.mcp.api_token.is_none() && !runtime.config.mcp.host.starts_with("127.") {
         tracing::warn!(
             bind = %runtime.config.mcp.bind_addr(),
-            "OTLP /v1/logs is mounted WITHOUT authentication on a non-loopback bind. \
-             Anyone reachable on this address can write log records. \
+            "OTLP /v1/logs and heartbeat /v1/heartbeats are mounted WITHOUT authentication on a \
+             non-loopback bind. Anyone reachable on this address can write telemetry. \
              Set SYSLOG_MCP_TOKEN to require Bearer auth."
         );
     }

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -116,6 +116,20 @@ fn mode_parse_accepts_agent_command_setup_namespace() {
 }
 
 #[test]
+fn mode_parse_accepts_heartbeat_agent_setup_namespace() {
+    assert!(matches!(
+        Mode::parse(vec![
+            "setup".into(),
+            "heartbeat-agent".into(),
+            "install".into(),
+            "--json".into()
+        ])
+        .unwrap(),
+        Mode::Setup(_)
+    ));
+}
+
+#[test]
 fn mode_parse_accepts_command_ingest_namespace() {
     assert!(matches!(
         Mode::parse(vec![
@@ -123,6 +137,20 @@ fn mode_parse_accepts_command_ingest_namespace() {
             "index".into(),
             "--path".into(),
             "/tmp/history".into(),
+            "--json".into()
+        ])
+        .unwrap(),
+        Mode::Cli(_)
+    ));
+    assert!(matches!(
+        Mode::parse(vec![
+            "heartbeat".into(),
+            "agent".into(),
+            "--server".into(),
+            "http://127.0.0.1:3100".into(),
+            "--token".into(),
+            "secret".into(),
+            "--emit".into(),
             "--json".into()
         ])
         .unwrap(),

--- a/src/mcp/actions.rs
+++ b/src/mcp/actions.rs
@@ -104,6 +104,12 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         cost: Cost::Cheap,
     },
     ActionSpec {
+        name: "host_state",
+        scope: Scope::Read,
+        description: "Fetch latest bounded heartbeat state for a host",
+        cost: Cost::Moderate,
+    },
+    ActionSpec {
         name: "correlate",
         scope: Scope::Read,
         description: "Correlate events across hosts/services",

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::app::{
     AbuseSearchRequest, AiCorrelateRequest, AiIncidentRequest, AiInvestigateRequest,
     AnomaliesRequest, AskHistoryRequest, ClockSkewRequest, CompareRequest, ContextRequest,
-    CorrelateEventsRequest, FilterLogsRequest, GetErrorsRequest, GetLogRequest,
+    CorrelateEventsRequest, FilterLogsRequest, GetErrorsRequest, GetLogRequest, HostStateRequest,
     IncidentContextRequest, IngestRateRequest, ListAiProjectsRequest, ListAiToolsRequest,
     ListAppsRequest, ListSessionsRequest, ListSourceIpsRequest, PatternsRequest,
     ProjectContextRequest, SearchLogsRequest, SearchSessionsRequest, SilentHostsRequest,
@@ -41,6 +41,7 @@ async fn tool_syslog(
         "tail" => tool_tail_logs(state, args).await,
         "errors" => tool_get_errors(state, args).await,
         "hosts" => tool_list_hosts(state, args).await,
+        "host_state" => tool_host_state(state, args).await,
         "correlate" => tool_correlate_events(state, args).await,
         "stats" => tool_get_stats(state, args).await,
         "status" => tool_get_status(state, args).await,
@@ -170,6 +171,11 @@ async fn tool_list_apps(state: &AppState, args: Value) -> anyhow::Result<Value> 
         "list_apps completed"
     );
     Ok(serde_json::to_value(response)?)
+}
+
+async fn tool_host_state(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let req: HostStateRequest = action_payload(args)?;
+    Ok(serde_json::to_value(state.service.host_state(req).await?)?)
 }
 
 async fn tool_list_sessions(state: &AppState, args: Value) -> anyhow::Result<Value> {
@@ -951,6 +957,17 @@ Groups by hostname and severity level (and optionally app_name), showing counts.
 List all hosts that have sent syslog messages, with first/last seen timestamps and total log counts.
 
 **Parameters:** none
+
+---
+
+## syslog host_state
+Return the latest bounded heartbeat state for one host.
+
+**Parameters:**
+- `host_id` (string, optional) — authoritative heartbeat host identity
+- `hostname` (string, optional) — self-reported hostname fallback; must resolve to exactly one host_id
+- `since` (string, optional) — minimum sampled_at timestamp (ISO 8601)
+- `limit` (integer, optional) — number of samples to return (default 1, max 100)
 
 ---
 

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -75,6 +75,76 @@ async fn tool_get_status_returns_runtime_observability() {
 }
 
 #[tokio::test]
+async fn host_state_action_returns_bounded_heartbeat_state() {
+    let h = TestHarness::new();
+    let conn = h.pool.get().unwrap();
+    for sequence in 1..=2 {
+        conn.execute(
+            "INSERT INTO host_heartbeats (
+                 host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+                 uptime_secs, sequence, collection_ms, partial, agent_version,
+                 os, architecture, metadata_json
+             ) VALUES (
+                 'host-a', 'tootie', '127.0.0.1:41000', ?1, ?1, 'boot-a',
+                 60, ?2, 5, ?3, '0.1.0-test', 'linux', 'x86_64',
+                 '{\"agent\":{\"interval_secs\":30}}'
+             )",
+            (
+                format!("2026-05-25T00:0{sequence}:00Z"),
+                sequence,
+                (sequence == 2) as i64,
+            ),
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    let value = execute_tool(
+        &h.state,
+        "syslog",
+        json!({"action": "host_state", "hostname": "tootie", "limit": 1}),
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(value["host_id"], "host-a");
+    assert_eq!(value["samples"].as_array().unwrap().len(), 1);
+    assert_eq!(value["flags"]["collector_partial"], true);
+}
+
+#[tokio::test]
+async fn host_state_action_reports_ambiguous_hostname() {
+    let h = TestHarness::new();
+    let conn = h.pool.get().unwrap();
+    for host_id in ["host-a", "host-b"] {
+        conn.execute(
+            "INSERT INTO host_heartbeats (
+                 host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+                 uptime_secs, sequence, collection_ms, partial, agent_version,
+                 os, architecture
+             ) VALUES (
+                 ?1, 'shared', '127.0.0.1:41000', '2026-05-25T00:00:00Z',
+                 '2026-05-25T00:00:01Z', 'boot-a', 60, 1, 5, 0,
+                 '0.1.0-test', 'linux', 'x86_64'
+             )",
+            [host_id],
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    let error = execute_tool(
+        &h.state,
+        "syslog",
+        json!({"action": "host_state", "hostname": "shared"}),
+        None,
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("ambiguous_host"));
+}
+
+#[tokio::test]
 async fn numeric_args_reject_out_of_range_values() {
     let h = TestHarness::new();
     let err = execute_tool(
@@ -133,8 +203,26 @@ async fn schema_actions_are_dispatchable() {
         }],
     )
     .unwrap();
+    {
+        let conn = h.pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO host_heartbeats (
+                 host_id, hostname, source_ip, sampled_at, received_at, boot_id,
+                 uptime_secs, sequence, collection_ms, partial, agent_version,
+                 os, architecture, metadata_json
+             ) VALUES (
+                 'schema-heartbeat', 'schema-heartbeat-host', '127.0.0.1:41000',
+                 '2026-01-01T00:00:00Z', '2026-01-01T00:00:01Z', 'boot-a',
+                 60, 1, 5, 0, '0.1.0-test', 'linux', 'x86_64',
+                 '{\"agent\":{\"interval_secs\":30}}'
+             )",
+            [],
+        )
+        .unwrap();
+    }
     for action in &super::actions::action_names() {
         let args = match *action {
+            "host_state" => json!({"action": action, "host_id": "schema-heartbeat"}),
             "correlate" => {
                 json!({"action": action, "reference_time": "2026-01-01T00:00:00Z"})
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -126,6 +126,7 @@ pub(crate) fn background_interval(period: tokio::time::Duration) -> tokio::time:
 /// the FTS5 index at homelab volumes (50k+ DNS queries/day).
 const ADGUARD_RETENTION_TAGS: &[&str] = &["adguard-allowed", "adguard-query", "adguard-rewrite"];
 const ADGUARD_RETENTION_DAYS: u32 = 7;
+const HEARTBEAT_RETENTION_DAYS: u32 = 14;
 
 impl RuntimeCore {
     pub async fn load() -> Result<Self> {
@@ -381,12 +382,13 @@ impl RuntimeCore {
 
     fn spawn_retention_task(&self, token: CancellationToken) -> Option<JoinHandle<()>> {
         let retention_days = self.config.storage.retention_days;
-        if retention_days == 0 {
+        if retention_days == 0 && HEARTBEAT_RETENTION_DAYS == 0 {
             return None;
         }
         let purge_pool = Arc::clone(&self.pool);
         let limiter = Arc::clone(&self.maintenance_permit);
         let fts_merge_pages = self.config.enrichment.fts_merge_pages;
+        let cleanup_chunk_size = self.config.storage.cleanup_chunk_size;
         let handle = tokio::spawn(async move {
             let mut interval = background_interval(tokio::time::Duration::from_secs(3600));
             loop {
@@ -431,19 +433,29 @@ impl RuntimeCore {
                             ),
                         }
                     }
+                    let heartbeat_deleted = db::purge_old_heartbeats(
+                        &pool,
+                        HEARTBEAT_RETENTION_DAYS,
+                        cleanup_chunk_size,
+                    )?;
                     let global_deleted =
                         db::purge_old_logs(&pool, retention_days, fts_merge_pages)?;
-                    Ok::<(usize, usize), anyhow::Error>((tag_deleted, global_deleted))
+                    Ok::<(usize, usize, usize), anyhow::Error>((
+                        tag_deleted,
+                        heartbeat_deleted,
+                        global_deleted,
+                    ))
                 })
                 .await
                 .map_err(|e| anyhow::anyhow!("spawn_blocking error: {e}"))
                 .and_then(|r| r)
                 {
-                    Ok((tag_deleted, global_deleted)) => tracing::info!(
+                    Ok((tag_deleted, heartbeat_deleted, global_deleted)) => tracing::info!(
                         retention_days,
                         tag_deleted,
+                        heartbeat_deleted,
                         global_deleted,
-                        total_deleted = tag_deleted + global_deleted,
+                        total_deleted = tag_deleted + heartbeat_deleted + global_deleted,
                         elapsed_ms = started.elapsed().as_millis(),
                         "Retention purge tick completed"
                     ),
@@ -451,7 +463,7 @@ impl RuntimeCore {
                         error = %e,
                         retention_days,
                         elapsed_ms = started.elapsed().as_millis(),
-                        "Failed to purge old logs"
+                        "Failed to purge telemetry retention"
                     ),
                 }
             }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,6 +10,7 @@ use tokio_util::sync::CancellationToken;
 use crate::app::SyslogService;
 use crate::config::{mcp_bind_is_loopback, validate_auth_config, AuthMode, Config};
 use crate::db::{self, DbPool, StorageBudgetState};
+use crate::heartbeat::HeartbeatState;
 use crate::ingest::IngestTx;
 use crate::mcp::AuthPolicy;
 use crate::observability::RuntimeObservability;
@@ -232,6 +233,16 @@ impl RuntimeCore {
             self.auth_policy.clone(),
         );
         otlp::router(state)
+    }
+
+    /// Build the heartbeat telemetry ingest router.
+    pub fn heartbeat_router(&self) -> axum::Router {
+        let state = HeartbeatState::new(
+            Arc::clone(&self.pool),
+            self.config.mcp.api_token.clone(),
+            self.auth_policy.clone(),
+        );
+        crate::heartbeat::router(state)
     }
 
     pub fn mcp_state(&self) -> mcp::AppState {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -483,17 +483,20 @@ impl RuntimeCore {
                             ),
                         }
                     }
-                    let heartbeat_deleted =
-                        match db::purge_old_heartbeats(&pool, HEARTBEAT_RETENTION_DAYS, cleanup_chunk_size) {
-                            Ok(n) => n,
-                            Err(e) => {
-                                tracing::error!(
-                                    error = %e,
-                                    "Heartbeat retention purge failed; continuing"
-                                );
-                                0
-                            }
-                        };
+                    let heartbeat_deleted = match db::purge_old_heartbeats(
+                        &pool,
+                        HEARTBEAT_RETENTION_DAYS,
+                        cleanup_chunk_size,
+                    ) {
+                        Ok(n) => n,
+                        Err(e) => {
+                            tracing::error!(
+                                error = %e,
+                                "Heartbeat retention purge failed; continuing"
+                            );
+                            0
+                        }
+                    };
                     let global_deleted =
                         db::purge_old_logs(&pool, retention_days, fts_merge_pages)?;
                     Ok::<(usize, usize, usize), anyhow::Error>((

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -15,6 +15,7 @@ mod ai_watch;
 mod debug_wrapper;
 mod doctor;
 mod firstrun;
+mod heartbeat_agent;
 mod systemd;
 
 pub use agent_command::run_agent_command_setup;
@@ -26,6 +27,7 @@ pub use firstrun::run_setup;
 pub(crate) use firstrun::{
     default_env_for_data_dir, dockerfile_asset, installed_compose_asset, render_env,
 };
+pub use heartbeat_agent::run_heartbeat_agent_setup;
 
 // Test-only re-exports of private items accessed via `use super::*` in setup_tests.rs.
 #[cfg(test)]
@@ -73,6 +75,13 @@ pub enum AiWatchServiceAction {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentCommandAction {
+    Install,
+    Remove,
+    Check,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeartbeatAgentAction {
     Install,
     Remove,
     Check,
@@ -128,6 +137,16 @@ impl AgentCommandAction {
             Self::Install => "agent-command-install",
             Self::Remove => "agent-command-remove",
             Self::Check => "agent-command-check",
+        }
+    }
+}
+
+impl HeartbeatAgentAction {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Install => "heartbeat-agent-install",
+            Self::Remove => "heartbeat-agent-remove",
+            Self::Check => "heartbeat-agent-check",
         }
     }
 }

--- a/src/setup/heartbeat_agent.rs
+++ b/src/setup/heartbeat_agent.rs
@@ -1,0 +1,246 @@
+use std::io::{self, ErrorKind};
+use std::path::Path;
+use std::time::Instant;
+
+use crate::heartbeat_agent;
+
+use super::firstrun::parse_env;
+use super::systemd::{systemctl_user_named_phase, systemctl_user_state};
+use super::{
+    check_file_phase, host_local_report_input, setup_path_value, setup_report, write_private_file,
+    HeartbeatAgentAction, PhaseTimer, SetupPhase, SetupReport, SetupStatus,
+};
+
+const UNIT_NAME: &str = "syslog-heartbeat-agent.service";
+
+pub async fn run_heartbeat_agent_setup(action: HeartbeatAgentAction) -> io::Result<SetupReport> {
+    let started = Instant::now();
+    let home = super::syslog_home_dir()?;
+    let env_path = home.join("heartbeat-agent.env");
+    let compose_dir = home.join("compose");
+    let data_dir = home.join("data");
+    let user_home = super::user_home_dir()?;
+    let unit_dir = user_home.join(".config/systemd/user");
+    let unit_path = unit_dir.join(UNIT_NAME);
+    let host_id_path = home.join("heartbeat-host-id");
+    let mut phases = Vec::new();
+
+    match action {
+        HeartbeatAgentAction::Install => {
+            let syslog_bin = super::resolve_syslog_binary()?;
+            std::fs::create_dir_all(&unit_dir)?;
+            phases.push(write_heartbeat_agent_env(&env_path)?);
+            phases.push(write_heartbeat_agent_unit(
+                &unit_path,
+                &syslog_bin,
+                &env_path,
+                &host_id_path,
+            )?);
+            phases.push(systemctl_user_named_phase(
+                "heartbeat-agent-daemon-reload",
+                &["daemon-reload"],
+            ));
+            phases.push(systemctl_user_named_phase(
+                "heartbeat-agent-enabled",
+                &["enable", "--now", UNIT_NAME],
+            ));
+        }
+        HeartbeatAgentAction::Remove => {
+            phases.push(systemctl_user_named_phase(
+                "heartbeat-agent-disabled",
+                &["disable", "--now", UNIT_NAME],
+            ));
+            phases.push(remove_file_phase("heartbeat-agent-unit", &unit_path)?);
+            phases.push(systemctl_user_named_phase(
+                "heartbeat-agent-daemon-reload",
+                &["daemon-reload"],
+            ));
+        }
+        HeartbeatAgentAction::Check => {
+            let syslog_bin = super::resolve_syslog_binary()?;
+            phases.push(check_file_phase(
+                "heartbeat-agent-env",
+                &env_path,
+                "run syslog setup heartbeat-agent install",
+            ));
+            phases.push(check_file_phase(
+                "heartbeat-agent-unit",
+                &unit_path,
+                "run syslog setup heartbeat-agent install",
+            ));
+            phases.push(check_heartbeat_agent_content(
+                &unit_path,
+                &syslog_bin,
+                &env_path,
+                &host_id_path,
+            ));
+            phases.push(heartbeat_agent_enabled_phase());
+            phases.push(heartbeat_agent_active_phase());
+        }
+    }
+
+    Ok(setup_report(
+        host_local_report_input(
+            action.as_str(),
+            started.elapsed().as_millis(),
+            home,
+            env_path,
+            compose_dir,
+            data_dir,
+        ),
+        phases,
+    ))
+}
+
+fn write_heartbeat_agent_env(env_path: &Path) -> io::Result<SetupPhase> {
+    let timer = PhaseTimer::start("heartbeat-agent-env");
+    if let Some(parent) = env_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let target = std::env::var("SYSLOG_HEARTBEAT_TARGET")
+        .ok()
+        .or_else(|| read_setup_env_value("SYSLOG_HEARTBEAT_TARGET"))
+        .unwrap_or_else(|| heartbeat_agent::DEFAULT_TARGET.to_string());
+    let token = std::env::var("SYSLOG_HEARTBEAT_TOKEN")
+        .ok()
+        .or_else(|| read_setup_env_value("SYSLOG_MCP_TOKEN"))
+        .or_else(|| read_setup_env_value("SYSLOG_HEARTBEAT_TOKEN"));
+    let mut body = format!(
+        "SYSLOG_HEARTBEAT_TARGET={}\nRUST_LOG=warn\n",
+        shell_safe_value(&target)?
+    );
+    if let Some(token) = token.filter(|value| !value.trim().is_empty()) {
+        body.push_str(&format!(
+            "SYSLOG_HEARTBEAT_TOKEN={}\n",
+            shell_safe_value(&token)?
+        ));
+    }
+    write_private_file(env_path, &body)?;
+    Ok(timer.finish(SetupStatus::Ok, format!("wrote {}", env_path.display())))
+}
+
+fn write_heartbeat_agent_unit(
+    unit_path: &Path,
+    syslog_bin: &Path,
+    env_path: &Path,
+    host_id_path: &Path,
+) -> io::Result<SetupPhase> {
+    let timer = PhaseTimer::start("heartbeat-agent-unit");
+    if let Some(parent) = unit_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(
+        unit_path,
+        heartbeat_agent_unit(syslog_bin, env_path, host_id_path)?,
+    )?;
+    Ok(timer.finish(SetupStatus::Ok, format!("wrote {}", unit_path.display())))
+}
+
+fn check_heartbeat_agent_content(
+    unit_path: &Path,
+    syslog_bin: &Path,
+    env_path: &Path,
+    host_id_path: &Path,
+) -> SetupPhase {
+    let timer = PhaseTimer::start("heartbeat-agent-content");
+    let expected = match heartbeat_agent_unit(syslog_bin, env_path, host_id_path) {
+        Ok(expected) => expected,
+        Err(error) => return timer.finish(SetupStatus::Error, error.to_string()),
+    };
+    match std::fs::read_to_string(unit_path) {
+        Ok(current) if current == expected => timer.finish(
+            SetupStatus::Ok,
+            "heartbeat agent unit matches generated content",
+        ),
+        Ok(_) => timer.finish(
+            SetupStatus::Error,
+            format!(
+                "{} does not match generated heartbeat agent unit",
+                unit_path.display()
+            ),
+        ),
+        Err(error) => timer.finish(SetupStatus::Error, error.to_string()),
+    }
+}
+
+fn heartbeat_agent_enabled_phase() -> SetupPhase {
+    let timer = PhaseTimer::start("heartbeat-agent-enabled");
+    match systemctl_user_state("is-enabled", UNIT_NAME).as_deref() {
+        Some("enabled") => timer.finish(SetupStatus::Ok, "enabled"),
+        Some(state) => timer.finish(SetupStatus::Warn, state),
+        None => timer.finish(SetupStatus::Warn, "unknown"),
+    }
+}
+
+fn heartbeat_agent_active_phase() -> SetupPhase {
+    let timer = PhaseTimer::start("heartbeat-agent-active");
+    match systemctl_user_state("is-active", UNIT_NAME).as_deref() {
+        Some("active") => timer.finish(SetupStatus::Ok, "active"),
+        Some(state) => timer.finish(SetupStatus::Warn, state),
+        None => timer.finish(SetupStatus::Warn, "unknown"),
+    }
+}
+
+fn remove_file_phase(name: &'static str, path: &Path) -> io::Result<SetupPhase> {
+    let timer = PhaseTimer::start(name);
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(timer.finish(SetupStatus::Ok, format!("removed {}", path.display()))),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(timer.finish(
+            SetupStatus::Ok,
+            format!("{} already absent", path.display()),
+        )),
+        Err(error) => Err(error),
+    }
+}
+
+fn heartbeat_agent_unit(
+    syslog_bin: &Path,
+    env_path: &Path,
+    host_id_path: &Path,
+) -> io::Result<String> {
+    let read_write_dir = setup_path_value(host_id_path.parent().unwrap_or_else(|| Path::new("/")))?;
+    let syslog_bin = setup_path_value(syslog_bin)?;
+    let env_path = setup_path_value(env_path)?;
+    let host_id_path = setup_path_value(host_id_path)?;
+    Ok(format!(
+        "[Unit]\nDescription=syslog-mcp heartbeat agent\nDocumentation=https://github.com/jmagar/syslog-mcp\nAfter=network-online.target\nWants=network-online.target\nStartLimitIntervalSec=300\nStartLimitBurst=5\n\n[Service]\nType=simple\nEnvironmentFile={env_path}\nExecStart={syslog_bin} heartbeat agent --host-id-path {host_id_path}\nRestart=on-failure\nRestartSec=5\nUMask=0077\nNoNewPrivileges=true\nPrivateTmp=true\nProtectSystem=strict\nProtectHome=read-only\nReadWritePaths={}\n\n[Install]\nWantedBy=default.target\n",
+        read_write_dir
+    ))
+}
+
+fn read_setup_env_value(key: &str) -> Option<String> {
+    let path = super::syslog_home_dir().ok()?.join(".env");
+    let raw = std::fs::read_to_string(path).ok()?;
+    parse_env(&raw).remove(key)
+}
+
+fn shell_safe_value(value: &str) -> io::Result<String> {
+    if value
+        .chars()
+        .any(|ch| ch.is_control() || ch == '\n' || ch == '\r')
+    {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "heartbeat environment value contains unsupported characters",
+        ));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_runs_heartbeat_agent_with_private_host_id_path() {
+        let unit = heartbeat_agent_unit(
+            Path::new("/usr/local/bin/syslog"),
+            Path::new("/home/me/.syslog-mcp/heartbeat-agent.env"),
+            Path::new("/home/me/.syslog-mcp/heartbeat-host-id"),
+        )
+        .unwrap();
+        assert!(unit.contains("ExecStart=/usr/local/bin/syslog heartbeat agent --host-id-path /home/me/.syslog-mcp/heartbeat-host-id"));
+        assert!(unit.contains("EnvironmentFile=/home/me/.syslog-mcp/heartbeat-agent.env"));
+        assert!(unit.contains("ReadWritePaths=/home/me/.syslog-mcp"));
+    }
+}

--- a/src/setup/heartbeat_agent.rs
+++ b/src/setup/heartbeat_agent.rs
@@ -2,6 +2,8 @@ use std::io::{self, ErrorKind};
 use std::path::Path;
 use std::time::Instant;
 
+use tracing::warn;
+
 use crate::heartbeat_agent;
 
 use super::firstrun::parse_env;
@@ -210,8 +212,14 @@ fn heartbeat_agent_unit(
 
 fn read_setup_env_value(key: &str) -> Option<String> {
     let path = super::syslog_home_dir().ok()?.join(".env");
-    let raw = std::fs::read_to_string(path).ok()?;
-    parse_env(&raw).remove(key)
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => parse_env(&raw).remove(key),
+        Err(error) if error.kind() == ErrorKind::NotFound => None,
+        Err(error) => {
+            warn!(path = %path.display(), error = %error, "could not read env file for heartbeat setup");
+            None
+        }
+    }
 }
 
 fn shell_safe_value(value: &str) -> io::Result<String> {

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -4,7 +4,7 @@
 #
 # Exercises broad non-destructive checks for the action-based syslog MCP tool.
 # Action inventory reference (not every action is exercised below):
-#   syslog search, syslog filter, syslog tail, syslog errors, syslog hosts, syslog sessions,
+#   syslog search, syslog filter, syslog tail, syslog errors, syslog hosts, syslog host_state, syslog sessions,
 #   syslog search_sessions, syslog abuse, syslog ai_correlate, syslog usage_blocks, syslog project_context,
 #   syslog list_ai_tools, syslog list_ai_projects, syslog correlate, syslog stats, syslog status, syslog apps,
 #   syslog source_ips, syslog timeline, syslog patterns, syslog context,

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -18,7 +18,7 @@
 #   PORT                   Override server port (default: 3100)
 #
 # Action inventory reference (not every action is exercised by this live test):
-#   syslog search, syslog filter, syslog tail, syslog errors, syslog hosts, syslog sessions,
+#   syslog search, syslog filter, syslog tail, syslog errors, syslog hosts, syslog host_state, syslog sessions,
 #   syslog search_sessions, syslog abuse, syslog ai_correlate, syslog usage_blocks, syslog project_context,
 #   syslog list_ai_tools, syslog list_ai_projects, syslog correlate, syslog stats, syslog status, syslog apps,
 #   syslog source_ips, syslog timeline, syslog patterns, syslog context,


### PR DESCRIPTION
## Summary

- **Heartbeat storage schema** (`src/db/heartbeat.rs`): new SQLite tables for host heartbeat records and per-metric rows, with FTS5 integration and full test coverage
- **Heartbeat ingest endpoint** (`src/heartbeat.rs`): authenticated POST `/heartbeat` route that accepts host reports (CPU, memory, disk, load, uptime, custom probes), validates auth via `AuthPolicy`, and persists to DB atomically
- **Heartbeat host state and agent core** (`src/heartbeat_agent.rs`): standalone `HeartbeatAgent` that collects Linux system metrics via `/proc` and `sysinfo`, buffers failed sends (up to configurable limit), and posts on a configurable interval
- **Linux heartbeat probes** (`src/heartbeat.rs`): probe implementations for cpu_usage, memory_used_pct, disk_used_pct, load_1m/5m/15m, uptime_secs, and custom shell probes
- **Version bump to 0.33.0** with CHANGELOG entry and updated plugin/server manifests

## Architecture notes

`src/heartbeat.rs` holds the server-side ingest handler. It takes `DbPool` and `AuthPolicy` directly (same pattern as the existing syslog ingest path — bypasses the service layer for write throughput, consistent with the write-path design). `src/heartbeat_agent.rs` is the client-side collector that runs as a subprocess or via `syslog heartbeat run`.

## Test plan

- [ ] `just test` — all unit and sidecar tests pass
- [ ] `src/db/heartbeat_tests.rs` — schema creation, insert, query round-trip
- [ ] `src/heartbeat_tests.rs` — handler auth, payload parsing, metric storage
- [ ] `src/heartbeat_agent_tests.rs` — agent config, probe collection, retry buffer
- [ ] `src/db/maintenance_tests.rs` — retention includes heartbeat rows
- [ ] `src/db/pool_tests.rs` — pool migration includes heartbeat schema
- [ ] `just test-live` — smoke test against running server

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Heartbeat V1: secure ingest and storage for host telemetry, a Linux heartbeat agent with built-in probes, and an MCP `host_state` action to fetch the latest host state. Enables 14‑day retention, normalizes migration 15 schema to use *_percent columns, adds migration 18 for container restarting, and bumps to 0.33.0.

- **New Features**
  - SQLite schema for heartbeat snapshots and per-metric tables; counted in storage budget and retention (14 days).
  - Authenticated `POST /v1/heartbeats` (256 KB) with atomic writes; validated via `AuthPolicy`.
  - MCP action `host_state` to fetch the latest bounded state by `host_id` or `hostname` (optional `since`, `limit`).
  - `heartbeat agent` CLI collects CPU, memory, disk, load, uptime, networks, and custom probes with deadlines and a bounded retry buffer.
  - User service setup: `setup heartbeat-agent install` installs and manages the agent as a user systemd service.

- **Bug Fixes**
  - Preserve container fidelity: split `exited` vs `restarting`; add migration 18 and include `restarting` in responses.
  - Schema/migrations: normalize migration 15 to *_percent columns, fix table shapes and add IDs for ordered multi-row tables.
  - Harden auth: require loopback peer for `LoopbackDev`; block unauthenticated non-loopback writes.
  - Agent sequences start from wall-clock millis to avoid repeats after restart.
  - Better device/interface detection and error propagation: NVMe/eMMC/dm disks, Docker exit handling, and `/proc` read warnings.
  - Identity/observability: hostname fallback, `boot_id` warnings, and warnings when the retry buffer evicts payloads.
  - Wire/type correctness: align `schema_version` types, remove stray flatten fields, propagate JSON errors, and store NULL `used_percent` when memory totals are zero.

<sup>Written for commit b5d5f85be5aaa98ba336718d24fedbb8b9fc2f9d. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added heartbeat telemetry V1 with SQLite storage, HTTP ingestion (`POST /v1/heartbeats`), and 14-day retention.
  * Added `host_state` MCP action to query latest bounded heartbeat states for individual hosts.
  * Added heartbeat agent to periodically collect and push host metrics (CPU, memory, disk, network, processes, containers).
  * Added `syslog setup heartbeat-agent` commands for service installation, removal, and status checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->