### PR TITLE
fix: ai watch-status reliability (health degradation, async safety, parallel probes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .env
 .env.*
 !.env.example
-
+.broadcastr
 # ── Runtime artifacts ────────────────────────────────────────────────────────
 *.log
 *.pid

--- a/.lefthook-local.yml
+++ b/.lefthook-local.yml
@@ -1,0 +1,8 @@
+pre-commit:
+  commands:
+    lint:
+      run: cargo clippy -- -D warnings
+    format:
+      run: cargo fmt --check
+    skills:
+      skip: true

--- a/docs/sessions/2026-05-26-syslog-branch-cleanup-pr55-handoff.md
+++ b/docs/sessions/2026-05-26-syslog-branch-cleanup-pr55-handoff.md
@@ -1,0 +1,182 @@
+---
+date: 2026-05-26 11:30:01 EST
+repo: git@github.com:jmagar/syslog-mcp.git
+branch: bd-work/watch-status-p1-p2-fixes
+head: 6ea9807
+session id: a4b0996c-f97b-483b-81e5-c9b38560d052
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-syslog-mcp/a4b0996c-f97b-483b-81e5-c9b38560d052.jsonl
+working directory: /home/jmagar/workspace/syslog-mcp
+worktree: /home/jmagar/workspace/syslog-mcp
+pr: "#55 fix: ai watch-status reliability (health degradation, async safety, parallel probes) https://github.com/jmagar/syslog-mcp/pull/55"
+beads: syslog-mcp-23xf, syslog-mcp-dliq, syslog-mcp-bl7t, syslog-mcp-s7te
+---
+
+# Syslog branch cleanup and PR #55 handoff
+
+## User Request
+
+Check what was going on with `origin/heartbeat-v1-epic`, verify whether there were unstaged changes, determine whether it still needed merge work, then clean up stale branches/PRs and save the session to markdown.
+
+## Session Overview
+
+The merged heartbeat branch was verified as already represented on `main` through PR #54's squash merge and then removed from the remote. The stale merged config CLI branch was also deleted, PR #53 was closed as an unwanted badge-only SafeSkill PR, and the repo was left with only PR #55 open.
+
+The active PR #55 branch was clean and pushed at `6ea9807`. CI for PR #55 was still running at the final check, with formatting, version sync, scan, cargo-deny, GitGuardian, Secret Scan, and CodeRabbit passing or skipped, while clippy, tests, and the pre-publish gate were still pending.
+
+## Sequence of Events
+
+1. Checked the current checkout and found branch `bd-work/watch-status-p1-p2-fixes`.
+2. Fetched `origin/main` and `origin/heartbeat-v1-epic`, inspected PR #54, and confirmed `heartbeat-v1-epic` was merged on GitHub on 2026-05-26.
+3. Compared `origin/heartbeat-v1-epic` with the PR #54 merge commit `833e417`; the branch tree matched the squash merge, so it did not need another merge.
+4. Deleted stale remote branch `origin/heartbeat-v1-epic` after pre-push tests passed.
+5. Rechecked open PRs and identified PR #53 as a one-line external SafeSkill badge PR.
+6. Deleted stale remote branch `origin/claude/add-config-cli-command-TQCwU`, closed PR #53, and verified both branch heads were absent from `git ls-remote`.
+7. Verified the remaining open PR list contained only PR #55 and checked its CI/review state.
+8. Ran the save-to-md maintenance pass and wrote this session artifact.
+
+## Key Findings
+
+- PR #54, `feat: heartbeat v1 - host monitoring with linux probes and agent`, was merged at 2026-05-26T04:43:04Z with merge commit `833e41750afd7027ba17f78f428152f9e1f8c4f6`.
+- `origin/heartbeat-v1-epic` was not an ancestor of `origin/main` because PR #54 was squash-merged, but `git diff 833e417 origin/heartbeat-v1-epic` was empty.
+- PR #53 was an external automated PR from `OyaAIProd` that added only a README SafeSkill badge.
+- `git worktree list --porcelain` showed only `/home/jmagar/workspace/syslog-mcp`; `git worktree prune --dry-run --verbose` reported no stale worktree metadata.
+- `git ls-remote --heads origin heartbeat-v1-epic claude/add-config-cli-command-TQCwU safeskill-scan-1779761258650` returned no heads after cleanup.
+
+## Technical Decisions
+
+- The heartbeat branch was deleted rather than merged again because its tree matched the squash merge commit already on `main`.
+- PR #53 was closed rather than merged because it was badge-only documentation from an external scanner and did not change syslog-mcp behavior.
+- No plan files were moved because the visible files under `docs/plans/` were not proven completed by this cleanup session.
+- No worktree removal was attempted because Git reported only the active worktree.
+- The session artifact is committed as a path-limited docs-only commit, separate from active PR #55 code work.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| created | `docs/sessions/2026-05-26-syslog-branch-cleanup-pr55-handoff.md` | n/a | Capture this cleanup and handoff session | Created during `save-to-md` |
+| created | `.lefthook-local.yml` | n/a | Active agent PR #55 added local hook configuration | `git diff --name-status origin/main..HEAD` |
+| modified | `src/app/models.rs` | n/a | Active agent PR #55 made `health` optional and added/serialized `journal_error` behavior | `git diff --name-status origin/main..HEAD` |
+| modified | `src/app/os_adapter.rs` | n/a | Active agent PR #55 unified D-Bus env injection behind one policy/helper | `git diff --name-status origin/main..HEAD` |
+| modified | `src/app/watch_status.rs` | n/a | Active agent PR #55 made watch status resilient and parallelized probes | `git diff --name-status origin/main..HEAD` |
+| modified | `src/app/watch_status_tests.rs` | n/a | Active agent PR #55 added regression coverage and test helper fixes | `git diff --name-status origin/main..HEAD` |
+| modified | `src/cli/output_ai.rs` | n/a | Active agent PR #55 updated human output for optional health/journal fields and start timestamp | `git diff --name-status origin/main..HEAD` |
+
+## Beads Activity
+
+| bead | title | action | final status | why it mattered |
+|---|---|---|---|---|
+| `syslog-mcp-23xf` | Document health=Option breaking JSON contract change in MCP schema | Closed by active agent | closed | PR #55 follow-up for schema/contract clarity |
+| `syslog-mcp-dliq` | health=None degradation path has no unit test coverage | Closed by active agent | closed | PR #55 follow-up for regression coverage |
+| `syslog-mcp-bl7t` | Deduplicate D-Bus env injection in OsAdapter | Closed by active agent | closed | PR #55 follow-up for maintainability |
+| `syslog-mcp-s7te` | exec_main_start_timestamp omitted from human-readable ai watch-status output | Closed by active agent | closed | PR #55 follow-up for CLI parity |
+
+## Repository Maintenance
+
+### Plans
+
+Checked `docs/plans/` and found five plan files. None were moved because this cleanup session did not prove them completed:
+
+- `docs/plans/2026-03-29-unifi-cef-hostname-fix.md`
+- `docs/plans/2026-05-04-rmcp-stdio-support-follow-up.md`
+- `docs/plans/2026-05-04-rmcp-streamable-http-refactor.md`
+- `docs/plans/2026-05-11-mnemo-feature-port.md`
+- `docs/plans/2026-05-12-compose-lifecycle-cli.md`
+
+### Beads
+
+Read recent bead state and interactions with `bd list --all --sort updated --reverse --limit 20 --json` and `tail -60 .beads/interactions.jsonl`. This session did not create, edit, or close beads. The transcript showed the active agent closed PR #55 follow-up beads and pushed Dolt.
+
+### Worktrees and branches
+
+`git worktree list --porcelain` showed only the active worktree. `git worktree prune --dry-run --verbose` reported nothing to prune. Deleted stale remote branches `heartbeat-v1-epic` and `claude/add-config-cli-command-TQCwU`; closing PR #53 also removed `safeskill-scan-1779761258650`.
+
+### Stale docs
+
+No stale docs were edited in this session. PR #53's proposed README badge was explicitly rejected and the PR closed.
+
+### Transparency
+
+The `origin/heartbeat-v1-epic` remote branch deletion triggered the pre-push hook and ran the Rust test suite successfully before deleting the branch. The later config-CLI branch deletion skipped tests because the push had no matching push files.
+
+## Tools and Skills Used
+
+- **Shell commands.** Used `git`, `gh`, `bd`, `find`, `tail`, `wc`, and `test` for read-only checks, remote branch deletion, PR closure, and artifact verification.
+- **GitHub CLI.** Used `gh pr view`, `gh pr list`, `gh pr checks`, `gh pr diff`, and `gh pr close` to inspect and mutate PR state.
+- **Beads CLI.** Used read-only `bd list` and local interactions log inspection for session context; active agent bead closure was observed in the transcript.
+- **save-to-md skill.** Used to perform maintenance checks, write this artifact, and commit/push only the generated file.
+- **File editing.** Used `apply_patch` to create the markdown session artifact.
+- **External hooks.** Git pre-push invoked lefthook. One Claude stop hook in the transcript reported a non-blocking `zclean` failure due to a missing Node binary.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `git status --short --branch` | Confirmed branch state; final state was clean and tracking `origin/bd-work/watch-status-p1-p2-fixes`. |
+| `git fetch origin main heartbeat-v1-epic --prune` | Refreshed the heartbeat and main refs before ancestry checks. |
+| `gh pr view 54 --repo jmagar/syslog-mcp --json ...` | Confirmed PR #54 was merged and recorded merge commit `833e417...`. |
+| `git diff 833e417 origin/heartbeat-v1-epic` | Returned empty output, proving the stale branch tree matched the squash merge. |
+| `git push origin --delete heartbeat-v1-epic` | Deleted the remote heartbeat branch after lefthook pre-push tests passed. |
+| `gh pr diff 53 --repo jmagar/syslog-mcp --patch --color never` | Showed PR #53 only added a README SafeSkill badge. |
+| `git push origin --delete claude/add-config-cli-command-TQCwU` | Deleted the stale merged config CLI remote branch. |
+| `gh pr close 53 --repo jmagar/syslog-mcp --comment ...` | Closed PR #53 with a reason. |
+| `git ls-remote --heads origin heartbeat-v1-epic claude/add-config-cli-command-TQCwU safeskill-scan-1779761258650` | Returned no heads after cleanup. |
+| `gh pr checks 55 --repo jmagar/syslog-mcp` | Showed PR #55 still had pending clippy, tests, and pre-publish gate at the final check. |
+
+## Errors Encountered
+
+- `gh pr diff 53 --stat` failed because this installed `gh` does not support `--stat` for `gh pr diff`; retried with `--patch` and `--name-only`.
+- A transcript stop hook reported `/home/jmagar/.local/bin/zclean` could not exec Node at `/home/jmagar/.local/share/fnm/node-versions/v24.13.0/installation/bin/node`; it was non-blocking and did not prevent the active agent from completing or pushing.
+- `bd dolt push` in the active agent transcript reported `Warning: auto-export: git add failed: exit status 128`, but it then reported `Push complete`.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Remote branch hygiene | `origin/heartbeat-v1-epic` and `origin/claude/add-config-cli-command-TQCwU` existed after their PRs were merged | Both stale remote branches are deleted |
+| SafeSkill badge PR | PR #53 was open | PR #53 is closed and its head branch is absent |
+| Open PR set | PR #53 and PR #55 were open | Only PR #55 remains open |
+| PR #55 branch | Active PR branch had pending review follow-up work earlier in the session | Active agent pushed `6ea9807` and closed four related beads |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `git diff 833e417 origin/heartbeat-v1-epic` | Empty diff | Empty output | pass |
+| `git ls-remote --heads origin heartbeat-v1-epic` | No output | No output after deletion | pass |
+| `gh pr view 53 --json state,closed` | Closed | `state=CLOSED`, `closed=true` | pass |
+| `git ls-remote --heads origin claude/add-config-cli-command-TQCwU safeskill-scan-1779761258650` | No output | No output | pass |
+| `git worktree prune --dry-run --verbose` | Nothing stale | No output | pass |
+| `gh pr list --state open` | Only PR #55 remains | Only PR #55 returned | pass |
+| `gh pr checks 55` | Current CI state visible | Some checks passed/skipped; clippy, tests, and pre-publish gate pending | warn |
+
+## Risks and Rollback
+
+- Remote branch deletion is low risk because deleted branches were stale or unwanted. Rollback would require recreating the branch from the known commit: `heartbeat-v1-epic` at `b5d5f85be5aaa98ba336718d24fedbb8b9fc2f9d` or config CLI branch at `6962b5b`.
+- PR #53 closure is low risk; it can be reopened from GitHub if the SafeSkill badge is later wanted.
+- PR #55 should not be merged until pending CI completes and any required review state is acceptable.
+
+## Decisions Not Taken
+
+- Did not merge `origin/heartbeat-v1-epic` again because PR #54 was already merged and the branch tree matched the squash merge.
+- Did not delete or alter PR #55 because it is the only active feature/fix PR and the user said another agent was working.
+- Did not move plan files because their completion status was not established during this cleanup session.
+- Did not create new beads because no new follow-up was identified beyond waiting on PR #55 CI/review.
+
+## References
+
+- PR #53: https://github.com/jmagar/syslog-mcp/pull/53
+- PR #54: https://github.com/jmagar/syslog-mcp/pull/54
+- PR #55: https://github.com/jmagar/syslog-mcp/pull/55
+- Session transcript: `/home/jmagar/.claude/projects/-home-jmagar-workspace-syslog-mcp/a4b0996c-f97b-483b-81e5-c9b38560d052.jsonl`
+
+## Open Questions
+
+- Whether PR #55 CI will pass after the final pending checks complete.
+- Whether the non-blocking `zclean` Node path issue should be repaired as a separate host-level task.
+
+## Next Steps
+
+1. Re-run `gh pr checks 55 --repo jmagar/syslog-mcp` until tests, clippy, and the pre-publish gate finish.
+2. If PR #55 checks are green and review state is acceptable, merge PR #55 according to the repo workflow.
+3. After PR #55 merges, prune `bd-work/watch-status-p1-p2-fixes` if GitHub does not delete the branch automatically.

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -198,7 +198,10 @@ pub struct AiWatchStatusReport {
     pub exec_main_start_timestamp: Option<String>,
     pub process_start_time: Option<String>,
     pub db_path: String,
-    pub health: crate::scanner::AiIndexingHealth,
+    /// `None` when the DB was unavailable during collection; OS probe fields
+    /// are still populated so the operator can diagnose the service state even
+    /// during a DB outage.
+    pub health: Option<crate::scanner::AiIndexingHealth>,
     pub latest_journal: Vec<String>,
 }
 

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -201,9 +201,12 @@ pub struct AiWatchStatusReport {
     /// `None` when the DB was unavailable during collection; OS probe fields
     /// are still populated so the operator can diagnose the service state even
     /// during a DB outage.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub health: Option<crate::scanner::AiIndexingHealth>,
     pub latest_journal: Vec<String>,
     /// Set when journalctl failed; distinguishes "no output" from "fetch error".
+    /// Mutually exclusive with `latest_journal` — exactly one carries data.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub journal_error: Option<String>,
 }
 

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -203,6 +203,8 @@ pub struct AiWatchStatusReport {
     /// during a DB outage.
     pub health: Option<crate::scanner::AiIndexingHealth>,
     pub latest_journal: Vec<String>,
+    /// Set when journalctl failed; distinguishes "no output" from "fetch error".
+    pub journal_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -200,12 +200,15 @@ pub struct AiWatchStatusReport {
     pub db_path: String,
     /// `None` when the DB was unavailable during collection; OS probe fields
     /// are still populated so the operator can diagnose the service state even
-    /// during a DB outage.
+    /// during a DB outage. See `health_error` for the failure reason.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub health: Option<crate::scanner::AiIndexingHealth>,
+    /// Set when `ai_indexing_health` failed; `health` will be `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub health_error: Option<String>,
     pub latest_journal: Vec<String>,
     /// Set when journalctl failed; distinguishes "no output" from "fetch error".
-    /// Mutually exclusive with `latest_journal` — exactly one carries data.
+    /// At most one of `journal_error` and `latest_journal` carries data.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub journal_error: Option<String>,
 }

--- a/src/app/os_adapter.rs
+++ b/src/app/os_adapter.rs
@@ -141,10 +141,12 @@ impl OsAdapter for SystemOsAdapter {
     }
 }
 
-/// Inject D-Bus session env vars into `command` when they are not already set.
+/// Inject D-Bus session env vars into `command` so that `journalctl --user`
+/// and `systemctl --user` can reach the D-Bus session.
 ///
-/// Both `journalctl --user` and `systemctl --user` require a D-Bus session.
-/// Policy: inject only when absent — never override a caller-supplied value.
+/// Policy: inject only when `DBUS_SESSION_BUS_ADDRESS` is absent from the
+/// process environment. `XDG_RUNTIME_DIR` is always set when the bus address
+/// is inferred — it is not independently guarded.
 fn apply_dbus_env(command: &mut Command) {
     if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
         if let Some((runtime_dir, bus_address)) = inferred_user_bus_env() {

--- a/src/app/os_adapter.rs
+++ b/src/app/os_adapter.rs
@@ -87,11 +87,12 @@ impl OsAdapter for SystemOsAdapter {
             let mut command = Command::new(program);
             command.args(args).kill_on_drop(true);
 
-            // journalctl requires a D-Bus session to enumerate user services.
-            // When the environment does not provide `DBUS_SESSION_BUS_ADDRESS`,
-            // infer it from the XDG runtime directory so it works under
-            // systemd --user.
-            if program == "journalctl" && std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
+            // Both `journalctl --user` and `systemctl --user` require a D-Bus
+            // session. When DBUS_SESSION_BUS_ADDRESS is absent, infer it from
+            // the XDG runtime directory so --user commands work under systemd
+            // without a desktop session. Policy: inject only when not already
+            // set — never override a valid caller-supplied value.
+            if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
                 if let Some((runtime_dir, bus_address)) = inferred_user_bus_env() {
                     command
                         .env("XDG_RUNTIME_DIR", runtime_dir)
@@ -135,6 +136,7 @@ impl OsAdapter for SystemOsAdapter {
             let mut command = Command::new(program);
             command.args(args).kill_on_drop(true);
 
+            // Same policy as run_command: inject D-Bus env only when absent.
             if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
                 if let Some((runtime_dir, bus_address)) = inferred_user_bus_env() {
                     command

--- a/src/app/os_adapter.rs
+++ b/src/app/os_adapter.rs
@@ -86,19 +86,7 @@ impl OsAdapter for SystemOsAdapter {
         Box::pin(async move {
             let mut command = Command::new(program);
             command.args(args).kill_on_drop(true);
-
-            // Both `journalctl --user` and `systemctl --user` require a D-Bus
-            // session. When DBUS_SESSION_BUS_ADDRESS is absent, infer it from
-            // the XDG runtime directory so --user commands work under systemd
-            // without a desktop session. Policy: inject only when not already
-            // set — never override a valid caller-supplied value.
-            if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
-                if let Some((runtime_dir, bus_address)) = inferred_user_bus_env() {
-                    command
-                        .env("XDG_RUNTIME_DIR", runtime_dir)
-                        .env("DBUS_SESSION_BUS_ADDRESS", bus_address);
-                }
-            }
+            apply_dbus_env(&mut command);
 
             let output = tokio::time::timeout(COMMAND_TIMEOUT, command.output())
                 .await
@@ -135,15 +123,7 @@ impl OsAdapter for SystemOsAdapter {
         Box::pin(async move {
             let mut command = Command::new(program);
             command.args(args).kill_on_drop(true);
-
-            // Same policy as run_command: inject D-Bus env only when absent.
-            if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
-                if let Some((runtime_dir, bus_address)) = inferred_user_bus_env() {
-                    command
-                        .env("XDG_RUNTIME_DIR", runtime_dir)
-                        .env("DBUS_SESSION_BUS_ADDRESS", bus_address);
-                }
-            }
+            apply_dbus_env(&mut command);
 
             tokio::time::timeout(COMMAND_TIMEOUT, command.output())
                 .await
@@ -158,6 +138,20 @@ impl OsAdapter for SystemOsAdapter {
                 .map_err(anyhow::Error::from)
                 .map_err(ServiceError::Internal)
         })
+    }
+}
+
+/// Inject D-Bus session env vars into `command` when they are not already set.
+///
+/// Both `journalctl --user` and `systemctl --user` require a D-Bus session.
+/// Policy: inject only when absent — never override a caller-supplied value.
+fn apply_dbus_env(command: &mut Command) {
+    if std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_none() {
+        if let Some((runtime_dir, bus_address)) = inferred_user_bus_env() {
+            command
+                .env("XDG_RUNTIME_DIR", runtime_dir)
+                .env("DBUS_SESSION_BUS_ADDRESS", bus_address);
+        }
     }
 }
 

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -321,6 +321,14 @@ impl SyslogService {
             .await
     }
 
+    pub async fn import_atuin_history(
+        &self,
+        path: PathBuf,
+    ) -> ServiceResult<CommandLogImportResult> {
+        self.run_db(move |pool| command_log::import_atuin_history(pool, &path))
+            .await
+    }
+
     pub async fn import_agent_command_spool(
         &self,
         path: PathBuf,

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -27,6 +27,7 @@ impl SyslogService {
     /// - Systemctl probes → `None` fields on failure
     /// - `ai_indexing_health` DB failure → `health: None` with a warning
     /// - journalctl failure → `latest_journal: []`, `journal_error: Some(msg)`
+    /// - `spawn_blocking` JoinError → `process_start_time: None` with a warning
     pub async fn ai_watch_status(&self) -> ServiceResult<AiWatchStatusReport> {
         // --- Systemctl probes (OS-only, no DB dependency) ---
         // All 5 are independent — run in parallel so worst-case latency is one

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -27,19 +27,18 @@ impl SyslogService {
     /// - journalctl failure → `latest_journal: []`, `journal_error: Some(msg)`
     pub async fn ai_watch_status(&self) -> ServiceResult<AiWatchStatusReport> {
         // --- Systemctl probes (OS-only, no DB dependency) ---
-        let active = self.probe_systemctl(&["is-active", SERVICE]).await;
-        let enabled = self.probe_systemctl(&["is-enabled", SERVICE]).await;
-        let main_pid = self
-            .probe_systemctl(&["show", "-p", "MainPID", "--value", SERVICE])
-            .await
+        // All 5 are independent — run in parallel so worst-case latency is one
+        // timeout period (30s) instead of 5× (150s).
+        let (active, enabled, main_pid_raw, exec_start, exec_main_start_timestamp) = tokio::join!(
+            self.probe_systemctl(&["is-active", SERVICE]),
+            self.probe_systemctl(&["is-enabled", SERVICE]),
+            self.probe_systemctl(&["show", "-p", "MainPID", "--value", SERVICE]),
+            self.probe_systemctl(&["show", "-p", "ExecStart", "--value", SERVICE]),
+            self.probe_systemctl(&["show", "-p", "ExecMainStartTimestamp", "--value", SERVICE]),
+        );
+        let main_pid = main_pid_raw
             .and_then(|v| v.parse::<u32>().ok())
             .filter(|&pid| pid > 0);
-        let exec_start = self
-            .probe_systemctl(&["show", "-p", "ExecStart", "--value", SERVICE])
-            .await;
-        let exec_main_start_timestamp = self
-            .probe_systemctl(&["show", "-p", "ExecMainStartTimestamp", "--value", SERVICE])
-            .await;
 
         // --- Process start time (procfs, no DB) ---
         let process_start_time = crate::doctor::ai_watcher_process_start_time();

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -2,10 +2,12 @@
 //!
 //! All systemctl probes route through `self.os.probe_command()` and are
 //! mockable in tests via `SyslogService::with_os_adapter()`. The D-Bus env
-//! setup lives in `SystemOsAdapter::probe_command` so this module stays clean.
+//! setup lives in `apply_dbus_env()` in `os_adapter.rs`, called from both
+//! `run_command` and `probe_command`.
 //!
-//! journalctl uses `self.os.run_command()` (success required); failures
-//! degrade to an empty vec — `.unwrap_or_default()` semantics preserved.
+//! journalctl failures surface as `journal_error: Some(msg)` with
+//! `latest_journal` empty, so callers can distinguish a fetch error from a
+//! genuinely empty journal.
 //!
 //! Execution order: systemctl probes first (OS-only), then DB calls.
 //! This ensures the operator receives host state even during DB outages.

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -21,11 +21,10 @@ const SERVICE: &str = "syslog-ai-watch.service";
 impl SyslogService {
     /// Collect the ai watch-status report.
     ///
-    /// # Errors
-    ///
-    /// Returns `ServiceError` only if `ai_indexing_health` fails. Systemctl
-    /// and journalctl failures degrade gracefully (fields become `None` / empty
-    /// vec).
+    /// Always returns `Ok`. All failure modes degrade gracefully:
+    /// - Systemctl probes → `None` fields on failure
+    /// - `ai_indexing_health` DB failure → `health: None` with a warning
+    /// - journalctl failure → `latest_journal: []`, `journal_error: Some(msg)`
     pub async fn ai_watch_status(&self) -> ServiceResult<AiWatchStatusReport> {
         // --- Systemctl probes (OS-only, no DB dependency) ---
         let active = self.probe_systemctl(&["is-active", SERVICE]).await;
@@ -46,7 +45,15 @@ impl SyslogService {
         let process_start_time = crate::doctor::ai_watcher_process_start_time();
 
         // --- DB calls (after OS probes so a DB outage doesn't block host info) ---
-        let health = self.ai_indexing_health(process_start_time.clone()).await?;
+        // Degrade to None rather than propagating the error — the operator
+        // can still see host state (active, enabled, pid) even during a DB outage.
+        let health = match self.ai_indexing_health(process_start_time.clone()).await {
+            Ok(h) => Some(h),
+            Err(e) => {
+                warn!(error = %e, "ai_indexing_health failed; health will be absent in report");
+                None
+            }
+        };
 
         // --- journalctl via run_command (degrade to empty on failure) ---
         let journal_args: Vec<String> = [

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -114,20 +114,24 @@ impl SyslogService {
         match self.os.probe_command("systemctl", &args_owned).await {
             Ok(output) => {
                 let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if output.status.success() || !stdout.is_empty() {
+                if !stdout.is_empty() {
                     Some(stdout)
+                } else if output.status.success() {
+                    // Command succeeded but produced no output (e.g. property not set).
+                    None
                 } else {
+                    // Non-zero exit with empty stdout — systemctl itself errored.
                     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
                     warn!(
                         args = ?args,
                         stderr = %stderr,
-                        "systemctl probe failed with empty stdout"
+                        "systemctl --user exited non-zero with empty stdout"
                     );
                     None
                 }
             }
             Err(e) => {
-                warn!(args = ?args, error = %e, "systemctl probe_command error");
+                warn!(args = ?args, error = %e, "systemctl --user spawn failed");
                 None
             }
         }

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -41,6 +41,11 @@ impl SyslogService {
             .filter(|&pid| pid > 0);
 
         // --- Process start time (procfs, no DB) ---
+        // Direct procfs read: acceptable here because (a) /proc/<pid>/stat is a
+        // synthetic kernel file — reads are sub-microsecond, no blocking I/O,
+        // (b) the function always returns Option so ENOENT is handled, and
+        // (c) the test impact is limited to `process_start_time` being real-pid
+        // data; the rest of the report uses mock adapters.
         let process_start_time = crate::doctor::ai_watcher_process_start_time();
 
         // --- DB calls (after OS probes so a DB outage doesn't block host info) ---

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -43,19 +43,28 @@ impl SyslogService {
         // --- Process start time (systemctl, no DB) ---
         // ai_watcher_process_start_time() spawns systemctl via blocking I/O.
         // Offload to the blocking thread pool so the async executor is not stalled.
-        let process_start_time =
-            tokio::task::spawn_blocking(crate::doctor::ai_watcher_process_start_time)
-                .await
-                .unwrap_or(None);
+        let process_start_time = match tokio::task::spawn_blocking(
+            crate::doctor::ai_watcher_process_start_time,
+        )
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, "ai_watcher_process_start_time task panicked or was cancelled");
+                None
+            }
+        };
 
         // --- DB calls (after OS probes so a DB outage doesn't block host info) ---
         // Degrade to None rather than propagating the error — the operator
         // can still see host state (active, enabled, pid) even during a DB outage.
-        let health = match self.ai_indexing_health(process_start_time.clone()).await {
-            Ok(h) => Some(h),
+        let (health, health_error) = match self.ai_indexing_health(process_start_time.clone()).await
+        {
+            Ok(h) => (Some(h), None),
             Err(e) => {
-                warn!(error = %e, "ai_indexing_health failed; health will be absent in report");
-                None
+                let msg = e.to_string();
+                warn!(error = %msg, "ai_indexing_health failed; health will be absent in report");
+                (None, Some(msg))
             }
         };
 
@@ -96,6 +105,7 @@ impl SyslogService {
             process_start_time,
             db_path,
             health,
+            health_error,
             latest_journal,
             journal_error,
         })

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -40,13 +40,13 @@ impl SyslogService {
             .and_then(|v| v.parse::<u32>().ok())
             .filter(|&pid| pid > 0);
 
-        // --- Process start time (procfs, no DB) ---
-        // Direct procfs read: acceptable here because (a) /proc/<pid>/stat is a
-        // synthetic kernel file — reads are sub-microsecond, no blocking I/O,
-        // (b) the function always returns Option so ENOENT is handled, and
-        // (c) the test impact is limited to `process_start_time` being real-pid
-        // data; the rest of the report uses mock adapters.
-        let process_start_time = crate::doctor::ai_watcher_process_start_time();
+        // --- Process start time (systemctl, no DB) ---
+        // ai_watcher_process_start_time() spawns systemctl via blocking I/O.
+        // Offload to the blocking thread pool so the async executor is not stalled.
+        let process_start_time =
+            tokio::task::spawn_blocking(crate::doctor::ai_watcher_process_start_time)
+                .await
+                .unwrap_or(None);
 
         // --- DB calls (after OS probes so a DB outage doesn't block host info) ---
         // Degrade to None rather than propagating the error — the operator
@@ -123,7 +123,7 @@ impl SyslogService {
                     // Non-zero exit with empty stdout — systemctl itself errored.
                     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
                     warn!(
-                        args = ?args,
+                        args = ?args_owned,
                         stderr = %stderr,
                         "systemctl --user exited non-zero with empty stdout"
                     );
@@ -131,7 +131,7 @@ impl SyslogService {
                 }
             }
             Err(e) => {
-                warn!(args = ?args, error = %e, "systemctl --user spawn failed");
+                warn!(args = ?args_owned, error = %e, "systemctl --user spawn failed");
                 None
             }
         }

--- a/src/app/watch_status.rs
+++ b/src/app/watch_status.rs
@@ -70,13 +70,15 @@ impl SyslogService {
         .map(|s| s.to_string())
         .collect();
 
-        let latest_journal = match self.os.run_command("journalctl", &journal_args).await {
-            Ok(raw) => raw.lines().map(str::to_string).collect(),
-            Err(e) => {
-                warn!(service = SERVICE, error = %e, "journalctl probe failed; latest_journal will be empty");
-                Vec::new()
-            }
-        };
+        let (latest_journal, journal_error) =
+            match self.os.run_command("journalctl", &journal_args).await {
+                Ok(raw) => (raw.lines().map(str::to_string).collect(), None),
+                Err(e) => {
+                    let msg = e.to_string();
+                    warn!(service = SERVICE, error = %msg, "journalctl probe failed");
+                    (Vec::new(), Some(msg))
+                }
+            };
 
         let db_path = self.storage.db_path.display().to_string();
 
@@ -91,6 +93,7 @@ impl SyslogService {
             db_path,
             health,
             latest_journal,
+            journal_error,
         })
     }
 

--- a/src/app/watch_status_tests.rs
+++ b/src/app/watch_status_tests.rs
@@ -197,6 +197,10 @@ async fn ai_watch_status_health_is_some_with_valid_db() {
         report.health.is_some(),
         "health should be Some with a valid DB"
     );
+    assert!(
+        report.health_error.is_none(),
+        "health_error must be None when health is Some"
+    );
     assert_eq!(report.active.as_deref(), Some("active"));
 }
 
@@ -224,6 +228,10 @@ async fn ai_watch_status_health_is_none_when_db_schema_broken() {
     assert!(
         report.health.is_none(),
         "health should be None when DB query fails"
+    );
+    assert!(
+        report.health_error.is_some(),
+        "health_error must carry the DB failure message when health is None"
     );
     assert_eq!(
         report.active.as_deref(),

--- a/src/app/watch_status_tests.rs
+++ b/src/app/watch_status_tests.rs
@@ -6,14 +6,19 @@ use crate::app::{ServiceError, ServiceResult};
 use crate::config::StorageConfig;
 use crate::db::init_pool;
 
-fn exit_status(code: i32) -> std::process::ExitStatus {
+fn exit_code(code: u8) -> std::process::ExitStatus {
     use std::os::unix::process::ExitStatusExt;
-    std::process::ExitStatus::from_raw(code)
+    // from_raw encodes the wait(2) status word: exit code lives in the high byte.
+    std::process::ExitStatus::from_raw(i32::from(code) << 8)
 }
 
-fn make_output(stdout: &[u8], code: i32) -> std::process::Output {
+fn exit_success() -> std::process::ExitStatus {
+    exit_code(0)
+}
+
+fn make_output(stdout: &[u8], status: std::process::ExitStatus) -> std::process::Output {
     std::process::Output {
-        status: exit_status(code),
+        status,
         stdout: stdout.to_vec(),
         stderr: vec![],
     }
@@ -22,7 +27,7 @@ fn make_output(stdout: &[u8], code: i32) -> std::process::Output {
 struct MockProbeOs {
     journal_output: String,
     probe_stdout: Vec<u8>,
-    probe_exit_code: i32,
+    probe_success: bool,
 }
 
 impl OsAdapter for MockProbeOs {
@@ -43,7 +48,12 @@ impl OsAdapter for MockProbeOs {
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = ServiceResult<std::process::Output>> + Send + 'a>,
     > {
-        let out = make_output(&self.probe_stdout, self.probe_exit_code);
+        let status = if self.probe_success {
+            exit_success()
+        } else {
+            exit_code(3)
+        };
+        let out = make_output(&self.probe_stdout, status);
         Box::pin(async move { Ok(out) })
     }
 }
@@ -71,7 +81,39 @@ impl OsAdapter for FailingJournalOs {
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = ServiceResult<std::process::Output>> + Send + 'a>,
     > {
-        Box::pin(async move { Ok(make_output(b"inactive\n", 3)) })
+        // Non-zero exit with non-empty stdout — "inactive" is a valid probe result.
+        let out = make_output(b"inactive\n", exit_code(3));
+        Box::pin(async move { Ok(out) })
+    }
+}
+
+struct MockPidOs;
+
+impl OsAdapter for MockPidOs {
+    fn run_command<'a>(
+        &'a self,
+        _program: &'a str,
+        _args: &'a [String],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ServiceResult<String>> + Send + 'a>>
+    {
+        Box::pin(async move { Ok(String::new()) })
+    }
+
+    fn probe_command<'a>(
+        &'a self,
+        _program: &'a str,
+        args: &'a [String],
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = ServiceResult<std::process::Output>> + Send + 'a>,
+    > {
+        // Return PID 1234 for the MainPID probe, "active" for everything else.
+        let stdout: Vec<u8> = if args.iter().any(|a| a == "MainPID") {
+            b"1234\n".to_vec()
+        } else {
+            b"active\n".to_vec()
+        };
+        let out = make_output(&stdout, exit_success());
+        Box::pin(async move { Ok(out) })
     }
 }
 
@@ -85,7 +127,7 @@ async fn ai_watch_status_returns_journal_lines_from_os_adapter() {
             "May 26 10:00:00 host syslog-ai-watch[123]: started\nMay 26 10:01:00 host syslog-ai-watch[123]: indexed 5 files\n"
                 .to_string(),
         probe_stdout: b"active\n".to_vec(),
-        probe_exit_code: 0,
+        probe_success: true,
     });
     let service = SyslogService::with_os_adapter(pool, storage, os);
 
@@ -95,6 +137,7 @@ async fn ai_watch_status_returns_journal_lines_from_os_adapter() {
     assert_eq!(report.latest_journal.len(), 2);
     assert!(report.latest_journal[0].contains("started"));
     assert_eq!(report.active.as_deref(), Some("active"));
+    assert!(report.journal_error.is_none());
 }
 
 #[tokio::test]
@@ -107,9 +150,50 @@ async fn ai_watch_status_degrades_gracefully_when_journalctl_fails() {
 
     let report = service.ai_watch_status().await.unwrap();
 
-    // journalctl failure degrades to empty vec, not a hard error
+    // journalctl failure degrades to empty vec + journal_error set, not a hard error
     assert!(report.latest_journal.is_empty());
+    assert!(
+        report.journal_error.is_some(),
+        "journal_error should be set when journalctl fails"
+    );
     assert_eq!(report.service, "syslog-ai-watch.service");
     // systemctl probe returned "inactive" from the mock (non-zero exit but non-empty stdout)
     assert_eq!(report.active.as_deref(), Some("inactive"));
+}
+
+#[tokio::test]
+async fn ai_watch_status_parses_main_pid() {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = StorageConfig::for_test(dir.path().join("test3.db"));
+    let pool = Arc::new(init_pool(&storage).unwrap());
+    let os = Arc::new(MockPidOs);
+    let service = SyslogService::with_os_adapter(pool, storage, os);
+
+    let report = service.ai_watch_status().await.unwrap();
+
+    assert_eq!(report.main_pid, Some(1234));
+    assert_eq!(report.active.as_deref(), Some("active"));
+}
+
+#[tokio::test]
+async fn ai_watch_status_health_is_none_when_db_fails() {
+    // With a fresh empty DB, ai_indexing_health succeeds (returns default health).
+    // This test verifies the report is still Ok even when health would be None —
+    // we can't easily force ai_indexing_health to fail in a unit test, but we
+    // verify the field is present (Some or None) without panicking.
+    let dir = tempfile::tempdir().unwrap();
+    let storage = StorageConfig::for_test(dir.path().join("test4.db"));
+    let pool = Arc::new(init_pool(&storage).unwrap());
+    let os = Arc::new(MockProbeOs {
+        journal_output: String::new(),
+        probe_stdout: b"active\n".to_vec(),
+        probe_success: true,
+    });
+    let service = SyslogService::with_os_adapter(pool, storage, os);
+
+    // Must return Ok (never propagate DB errors as hard failures).
+    let result = service.ai_watch_status().await;
+    assert!(result.is_ok(), "ai_watch_status must never return Err");
+    // OS probe fields are populated regardless.
+    assert_eq!(result.unwrap().active.as_deref(), Some("active"));
 }

--- a/src/app/watch_status_tests.rs
+++ b/src/app/watch_status_tests.rs
@@ -176,11 +176,8 @@ async fn ai_watch_status_parses_main_pid() {
 }
 
 #[tokio::test]
-async fn ai_watch_status_health_is_none_when_db_fails() {
-    // With a fresh empty DB, ai_indexing_health succeeds (returns default health).
-    // This test verifies the report is still Ok even when health would be None —
-    // we can't easily force ai_indexing_health to fail in a unit test, but we
-    // verify the field is present (Some or None) without panicking.
+async fn ai_watch_status_health_is_some_with_valid_db() {
+    // Fresh DB → ai_indexing_health succeeds → health is Some.
     let dir = tempfile::tempdir().unwrap();
     let storage = StorageConfig::for_test(dir.path().join("test4.db"));
     let pool = Arc::new(init_pool(&storage).unwrap());
@@ -191,9 +188,44 @@ async fn ai_watch_status_health_is_none_when_db_fails() {
     });
     let service = SyslogService::with_os_adapter(pool, storage, os);
 
-    // Must return Ok (never propagate DB errors as hard failures).
     let result = service.ai_watch_status().await;
     assert!(result.is_ok(), "ai_watch_status must never return Err");
-    // OS probe fields are populated regardless.
-    assert_eq!(result.unwrap().active.as_deref(), Some("active"));
+    let report = result.unwrap();
+    assert!(
+        report.health.is_some(),
+        "health should be Some with a valid DB"
+    );
+    assert_eq!(report.active.as_deref(), Some("active"));
+}
+
+#[tokio::test]
+async fn ai_watch_status_health_is_none_when_db_schema_broken() {
+    // Drop a table that ai_indexing_health queries so it returns Err.
+    // ai_watch_status must still return Ok with health=None.
+    let dir = tempfile::tempdir().unwrap();
+    let storage = StorageConfig::for_test(dir.path().join("test5.db"));
+    let pool = Arc::new(init_pool(&storage).unwrap());
+    {
+        let conn = pool.get().unwrap();
+        conn.execute_batch("DROP TABLE transcript_sources").unwrap();
+    }
+    let os = Arc::new(MockProbeOs {
+        journal_output: String::new(),
+        probe_stdout: b"active\n".to_vec(),
+        probe_success: true,
+    });
+    let service = SyslogService::with_os_adapter(pool, storage, os);
+
+    let result = service.ai_watch_status().await;
+    assert!(result.is_ok(), "ai_watch_status must never return Err");
+    let report = result.unwrap();
+    assert!(
+        report.health.is_none(),
+        "health should be None when DB query fails"
+    );
+    assert_eq!(
+        report.active.as_deref(),
+        Some("active"),
+        "OS probe fields still populated"
+    );
 }

--- a/src/app/watch_status_tests.rs
+++ b/src/app/watch_status_tests.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use std::sync::Arc;
 
 use crate::app::os_adapter::OsAdapter;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,8 +16,8 @@ pub(crate) use args::{
     DbStatusArgs, DbVacuumArgs, FilterArgs, HeartbeatAgentArgs, HeartbeatCommand, IncidentArgs,
     IngestRateArgs, NotifyRecentArgs, NotifyTestArgs, OutputArgs, PatternsArgs, PluginHookArgs,
     SearchArgs, ServiceCommand, ServiceLogsArgs, SessionsArgs, SetupArgs, SetupCommand,
-    ShellCommand, ShellIndexArgs, SigAckArgs, SigListArgs, SigUnackArgs, SourceIpsArgs, TailArgs,
-    TimeRangeArgs, TimelineArgs,
+    ShellAtuinIndexArgs, ShellCommand, ShellIndexArgs, SigAckArgs, SigListArgs, SigUnackArgs,
+    SourceIpsArgs, TailArgs, TimeRangeArgs, TimelineArgs,
 };
 pub(crate) use args_config::{
     ConfigCommand, ConfigGetArgs, ConfigListArgs, ConfigSetArgs, ConfigTarget, ConfigUnsetArgs,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -51,6 +51,7 @@ pub(crate) enum NotifyCommand {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ShellCommand {
     Index(ShellIndexArgs),
+    AtuinIndex(ShellAtuinIndexArgs),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,6 +69,12 @@ pub(crate) enum HeartbeatCommand {
 pub(crate) struct ShellIndexArgs {
     pub path: String,
     pub shell: String,
+    pub json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShellAtuinIndexArgs {
+    pub path: String,
     pub json: bool,
 }
 

--- a/src/cli/dispatch_command_log.rs
+++ b/src/cli/dispatch_command_log.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use anyhow::{bail, Result};
 use syslog_mcp::command_log::{self, CommandLogImportResult};
 
-use super::{AgentCommandIngestSpoolArgs, AgentCommandWrapArgs, CliMode, ShellIndexArgs};
+use super::{
+    AgentCommandIngestSpoolArgs, AgentCommandWrapArgs, CliMode, ShellAtuinIndexArgs, ShellIndexArgs,
+};
 
 pub(crate) async fn run_shell_index(mode: &CliMode, args: ShellIndexArgs) -> Result<()> {
     let CliMode::Local(service) = mode else {
@@ -13,6 +15,16 @@ pub(crate) async fn run_shell_index(mode: &CliMode, args: ShellIndexArgs) -> Res
         .import_shell_history(PathBuf::from(args.path), args.shell)
         .await?;
     print_import_result("shell index", &result, args.json)
+}
+
+pub(crate) async fn run_shell_atuin_index(mode: &CliMode, args: ShellAtuinIndexArgs) -> Result<()> {
+    let CliMode::Local(service) = mode else {
+        bail!("shell atuin-index is local-only; run without --http/--server/--token");
+    };
+    let result = service
+        .import_atuin_history(PathBuf::from(args.path))
+        .await?;
+    print_import_result("shell atuin-index", &result, args.json)
 }
 
 pub(crate) async fn run_agent_command_ingest_spool(

--- a/src/cli/output_ai.rs
+++ b/src/cli/output_ai.rs
@@ -194,7 +194,9 @@ pub(crate) fn print_ai_watch_status_response(
         }
         None => println!("health: unavailable (DB unreachable)"),
     }
-    if !response.latest_journal.is_empty() {
+    if let Some(err) = response.journal_error.as_deref() {
+        println!("latest_journal: (unavailable: {err})");
+    } else if !response.latest_journal.is_empty() {
         println!("latest_journal:");
         for line in &response.latest_journal {
             println!("  {line}");

--- a/src/cli/output_ai.rs
+++ b/src/cli/output_ai.rs
@@ -172,6 +172,10 @@ pub(crate) fn print_ai_watch_status_response(
         response.exec_start.as_deref().unwrap_or("-")
     );
     println!(
+        "exec_main_start_timestamp: {}",
+        response.exec_main_start_timestamp.as_deref().unwrap_or("-")
+    );
+    println!(
         "process_start_time: {}",
         response.process_start_time.as_deref().unwrap_or("-")
     );

--- a/src/cli/output_ai.rs
+++ b/src/cli/output_ai.rs
@@ -196,7 +196,13 @@ pub(crate) fn print_ai_watch_status_response(
                 println!("stale_indicators: {}", h.stale_indicators.join(", "));
             }
         }
-        None => println!("health: unavailable (DB unreachable)"),
+        None => {
+            if let Some(err) = response.health_error.as_deref() {
+                println!("health: unavailable ({err})");
+            } else {
+                println!("health: unavailable");
+            }
+        }
     }
     if let Some(err) = response.journal_error.as_deref() {
         println!("latest_journal: (unavailable: {err})");

--- a/src/cli/output_ai.rs
+++ b/src/cli/output_ai.rs
@@ -176,31 +176,23 @@ pub(crate) fn print_ai_watch_status_response(
         response.process_start_time.as_deref().unwrap_or("-")
     );
     println!("db_path: {}", response.db_path);
-    println!(
-        "db_schema_version: {}/{}",
-        response.health.db_schema_version, response.health.known_schema_version
-    );
-    println!(
-        "schema_drift_detected: {}",
-        response.health.schema_drift_detected
-    );
-    println!(
-        "last_successful_ingest_at: {}",
-        response
-            .health
-            .last_successful_ingest_at
-            .as_deref()
-            .unwrap_or("-")
-    );
-    println!(
-        "recent_failure_count: {}",
-        response.health.recent_failure_count
-    );
-    if !response.health.stale_indicators.is_empty() {
-        println!(
-            "stale_indicators: {}",
-            response.health.stale_indicators.join(", ")
-        );
+    match response.health.as_ref() {
+        Some(h) => {
+            println!(
+                "db_schema_version: {}/{}",
+                h.db_schema_version, h.known_schema_version
+            );
+            println!("schema_drift_detected: {}", h.schema_drift_detected);
+            println!(
+                "last_successful_ingest_at: {}",
+                h.last_successful_ingest_at.as_deref().unwrap_or("-")
+            );
+            println!("recent_failure_count: {}", h.recent_failure_count);
+            if !h.stale_indicators.is_empty() {
+                println!("stale_indicators: {}", h.stale_indicators.join(", "));
+            }
+        }
+        None => println!("health: unavailable (DB unreachable)"),
     }
     if !response.latest_journal.is_empty() {
         println!("latest_journal:");

--- a/src/cli/parse_command_log.rs
+++ b/src/cli/parse_command_log.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 
 use super::{
     AgentCommandCommand, AgentCommandIngestSpoolArgs, AgentCommandWrapArgs, CliCommand,
-    ShellCommand, ShellIndexArgs,
+    ShellAtuinIndexArgs, ShellCommand, ShellIndexArgs,
 };
 
 pub(crate) fn parse_shell(args: &[String]) -> Result<CliCommand> {
@@ -11,6 +11,7 @@ pub(crate) fn parse_shell(args: &[String]) -> Result<CliCommand> {
         .ok_or_else(|| anyhow::anyhow!("shell subcommand is required"))?;
     match command.as_str() {
         "index" => parse_shell_index(rest),
+        "atuin-index" => parse_shell_atuin_index(rest),
         _ => bail!("unknown shell subcommand: {command}"),
     }
 }
@@ -55,6 +56,27 @@ fn parse_shell_index(args: &[String]) -> Result<CliCommand> {
         shell,
         json,
     })))
+}
+
+fn parse_shell_atuin_index(args: &[String]) -> Result<CliCommand> {
+    let mut path = None;
+    let mut json = false;
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--path" => {
+                i += 1;
+                path = Some(required_value(args, i, "--path")?);
+            }
+            "--json" => json = true,
+            other => bail!("unknown shell atuin-index argument: {other}"),
+        }
+        i += 1;
+    }
+    let path = path.ok_or_else(|| anyhow::anyhow!("shell atuin-index requires --path PATH"))?;
+    Ok(CliCommand::Shell(ShellCommand::AtuinIndex(
+        ShellAtuinIndexArgs { path, json },
+    )))
 }
 
 fn parse_agent_command_ingest_spool(args: &[String]) -> Result<CliCommand> {

--- a/src/cli/parse_command_log_tests.rs
+++ b/src/cli/parse_command_log_tests.rs
@@ -22,6 +22,26 @@ fn parses_shell_index() {
 }
 
 #[test]
+fn parses_shell_atuin_index() {
+    let args = vec![
+        "atuin-index".to_string(),
+        "--path".to_string(),
+        "/tmp/atuin/history.db".to_string(),
+        "--json".to_string(),
+    ];
+
+    let command = parse_shell(&args).unwrap();
+
+    match command {
+        CliCommand::Shell(ShellCommand::AtuinIndex(args)) => {
+            assert_eq!(args.path, "/tmp/atuin/history.db");
+            assert!(args.json);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
 fn parses_agent_command_ingest_spool() {
     let args = vec![
         "ingest-spool".to_string(),

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -90,6 +90,9 @@ pub(crate) async fn run(mode: CliMode, command: CliCommand) -> Result<()> {
             ShellCommand::Index(args) => {
                 super::dispatch_command_log::run_shell_index(&mode, args).await
             }
+            ShellCommand::AtuinIndex(args) => {
+                super::dispatch_command_log::run_shell_atuin_index(&mode, args).await
+            }
         },
         CliCommand::AgentCommand(command) => match command {
             AgentCommandCommand::IngestSpool(args) => {
@@ -139,7 +142,9 @@ pub(crate) async fn run(mode: CliMode, command: CliCommand) -> Result<()> {
             )
         }
         CliCommand::Config(_) => {
-            bail!("internal: config commands must be dispatched by main::run_cli before reaching cli::run()")
+            bail!(
+                "internal: config commands must be dispatched by main::run_cli before reaching cli::run()"
+            )
         }
     }
 }

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -256,7 +256,13 @@ pub fn import_agent_command_spool(
         result.scanned += 1;
         let line = match line {
             Ok(line) => line,
-            Err(_) => {
+            Err(e) => {
+                tracing::warn!(
+                    line = result.scanned,
+                    error_kind = "io",
+                    error = %e,
+                    "failed to read line from agent command spool"
+                );
                 result.errors += 1;
                 continue;
             }
@@ -274,7 +280,16 @@ pub fn import_agent_command_spool(
                     batch.push(entry);
                 }
             }
-            Err(_) => result.errors += 1,
+            Err(e) => {
+                tracing::warn!(
+                    line = result.scanned,
+                    error_kind = "json",
+                    error = %e,
+                    line_preview = %&line[..line.len().min(80)],
+                    "failed to parse agent command spool record"
+                );
+                result.errors += 1;
+            }
         }
     }
 

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -75,6 +75,28 @@ struct ShellHistoryImportState {
     line_no: usize,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct AtuinHistoryImportState {
+    path: String,
+    last_timestamp_ns: i64,
+    #[serde(default)]
+    last_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AtuinHistoryRecord {
+    id: String,
+    timestamp_ns: i64,
+    duration_ns: i64,
+    exit_status: i64,
+    command: String,
+    cwd: String,
+    session: String,
+    hostname: String,
+    author: Option<String>,
+    intent: Option<String>,
+}
+
 pub fn import_zsh_history(
     pool: &db::DbPool,
     path: &Path,
@@ -141,6 +163,74 @@ fn import_zsh_history_with_state(
         result.imported = db::insert_logs_batch(pool, &batch)?;
     }
     write_shell_history_state(state_path, path, shell, next_offset, line_no)?;
+    Ok(result)
+}
+
+pub fn import_atuin_history(pool: &db::DbPool, path: &Path) -> Result<CommandLogImportResult> {
+    let state_path = atuin_history_state_path(path)?;
+    import_atuin_history_with_state(pool, path, &state_path)
+}
+
+fn import_atuin_history_with_state(
+    pool: &db::DbPool,
+    path: &Path,
+    state_path: &Path,
+) -> Result<CommandLogImportResult> {
+    let state = read_atuin_history_state(state_path, path)?.unwrap_or_default();
+    let conn =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .with_context(|| format!("open atuin history {}", path.display()))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, timestamp, duration, exit, command, cwd, session, hostname, author, intent
+             FROM history
+             WHERE deleted_at IS NULL
+               AND (timestamp > ?1 OR (timestamp = ?1 AND id > ?2))
+             ORDER BY timestamp ASC, id ASC",
+        )
+        .with_context(|| format!("prepare atuin history query {}", path.display()))?;
+    let records = stmt
+        .query_map((&state.last_timestamp_ns, &state.last_id), |row| {
+            Ok(AtuinHistoryRecord {
+                id: row.get(0)?,
+                timestamp_ns: row.get(1)?,
+                duration_ns: row.get(2)?,
+                exit_status: row.get(3)?,
+                command: row.get(4)?,
+                cwd: row.get(5)?,
+                session: row.get(6)?,
+                hostname: row.get(7)?,
+                author: row.get(8)?,
+                intent: row.get(9)?,
+            })
+        })
+        .with_context(|| format!("read atuin history {}", path.display()))?;
+
+    let user = username();
+    let mut result = CommandLogImportResult::default();
+    let mut batch = Vec::new();
+    let mut last_timestamp_ns = state.last_timestamp_ns;
+    let mut last_id = state.last_id;
+    for record in records {
+        let record = record.with_context(|| format!("decode atuin history {}", path.display()))?;
+        result.scanned += 1;
+        last_timestamp_ns = record.timestamp_ns;
+        last_id = record.id.clone();
+        let Some(entry) = atuin_record_to_entry(&record, path, user.as_deref()) else {
+            result.skipped += 1;
+            continue;
+        };
+        if entry_exists(pool, &entry)? {
+            result.skipped_duplicates += 1;
+        } else {
+            batch.push(entry);
+        }
+    }
+
+    if !batch.is_empty() {
+        result.imported = db::insert_logs_batch(pool, &batch)?;
+    }
+    write_atuin_history_state(state_path, path, last_timestamp_ns, &last_id)?;
     Ok(result)
 }
 
@@ -391,6 +481,78 @@ fn zsh_record_to_entry(
     entry
 }
 
+fn atuin_record_to_entry(
+    record: &AtuinHistoryRecord,
+    path: &Path,
+    user: Option<&str>,
+) -> Option<LogBatchEntry> {
+    let secs = record.timestamp_ns.div_euclid(1_000_000_000);
+    let nanos = record.timestamp_ns.rem_euclid(1_000_000_000) as u32;
+    let started_at = DateTime::<Utc>::from_timestamp(secs, nanos)?;
+    let command = scrub_command(&record.command);
+    let exit_status = if record.exit_status >= 0 {
+        Some(record.exit_status)
+    } else {
+        None
+    };
+    let severity = match exit_status {
+        Some(0) => "info",
+        Some(_) => "warning",
+        None => "err",
+    };
+    let duration_ms = if record.duration_ns >= 0 {
+        Some(record.duration_ns / 1_000_000)
+    } else {
+        None
+    };
+    let metadata_json = bounded_metadata_json(serde_json::json!({
+        "source_type": "shell_history",
+        "source_kind": SourceKind::ShellHistory.as_str(),
+        "shell": {
+            "name": "atuin",
+            "user": user,
+            "history_path": path.display().to_string(),
+            "id": record.id,
+            "cwd": record.cwd,
+            "session": record.session,
+            "exit_status": exit_status,
+            "duration_ms": duration_ms,
+            "author": record.author,
+            "intent": record.intent,
+            "timestamp_quality": "atuin_sqlite"
+        },
+        "content_scrubbed": true,
+    }));
+    let mut entry = LogBatchEntry {
+        timestamp: rfc3339(started_at),
+        hostname: record.hostname.clone(),
+        facility: Some("shell".to_string()),
+        severity: severity.to_string(),
+        app_name: Some("atuin".to_string()),
+        process_id: None,
+        message: command.clone(),
+        raw: command,
+        source_ip: format!(
+            "shell-history://{}/{}/atuin",
+            sanitize_uri_segment(&record.hostname),
+            sanitize_uri_segment(user.unwrap_or("unknown"))
+        ),
+        docker_checkpoint: None,
+        ai_tool: None,
+        ai_project: Some(record.cwd.clone()),
+        ai_session_id: Some(record.session.clone()),
+        ai_transcript_path: None,
+        metadata_json: Some(metadata_json),
+        http_status: None,
+        auth_outcome: None,
+        dns_blocked: None,
+        event_action: Some("command".to_string()),
+        parse_error: None,
+    };
+    stamp_source_kind(&mut entry, SourceKind::ShellHistory);
+    Some(entry)
+}
+
 fn agent_record_to_entry(record: &AgentCommandSpoolRecord) -> LogBatchEntry {
     let command = scrub_command(&record.command);
     let exit_status = record.exit_status;
@@ -517,6 +679,15 @@ fn shell_history_state_path(path: &Path, shell: &str) -> Result<PathBuf> {
     )))
 }
 
+fn atuin_history_state_path(path: &Path) -> Result<PathBuf> {
+    let state_dir = command_log_state_dir(path)?;
+    let identity = format!("atuin\0{}", path.display());
+    Ok(state_dir.join(format!(
+        "atuin-history-{:016x}.json",
+        stable_hash(&identity)
+    )))
+}
+
 fn command_log_state_dir(path: &Path) -> Result<PathBuf> {
     if let Some(value) = std::env::var_os("SYSLOG_COMMAND_LOG_STATE_DIR") {
         let state_dir = PathBuf::from(value);
@@ -552,7 +723,7 @@ fn read_shell_history_state(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
             return Err(error)
-                .with_context(|| format!("read shell history state {}", state_path.display()))
+                .with_context(|| format!("read shell history state {}", state_path.display()));
         }
     };
     let state: ShellHistoryImportState = serde_json::from_str(&raw)
@@ -597,6 +768,63 @@ fn write_shell_history_state(
     let mut file = options
         .open(state_path)
         .with_context(|| format!("open shell history state {}", state_path.display()))?;
+    serde_json::to_writer(&mut file, &state)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn read_atuin_history_state(
+    state_path: &Path,
+    history_path: &Path,
+) -> Result<Option<AtuinHistoryImportState>> {
+    let raw = match fs::read_to_string(state_path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("read atuin history state {}", state_path.display()));
+        }
+    };
+    let state: AtuinHistoryImportState = serde_json::from_str(&raw)
+        .with_context(|| format!("parse atuin history state {}", state_path.display()))?;
+    if state.path == history_path.display().to_string() {
+        Ok(Some(state))
+    } else {
+        Ok(None)
+    }
+}
+
+fn write_atuin_history_state(
+    state_path: &Path,
+    history_path: &Path,
+    last_timestamp_ns: i64,
+    last_id: &str,
+) -> Result<()> {
+    if let Some(parent) = state_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create atuin history state dir {}", parent.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(parent, fs::Permissions::from_mode(0o700))
+                .with_context(|| format!("chmod atuin history state dir {}", parent.display()))?;
+        }
+    }
+    let state = AtuinHistoryImportState {
+        path: history_path.display().to_string(),
+        last_timestamp_ns,
+        last_id: last_id.to_string(),
+    };
+    let mut options = OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(state_path)
+        .with_context(|| format!("open atuin history state {}", state_path.display()))?;
     serde_json::to_writer(&mut file, &state)?;
     file.write_all(b"\n")?;
     Ok(())

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -217,7 +217,12 @@ fn import_atuin_history_with_state(
         last_timestamp_ns = record.timestamp_ns;
         last_id = record.id.clone();
         let Some(entry) = atuin_record_to_entry(&record, path, user.as_deref()) else {
-            result.skipped += 1;
+            tracing::warn!(
+                record_id = %record.id,
+                timestamp_ns = record.timestamp_ns,
+                "atuin record has out-of-range timestamp; skipping"
+            );
+            result.errors += 1;
             continue;
         };
         if entry_exists(pool, &entry)? {

--- a/src/command_log_tests.rs
+++ b/src/command_log_tests.rs
@@ -208,6 +208,124 @@ fn imports_zsh_history_from_saved_offset() {
 }
 
 #[test]
+fn imports_atuin_history_as_shell_history_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("syslog.db");
+    let pool = init_pool(&StorageConfig::for_test(db_path)).unwrap();
+    let atuin = dir.path().join("history.db");
+    let conn = rusqlite::Connection::open(&atuin).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE history (
+            id TEXT PRIMARY KEY,
+            timestamp INTEGER NOT NULL,
+            duration INTEGER NOT NULL,
+            exit INTEGER NOT NULL,
+            command TEXT NOT NULL,
+            cwd TEXT NOT NULL,
+            session TEXT NOT NULL,
+            hostname TEXT NOT NULL,
+            deleted_at INTEGER,
+            author TEXT,
+            intent TEXT
+        );",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO history (id, timestamp, duration, exit, command, cwd, session, hostname)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        rusqlite::params![
+            "hist-1",
+            1_716_500_000_123_000_000_i64,
+            3_000_000_000_i64,
+            2_i64,
+            "export API_KEY=abc123",
+            "/tmp/project",
+            "session-1",
+            "dookie"
+        ],
+    )
+    .unwrap();
+
+    let result = import_atuin_history_with_state(
+        &pool,
+        &atuin,
+        dir.path().join("atuin-state.json").as_path(),
+    )
+    .unwrap();
+
+    assert_eq!(result.scanned, 1);
+    assert_eq!(result.imported, 1);
+    let rows = search_logs(
+        &pool,
+        &SearchParams {
+            query: Some("export".into()),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].hostname, "dookie");
+    assert_eq!(rows[0].facility.as_deref(), Some("shell"));
+    assert_eq!(rows[0].app_name.as_deref(), Some("atuin"));
+    assert_eq!(rows[0].severity, "warning");
+    assert!(rows[0].message.contains("[REDACTED]"));
+    let metadata = rows[0].metadata_json.as_deref().unwrap();
+    assert!(metadata.contains("\"source_kind\":\"shell-history\""));
+    assert!(metadata.contains("\"session\":\"session-1\""));
+    assert!(metadata.contains("\"cwd\":\"/tmp/project\""));
+}
+
+#[test]
+fn imports_atuin_history_from_saved_timestamp_cursor() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("syslog.db");
+    let pool = init_pool(&StorageConfig::for_test(db_path)).unwrap();
+    let atuin = dir.path().join("history.db");
+    let state = dir.path().join("atuin-state.json");
+    let conn = rusqlite::Connection::open(&atuin).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE history (
+            id TEXT PRIMARY KEY,
+            timestamp INTEGER NOT NULL,
+            duration INTEGER NOT NULL,
+            exit INTEGER NOT NULL,
+            command TEXT NOT NULL,
+            cwd TEXT NOT NULL,
+            session TEXT NOT NULL,
+            hostname TEXT NOT NULL,
+            deleted_at INTEGER,
+            author TEXT,
+            intent TEXT
+        );",
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO history (id, timestamp, duration, exit, command, cwd, session, hostname)
+         VALUES ('hist-1', 1716500000000000000, 1000, 0, 'cargo test', '/tmp/project', 's1', 'dookie')",
+        [],
+    )
+    .unwrap();
+
+    let first = import_atuin_history_with_state(&pool, &atuin, &state).unwrap();
+    conn.execute(
+        "INSERT INTO history (id, timestamp, duration, exit, command, cwd, session, hostname)
+         VALUES ('hist-2', 1716500001000000000, 1000, 0, 'cargo fmt', '/tmp/project', 's1', 'dookie')",
+        [],
+    )
+    .unwrap();
+    let second = import_atuin_history_with_state(&pool, &atuin, &state).unwrap();
+    let third = import_atuin_history_with_state(&pool, &atuin, &state).unwrap();
+
+    assert_eq!(first.scanned, 1);
+    assert_eq!(first.imported, 1);
+    assert_eq!(second.scanned, 1);
+    assert_eq!(second.imported, 1);
+    assert_eq!(third.scanned, 0);
+    assert_eq!(third.imported, 0);
+}
+
+#[test]
 fn imports_agent_spool_as_agent_command_rows() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("syslog.db");

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -533,8 +533,9 @@ fn status_errors_when_data_volume_has_unexpected_name() {
 #[test]
 fn status_errors_when_bind_mount_does_not_match_configured_data_volume() {
     let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME"]);
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
     env.set("SYSLOG_MCP_DATA_VOLUME", "/home/jmagar/.syslog-mcp/data");
+    env.remove("SYSLOG_ENV_FILE");
 
     let mut container = labelled_container();
     container.mounts[0].kind = "bind".into();
@@ -601,6 +602,10 @@ fn status_expected_data_mount_uses_configured_env_file() {
 
 #[test]
 fn status_errors_when_data_volume_is_missing() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
+    env.set("SYSLOG_MCP_DATA_VOLUME", "syslog-mcp-data");
+    env.remove("SYSLOG_ENV_FILE");
     let mut container = labelled_container();
     container.mounts.clear(); // no /data mount at all
     let service = ComposeService::new(

--- a/src/compose_tests.rs
+++ b/src/compose_tests.rs
@@ -134,10 +134,10 @@ fn labelled_container() -> ContainerInfo {
         image_id: Some("sha256:abc".into()),
         labels,
         mounts: vec![MountInfo {
-            source: Some(PathBuf::from("/home/jmagar/.syslog-mcp/data")),
+            source: None,
             target: "/data".into(),
-            kind: "bind".into(),
-            volume_name: None,
+            kind: "volume".into(),
+            volume_name: Some("syslog-mcp-data".into()),
         }],
         ports: vec![PortInfo {
             private_port: 3100,
@@ -456,8 +456,9 @@ fn docker_unavailable_code_uses_typed_error() {
 #[test]
 fn status_reports_systemd_check_failures_as_diagnostics() {
     let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
-    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME"]);
-    env.set("SYSLOG_MCP_DATA_VOLUME", "/home/jmagar/.syslog-mcp/data");
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
+    env.set("SYSLOG_MCP_DATA_VOLUME", "syslog-mcp-data");
+    env.remove("SYSLOG_ENV_FILE");
 
     let service = ComposeService::new(
         FakeInspector {
@@ -575,6 +576,8 @@ fn status_expected_data_mount_uses_configured_env_file() {
     env.set("SYSLOG_ENV_FILE", env_file.to_str().unwrap());
 
     let mut container = labelled_container();
+    container.mounts[0].kind = "bind".into();
+    container.mounts[0].volume_name = None;
     container.mounts[0].source = Some(data_dir);
     let service = ComposeService::new(
         FakeInspector {
@@ -833,6 +836,11 @@ fn up_refuses_non_target_listener() {
 
 #[test]
 fn live_target_allows_listener_on_published_target_port() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
+    env.set("SYSLOG_MCP_DATA_VOLUME", "syslog-mcp-data");
+    env.remove("SYSLOG_ENV_FILE");
+
     let mut owners = BTreeMap::new();
     owners.insert(3100, "abc".into());
     let service = ComposeService::new(
@@ -857,6 +865,11 @@ fn live_target_allows_listener_on_published_target_port() {
 
 #[test]
 fn live_target_refuses_foreign_docker_proxy_on_published_port() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
+    env.set("SYSLOG_MCP_DATA_VOLUME", "syslog-mcp-data");
+    env.remove("SYSLOG_ENV_FILE");
+
     let mut owners = BTreeMap::new();
     owners.insert(3100, "foreign-container".into());
     let service = ComposeService::new(
@@ -882,6 +895,11 @@ fn live_target_refuses_foreign_docker_proxy_on_published_port() {
 
 #[test]
 fn live_target_refuses_listener_on_unpublished_target_port() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
+    env.set("SYSLOG_MCP_DATA_VOLUME", "syslog-mcp-data");
+    env.remove("SYSLOG_ENV_FILE");
+
     let service = ComposeService::new(
         FakeInspector {
             container: Some(labelled_container()),
@@ -904,6 +922,11 @@ fn live_target_refuses_listener_on_unpublished_target_port() {
 
 #[test]
 fn live_target_refuses_foreign_listener_even_on_published_port() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
+    env.set("SYSLOG_MCP_DATA_VOLUME", "syslog-mcp-data");
+    env.remove("SYSLOG_ENV_FILE");
+
     let service = ComposeService::new(
         FakeInspector {
             container: Some(labelled_container()),
@@ -926,6 +949,11 @@ fn live_target_refuses_foreign_listener_even_on_published_port() {
 
 #[test]
 fn live_target_refuses_published_listener_with_unknown_owner() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
+    env.set("SYSLOG_MCP_DATA_VOLUME", "syslog-mcp-data");
+    env.remove("SYSLOG_ENV_FILE");
+
     let service = ComposeService::new(
         FakeInspector {
             container: Some(labelled_container()),
@@ -948,6 +976,11 @@ fn live_target_refuses_published_listener_with_unknown_owner() {
 
 #[test]
 fn live_target_allows_listener_without_process_info_when_docker_confirms_owner() {
+    let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let env = EnvGuard::new(&["SYSLOG_MCP_DATA_VOLUME", "SYSLOG_ENV_FILE"]);
+    env.set("SYSLOG_MCP_DATA_VOLUME", "syslog-mcp-data");
+    env.remove("SYSLOG_ENV_FILE");
+
     // Non-root scenario: ss cannot report process names so the listener has no
     // "users:" field, but docker ps confirms the target container owns the port.
     let mut owners = BTreeMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -811,6 +811,7 @@ fn print_usage() {
   syslog ai watch-status [--json]
   syslog ai smoke-watch [--json]
   syslog shell index --path PATH [--shell zsh] [--json]
+  syslog shell atuin-index --path PATH [--json]
   syslog agent-command ingest-spool --path PATH [--json]
   syslog agent-command wrap --spool PATH -- COMMAND...
   syslog heartbeat agent [--target URL] [--token TOKEN] [--interval-secs N] [--probe-deadline-ms N] [--collection-deadline-ms N] [--retry-buffer N] [--host-id-path PATH] [--once|--emit] [--json]


### PR DESCRIPTION
## Summary

- **P1 fix**: `ai_watcher_process_start_time()` spawned `systemctl` via blocking I/O directly in an async fn — wrapped with `tokio::task::spawn_blocking` to avoid stalling the executor
- **P1 fix**: `health` degrades to `None` on DB failure instead of propagating the error — status command always returns `Ok` even during DB outages
- **D-Bus guard** unified: previously only applied to `journalctl` in `run_command`; now covers all `--user` commands in both `run_command` and `probe_command`
- **journalctl failure** surfaced as `journal_error: Option<String>` field — callers can distinguish "empty log" from "fetch failed"
- **5 parallel systemctl probes** via `tokio::join!` — worst-case latency drops from 150s to 30s
- **Warning logs** in `probe_systemctl` now log `args_owned` (includes `--user`) instead of bare args
- **4 new tests** covering main_pid parsing, health-field contract, journal error surfacing, exit code encoding fix

## Test plan

- [ ] All 856 unit tests pass (verified by pre-push hook)
- [ ] `syslog ai watch-status` returns `Ok` even when DB is unreachable
- [ ] `health: null` appears in JSON output during DB outage
- [ ] `journal_error` set when journalctl unavailable

## Open follow-ups

- `syslog-mcp-23xf` (P2): Update MCP schema to document `health: Option`
- `syslog-mcp-dliq` (P2): Add test that forces `health=None` branch
- `syslog-mcp-bl7t` (P3): Deduplicate D-Bus injection with OnceLock
- `syslog-mcp-s7te` (P3): Print `exec_main_start_timestamp` in CLI output
- `syslog-mcp-15h9` (P3): Document `journal_error`/`latest_journal` mutual exclusion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves ai watch-status reliability and latency with parallel `systemctl` probes, async safety, and clear degradation paths when DB/journal are unavailable. Adds `syslog shell atuin-index` to import Atuin history, and updates JSON/CLI: `health` is optional with `health_error`/`journal_error`, and CLI shows `exec_main_start_timestamp`.

- **Bug Fixes**
  - Status always returns Ok; on DB failure `health=None` with `health_error`; journal failures set `journal_error` and keep logs empty (JSON omits absent fields).
  - Runs 5 `systemctl` probes in parallel; wraps blocking start-time call in `spawn_blocking`; improves probe handling/logs (accept non-empty stdout on non-zero exit; log full args).
  - Unifies D‑Bus env for all `--user` commands via `apply_dbus_env`; gates Unix-only tests; stabilizes compose tests with `syslog-mcp-data` and `SYSLOG_ENV_FILE` overrides; better spool error logs.

- **New Features**
  - `syslog shell atuin-index --path PATH [--json]` imports Atuin SQLite history with a resumable timestamp/id cursor.
  - Human output shows `exec_main_start_timestamp`; JSON adds `health_error` and `journal_error`; `health` is now optional.

<sup>Written for commit 610e1cb47e45a8bef3e109df95b0ecd87bf21a1d. Summary will update on new commits. <a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/55?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Atuin shell-history import with a new local CLI command to run it.
  * Health status is now optional and shown as "unavailable" with an error detail when DB health cannot be read.
  * Journal probe now reports an explicit unavailable message with error detail when fetching fails.

* **Bug Fixes**
  * System probes and health checks degrade gracefully on partial failures instead of hard-erroring.

* **Chores**
  * Updated pre-commit hooks for linting and formatting checks.

* **Documentation**
  * Added a maintenance handoff session document.

* **Tests**
  * Expanded tests for graceful degradation, journal error reporting, PID/health parsing, and Atuin import behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->