### PR TITLE
feat: complete CLI/API/MCP route parity (3 new routes + 3 unblocked)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "syslog",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-05-27
+
+### Added
+
+- Three new HTTP routes that close MCP/HTTP parity gaps:
+  - `GET /api/host-state` — bounded per-host heartbeat snapshot. 400 for
+    missing `host_id`/`hostname` or invalid `since` timestamp; 404 for
+    unknown host.
+  - `GET /api/context` — pivot-window log context around a `log_id` or
+    `hostname`+`timestamp`. 400 for missing pivot; 404 for unknown log.
+  - `GET /api/fleet-state` — fleet-wide heartbeat snapshot with pressure
+    flags and summary counts (`include_ok`, `sort` query params).
+- Registered `fleet_state` as a first-class MCP action so all three
+  surfaces (CLI, REST, MCP) see the same catalog. Tool dispatch, schema,
+  help text, and the registry-coverage fence files were updated.
+- `HttpClient` wrappers for `similar_incidents`, `ask_history`, and
+  `incident_context` — three CLI actions that previously had REST routes
+  but no client wrappers, so `--http` mode was blocked. The CLI now
+  reaches the REST surface end-to-end with Ctrl-C cancellation.
+
+### Changed
+
+- `SyslogService::host_state` now validates the `since` query parameter
+  via `parse_optional_timestamp` before passing it to SQL. Previously
+  garbage strings silently produced wrong results against
+  `sampled_at >= ?2`.
+- `SyslogService::context` now returns `ServiceError::InvalidInput` for
+  missing pivot and `ServiceError::NotFound` for unknown `log_id`. The
+  REST surface returns 400/404 instead of 500 for these client-side
+  conditions.
+- `fleet_state` MCP action cost classification: `Moderate` → `Expensive`.
+  The implementation issues N+1 DB calls across the fleet; the new
+  cost is honest about the resource profile.
+- `UnaddressedErrorsQuery` gains `#[serde(deny_unknown_fields)]` for
+  consistency with the rest of the query-string structs.
+
 ## [0.33.0] - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -23,6 +23,7 @@ that registry by `src/mcp/schemas.rs::tool_definitions()`.
 | `errors` | Error/warning summary grouped by hostname and severity level with counts | no |
 | `hosts` | List all hosts with first/last seen timestamps and total log counts | no |
 | `host_state` | Latest bounded heartbeat state for one host | no |
+| `fleet_state` | Fleet-wide heartbeat snapshot with pressure flags and summary counts | no |
 | `correlate` | Cross-host event correlation within a time window around a reference timestamp | no |
 | `stats` | Database statistics: total logs, hosts, time range, DB size, free disk, write-block status | no |
 | `status` | Lightweight runtime status: DB health, queue/backpressure state, listener/writer counters, OTLP counters | no |

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -20,7 +20,7 @@ wins.
 ## Current Actions
 
 syslog-mcp exposes one MCP tool named `syslog`. The required `action` argument
-selects one of these 41 actions:
+selects one of these 42 actions:
 
 | Action | Scope | Cost | Purpose |
 | --- | --- | --- | --- |
@@ -30,7 +30,7 @@ selects one of these 41 actions:
 | `errors` | `syslog:read` | cheap | Error/warning summary |
 | `hosts` | `syslog:read` | cheap | Known source hostnames |
 | `host_state` | `syslog:read` | moderate | Latest bounded heartbeat state for one host |
-| `fleet_state` | `syslog:read` | moderate | Fleet-wide heartbeat snapshot with pressure flags |
+| `fleet_state` | `syslog:read` | expensive | Fleet-wide heartbeat snapshot with pressure flags |
 | `correlate` | `syslog:read` | moderate | Time-window event correlation |
 | `stats` | `syslog:read` | expensive | DB statistics and runtime observability |
 | `status` | `syslog:read` | cheap | Lightweight health and runtime status |

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -30,6 +30,7 @@ selects one of these 41 actions:
 | `errors` | `syslog:read` | cheap | Error/warning summary |
 | `hosts` | `syslog:read` | cheap | Known source hostnames |
 | `host_state` | `syslog:read` | moderate | Latest bounded heartbeat state for one host |
+| `fleet_state` | `syslog:read` | moderate | Fleet-wide heartbeat snapshot with pressure flags |
 | `correlate` | `syslog:read` | moderate | Time-window event correlation |
 | `stats` | `syslog:read` | expensive | DB statistics and runtime observability |
 | `status` | `syslog:read` | cheap | Lightweight health and runtime status |

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -54,7 +54,7 @@ the repo-local debug binary at `target/debug/syslog`, so repo-local builds do
 not require an installed shell binary.
 
 Action registry covered by live/script references: `search`, `filter`, `tail`, `errors`,
-`hosts`, `host_state`, `sessions`, `search_sessions`, `abuse`, `abuse_incidents`, `abuse_investigate`, `ai_correlate`, `usage_blocks`, `project_context`,
+`hosts`, `host_state`, `fleet_state`, `sessions`, `search_sessions`, `abuse`, `abuse_incidents`, `abuse_investigate`, `ai_correlate`, `usage_blocks`, `project_context`,
 `list_ai_tools`, `list_ai_projects`, `correlate`, `stats`, `status`, `apps`,
 `source_ips`, `timeline`, `patterns`, `context`, `get`, `ingest_rate`,
 `silent_hosts`, `clock_skew`, `anomalies`, `compare`, `compose_status`,

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -13,6 +13,7 @@ syslog-mcp exposes one MCP tool named `syslog`. The required
 | `errors` | Error/warning summary by host and severity |
 | `hosts` | Host registry with first/last seen |
 | `host_state` | Latest bounded heartbeat state for one host |
+| `fleet_state` | Fleet-wide heartbeat snapshot with pressure flags and summary counts |
 | `sessions` | AI transcript sessions by project |
 | `search_sessions` | Ranked grouped session search |
 | `abuse` | Abuse hits in AI transcripts with same-session context |

--- a/docs/sessions/2026-05-27-api-route-parity-completion.md
+++ b/docs/sessions/2026-05-27-api-route-parity-completion.md
@@ -1,0 +1,140 @@
+---
+date: 2026-05-27 21:32:17 EST
+repo: git@github.com:jmagar/syslog-mcp.git
+branch: feat/api-route-parity-completion
+head: cad1349
+plan: docs/superpowers/plans/2026-05-27-api-route-parity-completion.md
+agent: Claude (Opus 4.7, 1M context)
+working directory: /home/jmagar/workspace/syslog-mcp/.worktrees/api-route-parity
+worktree: /home/jmagar/workspace/syslog-mcp/.worktrees/api-route-parity
+pr: 56 — feat: complete CLI/API/MCP route parity (3 new routes + 3 unblocked) — https://github.com/jmagar/syslog-mcp/pull/56
+---
+
+## User Request
+
+Two-step request: first, audit CLI/API/MCP feature parity in `syslog-mcp`; then use `superpowers:writing-plans` to write a plan to implement all remaining routes relevant for the API; then execute that plan through the `/work-it` workflow in an isolated worktree.
+
+## Session Overview
+
+Performed a three-surface (CLI / HTTP API / MCP) parity audit, discovered five real query gaps, wrote a 7-task TDD plan, and executed it in a `.worktrees/` checkout. The implementation added three new HTTP routes (`/api/host-state`, `/api/context`, `/api/fleet-state`), registered `fleet_state` as a first-class MCP action, added three `HttpClient` wrappers, and removed three stale `--http` `bail!` guards. After PR #56 opened, three independent review waves ran (4 lavra-style reviewers, 3 simplifier passes, 3 pr-review-toolkit roles) producing 9 actionable findings — all fixed in the same worktree. The Codex bot review then flagged the documented `/api/context` follow-up, so that was also resolved by reshaping `SyslogService::context` to return `ServiceError::InvalidInput`/`NotFound`. Final state: 1175 tests (+10 from baseline), zero lint findings, PR open and pushed.
+
+## Sequence of Events
+
+1. **Parity audit** — Dispatched a general-purpose agent to enumerate `ACTION_SPECS` in `src/mcp/actions.rs`, HTTP routes in `src/api.rs`, and CLI verbs in `src/cli/parse*.rs`. Produced a 41-action matrix.
+2. **Audit correction** — Discovered while writing the plan that the audit was wrong on `search_sessions` (it IS on HTTP as `/api/ai/search`) and missed `fleet_state` (service method exists, no MCP/HTTP exposure).
+3. **Plan authoring** — Wrote `docs/superpowers/plans/2026-05-27-api-route-parity-completion.md` with 7 TDD tasks covering the 3 missing routes + 3 orphaned-route CLI wire-up.
+4. **Worktree creation** — `git worktree add -b feat/api-route-parity-completion .worktrees/api-route-parity HEAD`.
+5. **Implementation agent** — Executed the full 7-task plan via `superpowers:executing-plans`. One deviation: `/api/context` returned 500 instead of 400/404 because `service.context()` used bare `anyhow!`; agent pinned tests with `TODO(follow-up)` markers per the plan's explicit guidance.
+6. **PR created** — `gh pr create` opened PR #56 immediately after plan completion (per work-it protocol — kicks off external reviewers).
+7. **Wave 1 review** — 4 reviewers in parallel: architecture-strategist (clean), security-sentinel (1 medium: `since` timestamp validation), silent-failure-hunter (1 medium: missing `http_or_cancel` wrapper), code-reviewer (clean). Fix agent applied all 3 in 3 commits.
+8. **Wave 2 — 3 simplifier passes** — Collapsed two `Query` wrappers (−34 LOC), trimmed redundant test name suffixes, fixed an inline-formatting drift in `smoke-test.sh`.
+9. **Wave 3 review** — 3 pr-review-toolkit roles: pr-test-analyzer (4 coverage gaps), comment-analyzer (stale `41 actions` count), type-design-analyzer (drop `ContextQuery`, reclassify `fleet_state` cost). Fix agent applied all 8 in 4 commits.
+10. **PR comment resolution** — Codex bot flagged the documented `/api/context` 500 issue. Decided to fix in-PR rather than defer; agent reshaped service errors to `ServiceError::InvalidInput`/`NotFound`, flipped pinned tests from 500 to 400/404. Posted resolution reply on PR.
+
+## Key Findings
+
+- `/api/ai/search` (already in `src/api.rs:247`) is the existing route for `search_sessions` — the audit missed this and counted it as a gap.
+- `SyslogService::fleet_state` exists at `src/app/service.rs:527` (added in commit `afd77e4`) but was never registered as an MCP action or exposed on HTTP — most egregious gap of the audit.
+- `src/cli/dispatch_ai.rs:389-423` had three `bail!("...currently runs locally only; omit --http.")` guards that were obsolete: the matching HTTP routes existed at `src/api.rs:238, 240, 239` but no `HttpClient` wrapper had been added.
+- `SyslogService::host_state` at `src/app/service.rs:505` forwarded `req.since` raw to SQL `sampled_at >= ?2`, bypassing `parse_optional_timestamp` validation that every other timestamp-bearing service method uses.
+- `SyslogService::fleet_state` at `src/app/service.rs:534-538` issues N+1 DB calls (one `heartbeat_metric_snapshot` per host) — `Cost::Moderate` classification was dishonest; reclassified to `Expensive`.
+- The schema-coverage fence test (`src/mcp/tools_tests.rs:226-248`) auto-covers new actions through its `ACTION_SPECS` iteration — no payload-mapping change was needed for `fleet_state` once added to `ACTION_SPECS`.
+- `docs/INVENTORY.md` + `docs/mcp/SCHEMA.md` + `docs/mcp/TOOLS.md` + `docs/mcp/TESTS.md` + `plugins/syslog/skills/syslog/SKILL.md` + 3 smoke-test scripts all need a row per registered action (enforced by `public_action_references_cover_schema_registry` fence) — caught only at `just test`, not at `cargo check`.
+
+## Technical Decisions
+
+- **No CLI verb additions for `host_state` / `context` / `fleet_state`.** Scoped the PR strictly to "API routes." Aurora UI consumes these directly; CLI verbs land later.
+- **In-PR fix of the Codex P2 instead of follow-up.** The fix was 15 lines using the existing `host_state` sentinel-error pattern; deferring would leave the route returning 500s for known client errors.
+- **Kept `ContextQuery` initially, then dropped it after type-design review.** Reasoning: `ContextRequest` didn't have `deny_unknown_fields`. Type reviewer pointed out the canonical type should carry the invariant; adding `deny_unknown_fields` to `ContextRequest` itself eliminated the wrapper.
+- **Pre-existing `UnaddressedErrorsQuery` missing `deny_unknown_fields` fixed.** Per work-it protocol the worktree "owns" pre-existing issues; one-line attribute add was cheap defense-in-depth.
+- **Plan format change deviation: extra commit `a8fbb8e`.** Task 3 plan step said `cargo check` suffices for MCP action registration, but the registry-coverage fence test only fires at `just test`. Implementation agent caught this and split the doc/script bookkeeping into its own commit before Task 6.
+
+## Files Modified
+
+| File | Purpose |
+|------|---------|
+| `src/api.rs` | Added 3 new GET handlers + `deny_unknown_fields` on `UnaddressedErrorsQuery`; later collapsed Query wrappers |
+| `src/api_tests.rs` | +12 tests covering happy path, 400/404, bearer-required, `deny_unknown_fields` for new routes |
+| `src/app/service.rs` | `host_state` validates `since` via `parse_optional_timestamp`; `context` returns `InvalidInput`/`NotFound` instead of `anyhow!` |
+| `src/app/models.rs` | Added `deny_unknown_fields` to `ContextRequest` |
+| `src/mcp/actions.rs` | Registered `fleet_state` ActionSpec (Read scope, Expensive cost) |
+| `src/mcp/tools.rs` | Added `tool_fleet_state` dispatch arm + handler + help-text block |
+| `src/mcp/tools_tests.rs` | Added `fleet_state_action_*` MCP dispatch tests |
+| `src/cli/http_client.rs` | Added 3 wrapper methods (similar_incidents, ask_history, incident_context) |
+| `src/cli/http_client_tests.rs` | NEW sidecar — wiremock round-trip tests for the 3 wrappers |
+| `src/cli/dispatch_ai.rs` | Removed 3 stale `bail!` guards; wrapped HTTP arms in `http_or_cancel` |
+| `src/app.rs` | Exported new request types needed by api.rs |
+| `docs/mcp/SCHEMA.md` | Bumped action count 41 → 42; added `fleet_state` row |
+| `docs/INVENTORY.md`, `docs/mcp/TOOLS.md`, `docs/mcp/TESTS.md`, `plugins/syslog/skills/syslog/SKILL.md` | Added `fleet_state` row (fence requirement) |
+| `scripts/smoke-test.sh`, `tests/test_live.sh`, `tests/mcporter/test-tools.sh` | Added `fleet_state` action to inventory lists |
+| `docs/superpowers/plans/2026-05-27-api-route-parity-completion.md` | The implementation plan itself |
+
+## Commands Executed
+
+- `git worktree add -b feat/api-route-parity-completion .worktrees/api-route-parity HEAD` — created isolated workspace
+- `just test` (run after every fix wave) — 873 → 1175 tests passing throughout
+- `just lint` (clippy `-D warnings`) — clean throughout
+- `rtk gh pr create --title ... --body ...` — opened PR #56
+- `rtk gh api repos/jmagar/syslog-mcp/pulls/56/comments` — fetched Codex inline review
+- `rtk gh pr comment 56 --body ...` — replied to Codex with resolution evidence
+
+## Errors Encountered
+
+- **Implementation agent's first cd was lost between Bash invocations.** Caught by `git status` showing `## main` instead of the branch. Fixed by including `cd <worktree>` at the start of every multi-step Bash chain.
+- **Original push command in coordinator session returned with empty output, looked successful but local was `ahead 3`.** Re-pushed from the worktree path explicitly; second push succeeded with `ok` confirmation.
+- **`http_client_tests.rs` first attempt failed on `crate::app::...` imports.** `http_client.rs` belongs to the `syslog` binary which consumes `syslog_mcp` as a library; switched to `syslog_mcp::app::...` paths.
+- **Commit 3 (wave-3 fixes) initially failed `lefthook format` pre-commit.** Reformatted and retried successfully — no `--no-verify` shortcut used.
+
+## Behavior Changes (Before/After)
+
+- `GET /api/host-state` — was 404 (route absent); now 200 with bounded heartbeat state, 400 if no host_id/hostname or invalid `since`, 404 if host unknown.
+- `GET /api/context` — was 404 (route absent); now 200 with pivot-window log context, 400 if no pivot, 404 if log_id unknown. (Initially 500 for those cases — fixed in `cad1349`.)
+- `GET /api/fleet-state` — was 404 (route absent); now 200 with fleet snapshot + pressure flags + summary counts.
+- `syslog ai similar-incidents --http`, `syslog ai ask-history --http`, `syslog ai incident-context --http` — was `bail!("...currently runs locally only; omit --http.")`; now reaches the matching HTTP route and supports Ctrl-C cancellation.
+- MCP action catalog grew from 41 → 42 actions; agents now see `fleet_state` in tool schemas.
+- `HostStateRequest.since` — was forwarded raw to SQL `sampled_at >=`; now validated as RFC3339 at the service boundary.
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---|---|---|---|
+| `just test` | all suites green, 1175 tests | 1175 passed, 1 ignored, 0 failed | pass |
+| `just lint` | clippy `-D warnings` clean | clean | pass |
+| `rtk cargo check --lib` | no errors or warnings | clean | pass |
+| `rtk gh pr view 56` | open, ahead of main | open, 14+ commits ahead | pass |
+| GitHub Actions CI | green | pending at session save (monitor running) | in-flight |
+
+## Risks and Rollback
+
+- **Surface widening risk** — three new public HTTP endpoints. Each is bearer-gated via the forced `AuthPolicy::Mounted` layer in `router()`. Rollback: revert the three handler commits (`41e18bf`, `ebd949d`, `4785171`) — pure additions, no schema/migration impact.
+- **`fleet_state` is `Expensive` cost** but exposed broadly. Agents that planned around the previous `Moderate` rating (if any) may need recalibration. Reclassification commit (`3278c2c`) is one-line and trivially revertable.
+- **`SyslogService::context` error reshape** changes wire-level status codes from 500 to 400/404 for two client-input cases. This is a behaviour change downstream consumers may observe — but a 500-on-bad-input was a bug, so no rollback expected.
+
+## Decisions Not Taken
+
+- **Did not refactor `HostStateRequest` into a `HostLookup` enum** to enforce the "exactly one of host_id / hostname" invariant at the type level. Type reviewer flagged this but explicitly deferred — refactor breaks URL-encoded query ergonomics and ripples through CLI + MCP construction sites; out of scope for a parity PR.
+- **Did not file a bead for the original context follow-up.** Resolved it in the PR instead.
+- **Did not add a live CLI smoke test for the 3 unblocked `--http` paths.** Architecture reviewer suggested it; unit-level `wiremock` coverage in `http_client_tests.rs` was deemed sufficient — live tests gated on infra availability.
+
+## References
+
+- Plan: `docs/superpowers/plans/2026-05-27-api-route-parity-completion.md`
+- PR: https://github.com/jmagar/syslog-mcp/pull/56
+- Original commit that added the `fleet_state` service method without exposure: `afd77e4`
+- The 2026-05-22 surface-parity gap closure that landed 12 routes but left these orphaned: `289d571` (this PR removes the resulting `bail!` guards)
+- Codex review comment ID: `chatgpt-codex-connector` P2 on `src/api.rs:622`
+
+## Open Questions
+
+- Should `host_state` / `context` / `fleet_state` get CLI verbs in a follow-up, or do operator surfaces consuming them via HTTP make that unnecessary?
+- Is `correlate` (currently `Cost::Moderate`) similarly mis-classified given that `fleet_state` was? Worth a sweep of the cost table.
+
+## Next Steps
+
+**Started but not completed in this session:**
+- CI checks on PR #56 are still pending (`Tests`, `Clippy`, `cargo-deny`, `Pre-publish CI gate`, CodeRabbit). Monitor running until they settle.
+
+**Follow-on tasks not yet started:**
+- `HostLookup` enum refactor for `HostStateRequest` (deferred per type-design reviewer).
+- Audit the rest of the `Cost` classifications in `src/mcp/actions.rs` for honesty (started with `fleet_state`, didn't sweep others).
+- Add CLI verbs (`syslog host-state`, `syslog context`, `syslog fleet-state`) that tunnel via `--http` to the new routes.

--- a/docs/superpowers/plans/2026-05-27-api-route-parity-completion.md
+++ b/docs/superpowers/plans/2026-05-27-api-route-parity-completion.md
@@ -1,0 +1,700 @@
+# API Route Parity Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining HTTP API parity gaps so every read action exposed on the MCP surface (and `fleet_state` on the service layer) is callable via `/api/*`, and unblock the three orphaned routes whose CLI `--http` mode is currently disabled.
+
+**Architecture:** Add three new GET handlers to `src/api.rs` (`/api/host-state`, `/api/context`, `/api/fleet-state`), register `fleet_state` as a first-class MCP action so the new HTTP route does not introduce surface drift, and remove the stale `--http` guards from `src/cli/dispatch_ai.rs` after wiring `HttpClient` methods for `similar_incidents`, `ask_history`, and `incident_context`. No changes to the service layer; every route just decodes its `Query`, calls an existing `SyslogService` method, and re-uses the shared `respond()` helper.
+
+**Tech Stack:** Rust 2024, axum 0.7, serde, sqlx (SQLite), rmcp, tokio, reqwest, anyhow.
+
+---
+
+## Background — what's actually missing
+
+From the parity audit run at the start of this session:
+
+| Action | MCP | HTTP | CLI | Status before this plan |
+|---|---|---|---|---|
+| `host_state` | yes | **no** | no | MCP-only (oversight from heartbeat post-v1 commit `afd77e4`) |
+| `context` | yes | **no** | no | MCP-only (pivot-window log context) |
+| `fleet_state` | **no** | **no** | no | `SyslogService::fleet_state` exists but is unexposed |
+| `similar_incidents` | yes | yes | guarded | route exists, CLI `--http` rejects with `bail!` |
+| `ask_history` | yes | yes | guarded | route exists, CLI `--http` rejects with `bail!` |
+| `incident_context` | yes | yes | guarded | route exists, CLI `--http` rejects with `bail!` |
+
+After this plan: every row above has working MCP + HTTP coverage, and the three orphaned routes have `HttpClient` wrappers so CLI `--http` reaches them. CLI verb additions for `host_state`, `context`, and `fleet_state` are intentionally out of scope — operator UIs (Aurora) consume the new routes directly; CLI verbs land in a follow-up.
+
+## File Structure
+
+**Modified:**
+- `src/api.rs` — three new handlers (`host_state`, `context`, `fleet_state`), three new route entries.
+- `src/api_tests.rs` — one smoke test per new route, asserting `200 OK` with a bearer token against an empty DB.
+- `src/mcp/actions.rs` — register `fleet_state` in `ACTION_SPECS` (single row).
+- `src/mcp/tools.rs` — add `"fleet_state" => tool_fleet_state(...)` arm + `tool_fleet_state` helper, mirroring `tool_host_state`.
+- `src/cli/http_client.rs` — three new methods: `similar_incidents`, `ask_history`, `incident_context`.
+- `src/cli/dispatch_ai.rs` — replace the three `bail!("...currently runs locally only; omit --http.")` arms with HTTP delegations.
+
+**Not modified:** `src/app/service.rs`, `src/app/models.rs`. Every service method and request struct needed by this plan already exists.
+
+---
+
+## Task 1: `GET /api/host-state`
+
+**Files:**
+- Modify: `src/api.rs:204-262` (route registration), append new handler after `hosts` (line 415)
+- Test: `src/api_tests.rs` (append at end-of-file, before any trailing `}`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/api_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn host_state_returns_400_without_host_id_or_hostname() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, value) = get_json(app, "/api/host-state", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+    assert!(
+        value.get("error").is_some(),
+        "missing error message: {value}"
+    );
+}
+
+#[tokio::test]
+async fn host_state_returns_404_for_unknown_host() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, _value) =
+        get_json(app, "/api/host-state?hostname=nonexistent", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --lib host_state_returns_400_without_host_id_or_hostname host_state_returns_404_for_unknown_host
+```
+
+Expected: both FAIL with `404 NOT_FOUND` (route does not exist).
+
+- [ ] **Step 3: Add the route registration**
+
+In `src/api.rs`, locate the `// --- surface parity routes ---` block (around line 221) and add the new route after `.route("/api/get", get(get_log))`:
+
+```rust
+        .route("/api/host-state", get(host_state))
+```
+
+- [ ] **Step 4: Add the import for `HostStateRequest`**
+
+In `src/api.rs`, locate the existing `use crate::app::{ ... }` import (line 16-27). Add `HostStateRequest` to the alphabetically-sorted import list (it slots between `GetLogRequest` and `IncidentContextRequest`):
+
+```rust
+use crate::app::{
+    AbuseSearchRequest, AckErrorRequest, AiCheckpointsRequest, AiCorrelateLimitPolicy,
+    AiCorrelateRequest, AiIncidentRequest, AiInvestigateRequest, AiLimitPolicy,
+    AiParseErrorsRequest, AiPruneCheckpointsRequest, AnomaliesRequest, AskHistoryRequest,
+    ClockSkewRequest, CompareRequest, CorrelateEventsRequest, DbCheckpointRequest,
+    DbIntegrityRequest, DbVacuumRequest, FilterLogsRequest, GetErrorsRequest, GetLogRequest,
+    HostStateRequest, IncidentContextRequest, IngestRateRequest, ListAiProjectsRequest,
+    ListAiToolsRequest, ListAppsRequest, ListSessionsRequest, ListSourceIpsRequest,
+    NotificationsRecentRequest, PatternsRequest, ProjectContextRequest, RequestActor,
+    SearchLogsRequest, SearchSessionsRequest, ServiceError, SilentHostsRequest,
+    SimilarIncidentsRequest, SyslogService, TailLogsRequest, TimelineRequest, UnackErrorRequest,
+    UnaddressedErrorsRequest, UsageBlocksRequest,
+};
+```
+
+- [ ] **Step 5: Add the handler**
+
+In `src/api.rs`, append after the `get_log` handler (around line 573):
+
+```rust
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HostStateQuery {
+    host_id: Option<String>,
+    hostname: Option<String>,
+    since: Option<String>,
+    limit: Option<u32>,
+}
+
+async fn host_state(
+    State(state): State<ApiState>,
+    Query(query): Query<HostStateQuery>,
+) -> impl IntoResponse {
+    respond(
+        state
+            .service
+            .host_state(HostStateRequest {
+                host_id: query.host_id,
+                hostname: query.hostname,
+                since: query.since,
+                limit: query.limit,
+            })
+            .await,
+    )
+}
+```
+
+The service already maps `"host_state requires host_id or hostname"` → `ServiceError::InvalidInput` (→ 400) and a missing host → `ServiceError::NotFound` (→ 404), so no extra mapping is needed in the handler. See `src/app/service.rs:487-525`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cargo test --lib host_state_returns_400_without_host_id_or_hostname host_state_returns_404_for_unknown_host
+```
+
+Expected: both PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add src/api.rs src/api_tests.rs
+rtk git commit -m "feat(api): expose host_state via GET /api/host-state
+
+Closes the MCP-only gap on host_state by adding a thin GET handler that
+deserialises into HostStateRequest and delegates to the existing service
+method. 400/404 mapping is inherited from the shared respond() helper."
+```
+
+---
+
+## Task 2: `GET /api/context`
+
+**Files:**
+- Modify: `src/api.rs` (route registration + handler)
+- Test: `src/api_tests.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/api_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn context_returns_400_without_pivot() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, value) = get_json(app, "/api/context", Some("secret")).await;
+    // Service requires either log_id OR (hostname+timestamp); empty query
+    // must surface as 400, not 200 with empty results.
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+    assert!(value.get("error").is_some(), "missing error: {value}");
+}
+
+#[tokio::test]
+async fn context_returns_404_for_unknown_log_id() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, _value) =
+        get_json(app, "/api/context?log_id=999999", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --lib context_returns_400_without_pivot context_returns_404_for_unknown_log_id
+```
+
+Expected: both FAIL with `404 NOT_FOUND` (route not mounted).
+
+- [ ] **Step 3: Add the route registration**
+
+In `src/api.rs`, append after the `host-state` route added in Task 1:
+
+```rust
+        .route("/api/context", get(context))
+```
+
+- [ ] **Step 4: Add the import for `ContextRequest`**
+
+In `src/api.rs`, extend the `use crate::app::{ ... }` block to include `ContextRequest` (alphabetically between `CompareRequest` and `CorrelateEventsRequest`):
+
+```rust
+    ClockSkewRequest, CompareRequest, ContextRequest, CorrelateEventsRequest,
+    DbCheckpointRequest,
+```
+
+- [ ] **Step 5: Add the handler**
+
+In `src/api.rs`, append after the `host_state` handler from Task 1:
+
+```rust
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextQuery {
+    log_id: Option<i64>,
+    hostname: Option<String>,
+    timestamp: Option<String>,
+    before: Option<u32>,
+    after: Option<u32>,
+}
+
+async fn context(
+    State(state): State<ApiState>,
+    Query(query): Query<ContextQuery>,
+) -> impl IntoResponse {
+    respond(
+        state
+            .service
+            .context(ContextRequest {
+                log_id: query.log_id,
+                hostname: query.hostname,
+                timestamp: query.timestamp,
+                before: query.before,
+                after: query.after,
+            })
+            .await,
+    )
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cargo test --lib context_returns_400_without_pivot context_returns_404_for_unknown_log_id
+```
+
+Expected: both PASS. If the 400 test fails because the service surfaces "no pivot" as `Internal`, open `src/app/service.rs:1625` and confirm it returns `ServiceError::InvalidInput` for the empty case; that mapping is required for the contract to hold. If the service maps "missing pivot" to `Internal`, file a follow-up bead — do NOT paper over it in the handler.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add src/api.rs src/api_tests.rs
+rtk git commit -m "feat(api): expose context via GET /api/context
+
+Adds the pivot-window log-context primitive to the REST surface. Mirrors
+the MCP tool_context dispatch — accepts log_id OR (hostname+timestamp),
+delegates to service.context(), and inherits 400/404 from respond()."
+```
+
+---
+
+## Task 3: Register `fleet_state` as an MCP action
+
+**Files:**
+- Modify: `src/mcp/actions.rs:74-324` (append a new `ActionSpec` row in the read-only section)
+- Modify: `src/mcp/tools.rs:8` (extend imports), `~line 45` (dispatch arm), append a `tool_fleet_state` helper alongside `tool_host_state` at ~line 177
+- Test: `src/mcp/tools.rs` already has its own integration coverage via `rmcp_server_tests.rs`; we'll add one dispatch smoke test in the existing `mcp::tools` tests module rather than spinning up an rmcp server.
+
+- [ ] **Step 1: Confirm there is no existing fleet_state dispatch**
+
+```bash
+rtk grep -n "fleet_state" src/mcp/
+```
+
+Expected: zero matches. If matches appear, STOP and re-read the file before proceeding — the action may have already been registered in a parallel branch.
+
+- [ ] **Step 2: Add the ActionSpec row**
+
+In `src/mcp/actions.rs`, locate the existing `host_state` row (around line 106-111) and append a new row immediately after it:
+
+```rust
+    ActionSpec {
+        name: "fleet_state",
+        scope: Scope::Read,
+        description: "Fleet-wide heartbeat snapshot with pressure flags",
+        cost: Cost::Moderate,
+    },
+```
+
+- [ ] **Step 3: Extend the tools.rs import**
+
+In `src/mcp/tools.rs:8`, add `FleetStateRequest` to the existing `use crate::app::{ ... }` import list (alphabetically; it sorts between `FilterLogsRequest` and `GetErrorsRequest`).
+
+- [ ] **Step 4: Add the dispatch arm**
+
+In `src/mcp/tools.rs` around line 45 (where `"host_state" => tool_host_state(...)` lives), append:
+
+```rust
+        "fleet_state" => tool_fleet_state(state, args).await,
+```
+
+- [ ] **Step 5: Add the handler helper**
+
+In `src/mcp/tools.rs`, append immediately after `tool_host_state` (around line 180):
+
+```rust
+async fn tool_fleet_state(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let req: FleetStateRequest = action_payload(args)?;
+    Ok(serde_json::to_value(state.service.fleet_state(req).await?)?)
+}
+```
+
+- [ ] **Step 6: Verify the project builds**
+
+```bash
+rtk cargo check
+```
+
+Expected: clean build, no warnings related to the new action. If `action_payload` is not in scope, copy the `use` line from `tool_host_state`'s surrounding context.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add src/mcp/actions.rs src/mcp/tools.rs
+rtk git commit -m "feat(mcp): register fleet_state as a first-class MCP action
+
+The fleet_state service method has existed since the heartbeat post-v1
+work (commit afd77e4) but was never wired into ACTION_SPECS or the tool
+dispatch table. Registering it now so the new /api/fleet-state route
+(next commit) does not introduce surface drift."
+```
+
+---
+
+## Task 4: `GET /api/fleet-state`
+
+**Files:**
+- Modify: `src/api.rs` (route registration + handler)
+- Test: `src/api_tests.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/api_tests.rs`:
+
+```rust
+#[tokio::test]
+async fn fleet_state_returns_200_with_token_on_empty_db() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, value) = get_json(app, "/api/fleet-state", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(value.get("hosts").is_some(), "missing hosts: {value}");
+    assert!(value.get("summary").is_some(), "missing summary: {value}");
+}
+
+#[tokio::test]
+async fn fleet_state_accepts_include_ok_and_sort_params() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, _value) = get_json(
+        app,
+        "/api/fleet-state?include_ok=false&sort=freshness",
+        Some("secret"),
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --lib fleet_state_returns_200_with_token_on_empty_db fleet_state_accepts_include_ok_and_sort_params
+```
+
+Expected: both FAIL with `404 NOT_FOUND`.
+
+- [ ] **Step 3: Add the route registration**
+
+In `src/api.rs`, append after the `/api/context` route added in Task 2:
+
+```rust
+        .route("/api/fleet-state", get(fleet_state))
+```
+
+- [ ] **Step 4: Add the import for `FleetStateRequest`**
+
+In `src/api.rs`, extend the `use crate::app::{ ... }` block to include `FleetStateRequest` (alphabetically between `FilterLogsRequest` and `GetErrorsRequest`):
+
+```rust
+    DbIntegrityRequest, DbVacuumRequest, FilterLogsRequest, FleetStateRequest,
+    GetErrorsRequest, GetLogRequest,
+```
+
+- [ ] **Step 5: Add the handler**
+
+In `src/api.rs`, append after the `context` handler from Task 2:
+
+```rust
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FleetStateQuery {
+    include_ok: Option<bool>,
+    sort: Option<String>,
+}
+
+async fn fleet_state(
+    State(state): State<ApiState>,
+    Query(query): Query<FleetStateQuery>,
+) -> impl IntoResponse {
+    respond(
+        state
+            .service
+            .fleet_state(FleetStateRequest {
+                include_ok: query.include_ok,
+                sort: query.sort,
+            })
+            .await,
+    )
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cargo test --lib fleet_state_returns_200_with_token_on_empty_db fleet_state_accepts_include_ok_and_sort_params
+```
+
+Expected: both PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add src/api.rs src/api_tests.rs
+rtk git commit -m "feat(api): expose fleet_state via GET /api/fleet-state
+
+Pairs with the new fleet_state MCP action. Returns the fleet-wide
+heartbeat snapshot with pressure flags and summary counts so Aurora
+operator surfaces can pull a single fleet view in one call."
+```
+
+---
+
+## Task 5: `HttpClient` wrappers for `similar_incidents`, `ask_history`, `incident_context`
+
+**Files:**
+- Modify: `src/cli/http_client.rs` (append three methods inside the `impl HttpClient` block ending around line 633)
+
+- [ ] **Step 1: Locate the insertion point**
+
+Open `src/cli/http_client.rs` and find the last existing wrapper inside `impl HttpClient`. The audit found `list_apps` at line 623 returning `Result<ListAppsResponse>`. Insert the new methods immediately after it, before the helper block that starts at line 633.
+
+- [ ] **Step 2: Confirm the imports already cover the request/response types**
+
+```bash
+rtk grep -n "SimilarIncidentsRequest\|SimilarIncidentsResponse\|AskHistoryRequest\|AskHistoryResponse\|IncidentContextRequest\|IncidentContextResponse" src/cli/http_client.rs
+```
+
+Expected: each request type appears in the existing `use` block; if any response type is missing, add it to the existing `use crate::app::{ ... }` import (the file imports request/response pairs together — pattern matches `SilentHostsRequest, SilentHostsResponse`, etc.).
+
+- [ ] **Step 3: Add the three wrapper methods**
+
+In `src/cli/http_client.rs`, append inside `impl HttpClient` (immediately after the `list_apps` method):
+
+```rust
+    pub async fn similar_incidents(
+        &self,
+        req: &SimilarIncidentsRequest,
+    ) -> Result<SimilarIncidentsResponse> {
+        self.get_json("/api/similar-incidents", Some(req)).await
+    }
+
+    pub async fn ask_history(
+        &self,
+        req: &AskHistoryRequest,
+    ) -> Result<AskHistoryResponse> {
+        self.get_json("/api/ai/ask-history", Some(req)).await
+    }
+
+    pub async fn incident_context(
+        &self,
+        req: &IncidentContextRequest,
+    ) -> Result<IncidentContextResponse> {
+        self.get_json("/api/incident-context", Some(req)).await
+    }
+```
+
+`get_json` is the existing generic helper used by every other wrapper in this file (e.g. `silent_hosts` at line 607-609); it takes the path + an optional reference to a `Serialize` request and returns `Result<T>` decoded from JSON.
+
+- [ ] **Step 4: Verify the file compiles**
+
+```bash
+rtk cargo check --lib
+```
+
+Expected: clean. If a response type is unknown, locate it in `src/app/models.rs` and add it to the import block at the top of `http_client.rs`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add src/cli/http_client.rs
+rtk git commit -m "feat(cli): add HttpClient wrappers for similar_incidents, ask_history, incident_context
+
+The REST routes for these three actions have existed since the surface
+parity gap closure (2026-05-22), but the CLI had no client method to
+reach them — dispatch_ai.rs bailed on --http with 'currently runs
+locally only'. Adding the wrappers here unblocks the guard removal in
+the next commit."
+```
+
+---
+
+## Task 6: Remove the stale `--http` guards in `dispatch_ai.rs`
+
+**Files:**
+- Modify: `src/cli/dispatch_ai.rs:389-423` (three functions: `run_ai_similar_incidents`, `run_ai_ask_history`, `run_ai_incident_context`)
+
+- [ ] **Step 1: Inspect the existing pattern**
+
+```bash
+rtk read src/cli/dispatch_ai.rs --offset 388 --limit 36
+```
+
+Confirm the three target functions match the snippet pasted in Step 2 below. If a function has drifted (extra args, different name), STOP and reconcile before editing — do not assume the original form.
+
+- [ ] **Step 2: Replace `run_ai_similar_incidents`**
+
+In `src/cli/dispatch_ai.rs`, locate the function at line 389. Replace the body with:
+
+```rust
+pub(crate) async fn run_ai_similar_incidents(mode: &CliMode, args: AiSimilarArgs) -> Result<()> {
+    let json = args.json;
+    let req = args.into_request();
+    let response = match mode {
+        CliMode::Http(client) => client.similar_incidents(&req).await?,
+        CliMode::Local(service) => service.similar_incidents(req).await?,
+    };
+    print_similar_incidents_response(&response, json)
+}
+```
+
+- [ ] **Step 3: Replace `run_ai_ask_history`**
+
+Replace the function at line 400 with:
+
+```rust
+pub(crate) async fn run_ai_ask_history(mode: &CliMode, args: AiAskHistoryArgs) -> Result<()> {
+    let json = args.json;
+    let req = args.into_request();
+    let response = match mode {
+        CliMode::Http(client) => client.ask_history(&req).await?,
+        CliMode::Local(service) => service.ask_history(req).await?,
+    };
+    print_ask_history_response(&response, json)
+}
+```
+
+- [ ] **Step 4: Replace `run_ai_incident_context`**
+
+Replace the function at line 411 with:
+
+```rust
+pub(crate) async fn run_ai_incident_context(
+    mode: &CliMode,
+    args: AiIncidentContextArgs,
+) -> Result<()> {
+    let json = args.json;
+    let req = args.into_request();
+    let response = match mode {
+        CliMode::Http(client) => client.incident_context(&req).await?,
+        CliMode::Local(service) => service.incident_context(req).await?,
+    };
+    print_incident_context_response(&response, json)
+}
+```
+
+- [ ] **Step 5: Verify the build is clean and `bail!`/`anyhow` are still actually needed**
+
+```bash
+rtk cargo check --lib --bin syslog
+```
+
+Expected: no warnings about unused `bail` imports. If `anyhow::bail` is no longer used anywhere else in the file (other host-local guards at lines 312, 325, 336, 348, 362, 373, 478 still use it — confirm with grep), keep the import.
+
+```bash
+rtk grep -n "bail!" src/cli/dispatch_ai.rs
+```
+
+Expected: matches still present at the other guard sites (`ai add`, `ai watch`, `ai index`, `ai doctor`, `ai smoke-watch`, `ai watch-status`, `ai assess`).
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+just test
+```
+
+Expected: all tests pass. The `dispatch_tests.rs` file is large — if a test asserted the old bail message, it'll fail loudly and you'll need to delete or update it. Search for the old error strings:
+
+```bash
+rtk grep -n "currently runs locally only" src/cli/
+```
+
+Expected: zero matches after this task.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add src/cli/dispatch_ai.rs
+rtk git commit -m "fix(cli): allow --http for similar_incidents, ask_history, incident_context
+
+The bail!() guards were placeholders from when the REST routes did not
+exist; they were left in place by oversight when the gap closure landed
+on 2026-05-22. With the HttpClient wrappers from the previous commit,
+these functions now have honest dual-mode support."
+```
+
+---
+
+## Task 7: End-to-end smoke verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+just test
+```
+
+Expected: green. If anything related to scope gating or `action_names()` ordering fails because of the new `fleet_state` entry in `ACTION_SPECS`, locate the failing assertion and update it to include the new action — those tests are protecting against unintentional registry changes and need an intentional bump here.
+
+- [ ] **Step 2: Run clippy**
+
+```bash
+just lint
+```
+
+Expected: clean. Common issue: a new `#[derive(Debug, Deserialize)]` struct without `Default` may trigger `clippy::derive_partial_eq_without_eq` if a downstream type needs it — none of the new query structs cross that line, but check the output.
+
+- [ ] **Step 3: Build a release binary and check version output**
+
+```bash
+just build
+./target/release/syslog --version
+```
+
+Expected: prints the current crate version. (This step exists because every prior parity-closure PR has hit a missing-feature flag or release-build divergence — running release once catches it before pushing.)
+
+- [ ] **Step 4: Run the live smoke harness if a server is reachable**
+
+```bash
+just test-live
+```
+
+Expected: passes if `SYSLOG_API_TOKEN` and a running server are configured (per CLAUDE.md). Skip on machines without a configured local instance — the unit suite from Step 1 already covers route correctness.
+
+- [ ] **Step 5: Commit any stray formatting changes from clippy/fmt**
+
+```bash
+rtk cargo fmt
+rtk git diff --stat
+```
+
+If `git diff` shows changes, commit them with `chore: cargo fmt after api parity completion`. If clean, skip.
+
+- [ ] **Step 6: Push**
+
+```bash
+rtk git pull --rebase
+bd dolt push
+rtk git push
+rtk git status
+```
+
+Expected: `git status` reports the branch is up-to-date with origin. Per CLAUDE.md's Session Completion protocol, work is not complete until this step succeeds.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Every action from the audit's "Gaps" list has a task (`host_state` → Task 1, `context` → Task 2, `fleet_state` → Tasks 3+4, `similar_incidents`/`ask_history`/`incident_context` orphan-route wire-up → Tasks 5+6). The `get` CLI-verb gap and the `status` HTTP-shape gap are out of scope — they're CLI-only changes that don't add routes.
+- **Type consistency:** `HostStateRequest`, `ContextRequest`, `FleetStateRequest`, `SimilarIncidentsRequest`, `AskHistoryRequest`, `IncidentContextRequest` and their `*Response` counterparts all exist in `src/app/models.rs` today — no struct definitions need to be added.
+- **No placeholders:** every step has either runnable code, a runnable command with expected output, or both.
+- **DRY:** each handler is a thin `Query` → `Request` → `service.method().await` → `respond()` shim that exactly mirrors the existing handlers in `src/api.rs` (`silent_hosts`, `clock_skew`, `anomalies`). The plan does not invent a new pattern.
+- **TDD:** every route task starts with a failing test and ends with a green run; the MCP action registration (Task 3) is checked by `cargo check` because it has no behaviour worth a unit test on its own — the integration coverage from Task 4's HTTP smoke tests will exercise the new service path end-to-end through the REST surface.

--- a/docs/superpowers/plans/2026-05-27-api-route-parity-completion.md
+++ b/docs/superpowers/plans/2026-05-27-api-route-parity-completion.md
@@ -165,6 +165,14 @@ method. 400/404 mapping is inherited from the shared respond() helper."
 
 ## Task 2: `GET /api/context`
 
+> **Deviation note (resolved in commit `cad1349`):** during initial implementation
+> the service surfaced "missing pivot" / "unknown log_id" as `Internal` errors,
+> which mapped to HTTP 500. The wave-3 fix reshaped `service.context()` to
+> return `ServiceError::InvalidInput` / `ServiceError::NotFound`, so the
+> handler now inherits the documented 400 / 404 mapping via `respond()`.
+> The snippets below already reflect that final shape — a replay should
+> produce 400/404, not 500.
+
 **Files:**
 - Modify: `src/api.rs` (route registration + handler)
 - Test: `src/api_tests.rs`
@@ -299,7 +307,7 @@ In `src/mcp/actions.rs`, locate the existing `host_state` row (around line 106-1
         name: "fleet_state",
         scope: Scope::Read,
         description: "Fleet-wide heartbeat snapshot with pressure flags",
-        cost: Cost::Moderate,
+        cost: Cost::Expensive,
     },
 ```
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "syslog-mcp",
   "display_name": "Syslog MCP",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Query local syslog-mcp SQLite logs through a bundled stdio MCP server.",
   "long_description": "Syslog MCP packages the existing syslog mcp stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/plugins/syslog/skills/syslog/SKILL.md
+++ b/plugins/syslog/skills/syslog/SKILL.md
@@ -19,6 +19,7 @@ A single MCP tool, `mcp__syslog__syslog`, dispatches on a required `action` argu
 | `errors` | Error/warning summary by host and severity |
 | `hosts` | List all known hosts with first/last seen |
 | `host_state` | Latest bounded heartbeat state for one host |
+| `fleet_state` | Fleet-wide heartbeat snapshot with pressure flags and summary counts |
 | `sessions` | AI transcript sessions by project |
 | `search_sessions` | Ranked grouped session search |
 | `abuse` | Abuse hits in AI transcripts with same-session context |

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10,8 +10,7 @@
 # Requirements: mcporter, nc, curl, python3
 #
 # Action inventory reference:
-#   mcp_call search, mcp_call filter, mcp_call tail, mcp_call errors, mcp_call hosts, mcp_call host_state,
-#   mcp_call fleet_state,
+#   mcp_call search, mcp_call filter, mcp_call tail, mcp_call errors, mcp_call hosts, mcp_call host_state, mcp_call fleet_state,
 #   mcp_call sessions, mcp_call search_sessions, mcp_call abuse, mcp_call ai_correlate,
 #   mcp_call usage_blocks, mcp_call project_context, mcp_call list_ai_tools, mcp_call list_ai_projects,
 #   mcp_call correlate, mcp_call stats, mcp_call status, mcp_call apps,

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11,6 +11,7 @@
 #
 # Action inventory reference:
 #   mcp_call search, mcp_call filter, mcp_call tail, mcp_call errors, mcp_call hosts, mcp_call host_state,
+#   mcp_call fleet_state,
 #   mcp_call sessions, mcp_call search_sessions, mcp_call abuse, mcp_call ai_correlate,
 #   mcp_call usage_blocks, mcp_call project_context, mcp_call list_ai_tools, mcp_call list_ai_projects,
 #   mcp_call correlate, mcp_call stats, mcp_call status, mcp_call apps,

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/syslog-mcp",
     "source": "github"
   },
-  "version": "0.34.0",
+  "version": "0.35.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.34.0",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.35.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/api.rs
+++ b/src/api.rs
@@ -17,7 +17,7 @@ use crate::app::{
     AbuseSearchRequest, AckErrorRequest, AiCheckpointsRequest, AiCorrelateLimitPolicy,
     AiCorrelateRequest, AiIncidentRequest, AiInvestigateRequest, AiLimitPolicy,
     AiParseErrorsRequest, AiPruneCheckpointsRequest, AnomaliesRequest, AskHistoryRequest,
-    ClockSkewRequest, CompareRequest, CorrelateEventsRequest, DbCheckpointRequest,
+    ClockSkewRequest, CompareRequest, ContextRequest, CorrelateEventsRequest, DbCheckpointRequest,
     DbIntegrityRequest, DbVacuumRequest, FilterLogsRequest, GetErrorsRequest, GetLogRequest,
     HostStateRequest, IncidentContextRequest, IngestRateRequest, ListAiProjectsRequest,
     ListAiToolsRequest, ListAppsRequest, ListSessionsRequest, ListSourceIpsRequest,
@@ -226,6 +226,7 @@ pub fn router(state: ApiState) -> anyhow::Result<Router> {
         .route("/api/ingest-rate", get(ingest_rate))
         .route("/api/get", get(get_log))
         .route("/api/host-state", get(host_state))
+        .route("/api/context", get(context))
         .route("/api/errors/unaddressed", get(unaddressed_errors))
         .route("/api/errors/ack", post(ack_error))
         .route("/api/errors/unack", post(unack_error))
@@ -595,6 +596,34 @@ async fn host_state(
                 hostname: query.hostname,
                 since: query.since,
                 limit: query.limit,
+            })
+            .await,
+    )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ContextQuery {
+    log_id: Option<i64>,
+    hostname: Option<String>,
+    timestamp: Option<String>,
+    before: Option<u32>,
+    after: Option<u32>,
+}
+
+async fn context(
+    State(state): State<ApiState>,
+    Query(query): Query<ContextQuery>,
+) -> impl IntoResponse {
+    respond(
+        state
+            .service
+            .context(ContextRequest {
+                log_id: query.log_id,
+                hostname: query.hostname,
+                timestamp: query.timestamp,
+                before: query.before,
+                after: query.after,
             })
             .await,
     )

--- a/src/api.rs
+++ b/src/api.rs
@@ -18,11 +18,11 @@ use crate::app::{
     AiCorrelateRequest, AiIncidentRequest, AiInvestigateRequest, AiLimitPolicy,
     AiParseErrorsRequest, AiPruneCheckpointsRequest, AnomaliesRequest, AskHistoryRequest,
     ClockSkewRequest, CompareRequest, ContextRequest, CorrelateEventsRequest, DbCheckpointRequest,
-    DbIntegrityRequest, DbVacuumRequest, FilterLogsRequest, GetErrorsRequest, GetLogRequest,
-    HostStateRequest, IncidentContextRequest, IngestRateRequest, ListAiProjectsRequest,
-    ListAiToolsRequest, ListAppsRequest, ListSessionsRequest, ListSourceIpsRequest,
-    NotificationsRecentRequest, PatternsRequest, ProjectContextRequest, RequestActor,
-    SearchLogsRequest, SearchSessionsRequest, ServiceError, SilentHostsRequest,
+    DbIntegrityRequest, DbVacuumRequest, FilterLogsRequest, FleetStateRequest, GetErrorsRequest,
+    GetLogRequest, HostStateRequest, IncidentContextRequest, IngestRateRequest,
+    ListAiProjectsRequest, ListAiToolsRequest, ListAppsRequest, ListSessionsRequest,
+    ListSourceIpsRequest, NotificationsRecentRequest, PatternsRequest, ProjectContextRequest,
+    RequestActor, SearchLogsRequest, SearchSessionsRequest, ServiceError, SilentHostsRequest,
     SimilarIncidentsRequest, SyslogService, TailLogsRequest, TimelineRequest, UnackErrorRequest,
     UnaddressedErrorsRequest, UsageBlocksRequest,
 };
@@ -227,6 +227,7 @@ pub fn router(state: ApiState) -> anyhow::Result<Router> {
         .route("/api/get", get(get_log))
         .route("/api/host-state", get(host_state))
         .route("/api/context", get(context))
+        .route("/api/fleet-state", get(fleet_state))
         .route("/api/errors/unaddressed", get(unaddressed_errors))
         .route("/api/errors/ack", post(ack_error))
         .route("/api/errors/unack", post(unack_error))
@@ -624,6 +625,28 @@ async fn context(
                 timestamp: query.timestamp,
                 before: query.before,
                 after: query.after,
+            })
+            .await,
+    )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FleetStateQuery {
+    include_ok: Option<bool>,
+    sort: Option<String>,
+}
+
+async fn fleet_state(
+    State(state): State<ApiState>,
+    Query(query): Query<FleetStateQuery>,
+) -> impl IntoResponse {
+    respond(
+        state
+            .service
+            .fleet_state(FleetStateRequest {
+                include_ok: query.include_ok,
+                sort: query.sort,
             })
             .await,
     )

--- a/src/api.rs
+++ b/src/api.rs
@@ -583,32 +583,11 @@ async fn host_state(
     respond(state.service.host_state(req).await)
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct ContextQuery {
-    log_id: Option<i64>,
-    hostname: Option<String>,
-    timestamp: Option<String>,
-    before: Option<u32>,
-    after: Option<u32>,
-}
-
 async fn context(
     State(state): State<ApiState>,
-    Query(query): Query<ContextQuery>,
+    Query(req): Query<ContextRequest>,
 ) -> impl IntoResponse {
-    respond(
-        state
-            .service
-            .context(ContextRequest {
-                log_id: query.log_id,
-                hostname: query.hostname,
-                timestamp: query.timestamp,
-                before: query.before,
-                after: query.after,
-            })
-            .await,
-    )
+    respond(state.service.context(req).await)
 }
 
 async fn fleet_state(

--- a/src/api.rs
+++ b/src/api.rs
@@ -19,11 +19,12 @@ use crate::app::{
     AiParseErrorsRequest, AiPruneCheckpointsRequest, AnomaliesRequest, AskHistoryRequest,
     ClockSkewRequest, CompareRequest, CorrelateEventsRequest, DbCheckpointRequest,
     DbIntegrityRequest, DbVacuumRequest, FilterLogsRequest, GetErrorsRequest, GetLogRequest,
-    IncidentContextRequest, IngestRateRequest, ListAiProjectsRequest, ListAiToolsRequest,
-    ListAppsRequest, ListSessionsRequest, ListSourceIpsRequest, NotificationsRecentRequest,
-    PatternsRequest, ProjectContextRequest, RequestActor, SearchLogsRequest, SearchSessionsRequest,
-    ServiceError, SilentHostsRequest, SimilarIncidentsRequest, SyslogService, TailLogsRequest,
-    TimelineRequest, UnackErrorRequest, UnaddressedErrorsRequest, UsageBlocksRequest,
+    HostStateRequest, IncidentContextRequest, IngestRateRequest, ListAiProjectsRequest,
+    ListAiToolsRequest, ListAppsRequest, ListSessionsRequest, ListSourceIpsRequest,
+    NotificationsRecentRequest, PatternsRequest, ProjectContextRequest, RequestActor,
+    SearchLogsRequest, SearchSessionsRequest, ServiceError, SilentHostsRequest,
+    SimilarIncidentsRequest, SyslogService, TailLogsRequest, TimelineRequest, UnackErrorRequest,
+    UnaddressedErrorsRequest, UsageBlocksRequest,
 };
 use crate::config::ApiConfig;
 use crate::db::DbPool;
@@ -224,6 +225,7 @@ pub fn router(state: ApiState) -> anyhow::Result<Router> {
         .route("/api/patterns", get(patterns))
         .route("/api/ingest-rate", get(ingest_rate))
         .route("/api/get", get(get_log))
+        .route("/api/host-state", get(host_state))
         .route("/api/errors/unaddressed", get(unaddressed_errors))
         .route("/api/errors/ack", post(ack_error))
         .route("/api/errors/unack", post(unack_error))
@@ -570,6 +572,32 @@ async fn get_log(
     Query(query): Query<GetLogQuery>,
 ) -> impl IntoResponse {
     respond(state.service.get_log(GetLogRequest { id: query.id }).await)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HostStateQuery {
+    host_id: Option<String>,
+    hostname: Option<String>,
+    since: Option<String>,
+    limit: Option<u32>,
+}
+
+async fn host_state(
+    State(state): State<ApiState>,
+    Query(query): Query<HostStateQuery>,
+) -> impl IntoResponse {
+    respond(
+        state
+            .service
+            .host_state(HostStateRequest {
+                host_id: query.host_id,
+                hostname: query.hostname,
+                since: query.since,
+                limit: query.limit,
+            })
+            .await,
+    )
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -576,30 +576,11 @@ async fn get_log(
     respond(state.service.get_log(GetLogRequest { id: query.id }).await)
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct HostStateQuery {
-    host_id: Option<String>,
-    hostname: Option<String>,
-    since: Option<String>,
-    limit: Option<u32>,
-}
-
 async fn host_state(
     State(state): State<ApiState>,
-    Query(query): Query<HostStateQuery>,
+    Query(req): Query<HostStateRequest>,
 ) -> impl IntoResponse {
-    respond(
-        state
-            .service
-            .host_state(HostStateRequest {
-                host_id: query.host_id,
-                hostname: query.hostname,
-                since: query.since,
-                limit: query.limit,
-            })
-            .await,
-    )
+    respond(state.service.host_state(req).await)
 }
 
 #[derive(Debug, Deserialize)]
@@ -630,26 +611,11 @@ async fn context(
     )
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct FleetStateQuery {
-    include_ok: Option<bool>,
-    sort: Option<String>,
-}
-
 async fn fleet_state(
     State(state): State<ApiState>,
-    Query(query): Query<FleetStateQuery>,
+    Query(req): Query<FleetStateRequest>,
 ) -> impl IntoResponse {
-    respond(
-        state
-            .service
-            .fleet_state(FleetStateRequest {
-                include_ok: query.include_ok,
-                sort: query.sort,
-            })
-            .await,
-    )
+    respond(state.service.fleet_state(req).await)
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -653,6 +653,7 @@ async fn fleet_state(
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct UnaddressedErrorsQuery {
     limit: Option<u32>,
     include_acknowledged: Option<bool>,

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -2261,3 +2261,28 @@ async fn host_state_returns_404_for_unknown_host() {
         get_json(app, "/api/host-state?hostname=nonexistent", Some("secret")).await;
     assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
 }
+
+// ─── /api/context ───────────────────────────────────────────────────────────
+// NOTE: `SyslogService::context` surfaces "missing pivot" and "unknown log_id"
+// via `anyhow!` → `ServiceError::Internal` → 500. The plan flagged this as a
+// service-layer gap to be addressed in a follow-up; these tests pin current
+// behaviour rather than papering over the gap in the handler.
+
+#[tokio::test]
+async fn context_returns_500_without_pivot_pending_service_mapping() {
+    // TODO(follow-up): service should map "no pivot" to ServiceError::InvalidInput → 400.
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, value) = get_json(app, "/api/context", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(value.get("error").is_some(), "missing error: {value}");
+}
+
+#[tokio::test]
+async fn context_returns_500_for_unknown_log_id_pending_service_mapping() {
+    // TODO(follow-up): service should map "log id not found" to ServiceError::NotFound → 404.
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, _value) = get_json(app, "/api/context?log_id=999999", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+}

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -2286,3 +2286,28 @@ async fn context_returns_500_for_unknown_log_id_pending_service_mapping() {
     let (status, _value) = get_json(app, "/api/context?log_id=999999", Some("secret")).await;
     assert_eq!(status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
 }
+
+// ─── /api/fleet-state ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn fleet_state_returns_200_with_token_on_empty_db() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, value) = get_json(app, "/api/fleet-state", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert!(value.get("hosts").is_some(), "missing hosts: {value}");
+    assert!(value.get("summary").is_some(), "missing summary: {value}");
+}
+
+#[tokio::test]
+async fn fleet_state_accepts_include_ok_and_sort_params() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, _value) = get_json(
+        app,
+        "/api/fleet-state?include_ok=false&sort=freshness",
+        Some("secret"),
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+}

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -2283,7 +2283,7 @@ async fn host_state_returns_404_for_unknown_host() {
 // behaviour rather than papering over the gap in the handler.
 
 #[tokio::test]
-async fn context_returns_500_without_pivot_pending_service_mapping() {
+async fn context_returns_500_without_pivot() {
     // TODO(follow-up): service should map "no pivot" to ServiceError::InvalidInput → 400.
     let (state, _pool, _dir) = test_state(Some("secret".into()));
     let app = test_router(state);
@@ -2293,7 +2293,7 @@ async fn context_returns_500_without_pivot_pending_service_mapping() {
 }
 
 #[tokio::test]
-async fn context_returns_500_for_unknown_log_id_pending_service_mapping() {
+async fn context_returns_500_for_unknown_log_id() {
     // TODO(follow-up): service should map "log id not found" to ServiceError::NotFound → 404.
     let (state, _pool, _dir) = test_state(Some("secret".into()));
     let app = test_router(state);

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -2238,3 +2238,26 @@ async fn compose_doctor_unready_returns_structured_projection() {
     assert_eq!(value["runtime_state"], "docker_unavailable");
     assert_eq!(value["diagnostics"][0]["code"], "docker_unavailable");
 }
+
+// ─── /api/host-state ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn host_state_returns_400_without_host_id_or_hostname() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, value) = get_json(app, "/api/host-state", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+    assert!(
+        value.get("error").is_some(),
+        "missing error message: {value}"
+    );
+}
+
+#[tokio::test]
+async fn host_state_returns_404_for_unknown_host() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, _value) =
+        get_json(app, "/api/host-state?hostname=nonexistent", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+}

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -2325,3 +2325,55 @@ async fn fleet_state_accepts_include_ok_and_sort_params() {
     .await;
     assert_eq!(status, axum::http::StatusCode::OK);
 }
+
+// ── bearer enforcement on new RAG-adjacent / heartbeat routes ───────────────
+
+#[tokio::test]
+async fn host_state_route_requires_bearer() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = router(state).unwrap();
+    let (status, _) = get_json(app, "/api/host-state?hostname=foo", None).await;
+    assert_eq!(status, axum::http::StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn context_route_requires_bearer() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = router(state).unwrap();
+    let (status, _) = get_json(app, "/api/context?log_id=1", None).await;
+    assert_eq!(status, axum::http::StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn fleet_state_route_requires_bearer() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = router(state).unwrap();
+    let (status, _) = get_json(app, "/api/fleet-state", None).await;
+    assert_eq!(status, axum::http::StatusCode::UNAUTHORIZED);
+}
+
+// ── deny_unknown_fields enforcement on new routes ───────────────────────────
+
+#[tokio::test]
+async fn unknown_query_param_returns_400_on_host_state() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = router(state).unwrap();
+    let (status, _) = get_json(app, "/api/host-state?hostname=foo&bogus=1", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn unknown_query_param_returns_400_on_context() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = router(state).unwrap();
+    let (status, _) = get_json(app, "/api/context?bogus=1", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn unknown_query_param_returns_400_on_fleet_state() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = router(state).unwrap();
+    let (status, _) = get_json(app, "/api/fleet-state?bogus=1", Some("secret")).await;
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+}

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -2277,28 +2277,22 @@ async fn host_state_returns_404_for_unknown_host() {
 }
 
 // ─── /api/context ───────────────────────────────────────────────────────────
-// NOTE: `SyslogService::context` surfaces "missing pivot" and "unknown log_id"
-// via `anyhow!` → `ServiceError::Internal` → 500. The plan flagged this as a
-// service-layer gap to be addressed in a follow-up; these tests pin current
-// behaviour rather than papering over the gap in the handler.
 
 #[tokio::test]
-async fn context_returns_500_without_pivot() {
-    // TODO(follow-up): service should map "no pivot" to ServiceError::InvalidInput → 400.
+async fn context_returns_400_without_pivot() {
     let (state, _pool, _dir) = test_state(Some("secret".into()));
     let app = test_router(state);
     let (status, value) = get_json(app, "/api/context", Some("secret")).await;
-    assert_eq!(status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
     assert!(value.get("error").is_some(), "missing error: {value}");
 }
 
 #[tokio::test]
-async fn context_returns_500_for_unknown_log_id() {
-    // TODO(follow-up): service should map "log id not found" to ServiceError::NotFound → 404.
+async fn context_returns_404_for_unknown_log_id() {
     let (state, _pool, _dir) = test_state(Some("secret".into()));
     let app = test_router(state);
     let (status, _value) = get_json(app, "/api/context?log_id=999999", Some("secret")).await;
-    assert_eq!(status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
 }
 
 // ─── /api/fleet-state ───────────────────────────────────────────────────────

--- a/src/api_tests.rs
+++ b/src/api_tests.rs
@@ -2254,6 +2254,20 @@ async fn host_state_returns_400_without_host_id_or_hostname() {
 }
 
 #[tokio::test]
+async fn host_state_returns_400_for_invalid_since_timestamp() {
+    let (state, _pool, _dir) = test_state(Some("secret".into()));
+    let app = test_router(state);
+    let (status, value) = get_json(
+        app,
+        "/api/host-state?hostname=foo&since=not-a-timestamp",
+        Some("secret"),
+    )
+    .await;
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+    assert!(value.get("error").is_some(), "missing error: {value}");
+}
+
+#[tokio::test]
 async fn host_state_returns_404_for_unknown_host() {
     let (state, _pool, _dir) = test_state(Some("secret".into()));
     let app = test_router(state);

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,6 +64,8 @@ pub use models::{
     ErrorSignatureEntry,
     ErrorSummaryEntry,
     FilterLogsRequest,
+    FleetStateRequest,
+    FleetStateResponse,
     GetErrorsRequest,
     GetErrorsResponse,
     GetLogRequest,

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -1332,6 +1332,7 @@ impl From<db::PatternEntry> for PatternEntry {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ContextRequest {
     pub log_id: Option<i64>,
     pub hostname: Option<String>,

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -502,7 +502,7 @@ impl SyslogService {
             }
         };
         let limit = req.limit.unwrap_or(1).clamp(1, 100) as usize;
-        let since = req.since.clone();
+        let since = parse_optional_timestamp(req.since.as_deref(), "since")?;
         self.run_db(move |pool| {
             db::heartbeat_host_state(pool, lookup, since.as_deref(), limit).map_err(|error| {
                 match error.to_string().as_str() {

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1645,7 +1645,7 @@ impl SyslogService {
                 let (reference, hostname, timestamp, id): (LogEntry, String, String, Option<i64>) =
                     if let Some(id) = req.log_id {
                         let row = db::fetch_log_by_id(pool, id)?
-                            .ok_or_else(|| anyhow::anyhow!("No log found for id {id}"))?;
+                            .ok_or_else(|| anyhow::anyhow!("context_log_not_found:{id}"))?;
                         let entry = LogEntry {
                             id: row.id,
                             timestamp: row.timestamp.clone(),
@@ -1665,16 +1665,12 @@ impl SyslogService {
                         };
                         (entry, row.hostname, row.timestamp, Some(row.id))
                     } else {
-                        let hostname = req.hostname.clone().ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "Either `log_id` or both `hostname` + `timestamp` are required"
-                            )
-                        })?;
-                        let timestamp = synthetic_timestamp.ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "Either `log_id` or both `hostname` + `timestamp` are required"
-                            )
-                        })?;
+                        let hostname = req
+                            .hostname
+                            .clone()
+                            .ok_or_else(|| anyhow::anyhow!("context_missing_pivot"))?;
+                        let timestamp = synthetic_timestamp
+                            .ok_or_else(|| anyhow::anyhow!("context_missing_pivot"))?;
                         let synthetic = LogEntry {
                             id: 0,
                             timestamp: timestamp.clone(),
@@ -1707,7 +1703,22 @@ impl SyslogService {
                 )?;
                 Ok((reference, before_rows, after_rows))
             })
-            .await?;
+            .await
+            .map_err(|error| match error {
+                ServiceError::Internal(inner) => {
+                    let msg = inner.to_string();
+                    if msg == "context_missing_pivot" {
+                        ServiceError::InvalidInput(
+                            "Either `log_id` or both `hostname` + `timestamp` are required".into(),
+                        )
+                    } else if let Some(id) = msg.strip_prefix("context_log_not_found:") {
+                        ServiceError::NotFound(format!("No log found for id {id}"))
+                    } else {
+                        ServiceError::Internal(inner)
+                    }
+                }
+                other => other,
+            })?;
         let (reference, before_rows, after_rows) = resolved;
         Ok(ContextResponse {
             reference,

--- a/src/cli/dispatch_ai.rs
+++ b/src/cli/dispatch_ai.rs
@@ -390,7 +390,7 @@ pub(crate) async fn run_ai_similar_incidents(mode: &CliMode, args: AiSimilarArgs
     let json = args.json;
     let req = args.into_request();
     let response = match mode {
-        CliMode::Http(client) => client.similar_incidents(&req).await?,
+        CliMode::Http(client) => http_or_cancel(client.similar_incidents(&req)).await?,
         CliMode::Local(service) => service.similar_incidents(req).await?,
     };
     print_similar_incidents_response(&response, json)
@@ -400,7 +400,7 @@ pub(crate) async fn run_ai_ask_history(mode: &CliMode, args: AiAskHistoryArgs) -
     let json = args.json;
     let req = args.into_request();
     let response = match mode {
-        CliMode::Http(client) => client.ask_history(&req).await?,
+        CliMode::Http(client) => http_or_cancel(client.ask_history(&req)).await?,
         CliMode::Local(service) => service.ask_history(req).await?,
     };
     print_ask_history_response(&response, json)
@@ -413,7 +413,7 @@ pub(crate) async fn run_ai_incident_context(
     let json = args.json;
     let req = args.into_request();
     let response = match mode {
-        CliMode::Http(client) => client.incident_context(&req).await?,
+        CliMode::Http(client) => http_or_cancel(client.incident_context(&req)).await?,
         CliMode::Local(service) => service.incident_context(req).await?,
     };
     print_incident_context_response(&response, json)

--- a/src/cli/dispatch_ai.rs
+++ b/src/cli/dispatch_ai.rs
@@ -389,22 +389,20 @@ pub(crate) async fn run_ai_watch(mode: &CliMode, args: AiWatchArgs) -> Result<()
 pub(crate) async fn run_ai_similar_incidents(mode: &CliMode, args: AiSimilarArgs) -> Result<()> {
     let json = args.json;
     let req = args.into_request();
-    let service = match mode {
-        CliMode::Http(_) => bail!("similar_incidents currently runs locally only; omit --http."),
-        CliMode::Local(service) => service,
+    let response = match mode {
+        CliMode::Http(client) => client.similar_incidents(&req).await?,
+        CliMode::Local(service) => service.similar_incidents(req).await?,
     };
-    let response = service.similar_incidents(req).await?;
     print_similar_incidents_response(&response, json)
 }
 
 pub(crate) async fn run_ai_ask_history(mode: &CliMode, args: AiAskHistoryArgs) -> Result<()> {
     let json = args.json;
     let req = args.into_request();
-    let service = match mode {
-        CliMode::Http(_) => bail!("ask_history currently runs locally only; omit --http."),
-        CliMode::Local(service) => service,
+    let response = match mode {
+        CliMode::Http(client) => client.ask_history(&req).await?,
+        CliMode::Local(service) => service.ask_history(req).await?,
     };
-    let response = service.ask_history(req).await?;
     print_ask_history_response(&response, json)
 }
 
@@ -414,11 +412,10 @@ pub(crate) async fn run_ai_incident_context(
 ) -> Result<()> {
     let json = args.json;
     let req = args.into_request();
-    let service = match mode {
-        CliMode::Http(_) => bail!("incident_context currently runs locally only; omit --http."),
-        CliMode::Local(service) => service,
+    let response = match mode {
+        CliMode::Http(client) => client.incident_context(&req).await?,
+        CliMode::Local(service) => service.incident_context(req).await?,
     };
-    let response = service.incident_context(req).await?;
     print_incident_context_response(&response, json)
 }
 

--- a/src/cli/http_client.rs
+++ b/src/cli/http_client.rs
@@ -64,19 +64,20 @@ use syslog_mcp::app::{
     AbuseSearchRequest, AbuseSearchResponse, AckErrorRequest, AckErrorResponse,
     AiCheckpointsRequest, AiCorrelateRequest, AiCorrelateResponse, AiIncidentRequest,
     AiIncidentResponse, AiInvestigateRequest, AiInvestigateResponse, AiParseErrorsRequest,
-    AiPruneCheckpointsRequest, AnomaliesRequest, AnomaliesResponse, ClockSkewRequest,
-    ClockSkewResponse, CompareRequest, CompareResponse, CorrelateEventsRequest,
-    CorrelateEventsResponse, DbCheckpointRequest, DbCheckpointResult, DbIntegrityRequest,
-    DbIntegrityResult, DbMaintenanceStatus, DbStats, DbVacuumRequest, DbVacuumResult,
-    FilterLogsRequest, GetErrorsRequest, GetErrorsResponse, GetLogRequest, GetLogResponse,
-    IngestRateRequest, IngestRateResponse, ListAiProjectsRequest, ListAiProjectsResponse,
-    ListAiToolsRequest, ListAiToolsResponse, ListAppsRequest, ListAppsResponse, ListHostsResponse,
-    ListSessionsRequest, ListSessionsResponse, ListSourceIpsRequest, ListSourceIpsResponse,
-    PatternsRequest, PatternsResponse, ProjectContextRequest, ProjectContextResponse,
-    SearchLogsRequest, SearchLogsResponse, SearchSessionsRequest, SearchSessionsResponse,
-    SilentHostsRequest, SilentHostsResponse, TailLogsRequest, TimelineRequest, TimelineResponse,
-    UnackErrorRequest, UnackErrorResponse, UnaddressedErrorsRequest, UnaddressedErrorsResponse,
-    UsageBlocksRequest, UsageBlocksResponse,
+    AiPruneCheckpointsRequest, AnomaliesRequest, AnomaliesResponse, AskHistoryRequest,
+    AskHistoryResponse, ClockSkewRequest, ClockSkewResponse, CompareRequest, CompareResponse,
+    CorrelateEventsRequest, CorrelateEventsResponse, DbCheckpointRequest, DbCheckpointResult,
+    DbIntegrityRequest, DbIntegrityResult, DbMaintenanceStatus, DbStats, DbVacuumRequest,
+    DbVacuumResult, FilterLogsRequest, GetErrorsRequest, GetErrorsResponse, GetLogRequest,
+    GetLogResponse, IncidentContextRequest, IncidentContextResponse, IngestRateRequest,
+    IngestRateResponse, ListAiProjectsRequest, ListAiProjectsResponse, ListAiToolsRequest,
+    ListAiToolsResponse, ListAppsRequest, ListAppsResponse, ListHostsResponse, ListSessionsRequest,
+    ListSessionsResponse, ListSourceIpsRequest, ListSourceIpsResponse, PatternsRequest,
+    PatternsResponse, ProjectContextRequest, ProjectContextResponse, SearchLogsRequest,
+    SearchLogsResponse, SearchSessionsRequest, SearchSessionsResponse, SilentHostsRequest,
+    SilentHostsResponse, SimilarIncidentsRequest, SimilarIncidentsResponse, TailLogsRequest,
+    TimelineRequest, TimelineResponse, UnackErrorRequest, UnackErrorResponse,
+    UnaddressedErrorsRequest, UnaddressedErrorsResponse, UsageBlocksRequest, UsageBlocksResponse,
 };
 use syslog_mcp::scanner::{CheckpointEntry, ParseErrorEntry, PruneCheckpointsResult};
 
@@ -622,6 +623,24 @@ impl HttpClient {
 
     pub async fn list_apps(&self, req: &ListAppsRequest) -> Result<ListAppsResponse> {
         self.get_json("/api/apps", Some(req)).await
+    }
+
+    pub async fn similar_incidents(
+        &self,
+        req: &SimilarIncidentsRequest,
+    ) -> Result<SimilarIncidentsResponse> {
+        self.get_json("/api/similar-incidents", Some(req)).await
+    }
+
+    pub async fn ask_history(&self, req: &AskHistoryRequest) -> Result<AskHistoryResponse> {
+        self.get_json("/api/ai/ask-history", Some(req)).await
+    }
+
+    pub async fn incident_context(
+        &self,
+        req: &IncidentContextRequest,
+    ) -> Result<IncidentContextResponse> {
+        self.get_json("/api/incident-context", Some(req)).await
     }
 }
 

--- a/src/cli/http_client_tests.rs
+++ b/src/cli/http_client_tests.rs
@@ -512,6 +512,117 @@ async fn ai_abuse_request_round_trips_through_serde_qs() {
     assert_eq!(decoded.terms, req.terms);
 }
 
+// ─── Round-trip coverage for RAG v1 wrappers (similar_incidents, ask_history,
+//     incident_context) — bead 0p8r.6. Verifies HttpClient → /api/<path> wires
+//     the bearer header, hits the documented URL, and deserialises a typed
+//     response. ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn similar_incidents_round_trips_typed_response() {
+    use syslog_mcp::app::SimilarIncidentsRequest;
+
+    let (server, client) = start_mock_with_client().await;
+    Mock::given(method("GET"))
+        .and(path("/api/similar-incidents"))
+        .and(header("authorization", "Bearer test-value"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "query": "disk full",
+            "total_clusters": 0,
+            "truncated": false,
+            "clusters": [],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let req = SimilarIncidentsRequest {
+        query: "disk full".into(),
+        hostname: None,
+        app_name: None,
+        severity_min: None,
+        from: None,
+        to: None,
+        window_minutes: None,
+        limit: None,
+    };
+    let resp = client
+        .similar_incidents(&req)
+        .await
+        .expect("similar_incidents wrapper should succeed");
+    assert_eq!(resp.query, "disk full");
+    assert_eq!(resp.total_clusters, 0);
+    assert!(resp.clusters.is_empty());
+}
+
+#[tokio::test]
+async fn ask_history_round_trips_typed_response() {
+    use syslog_mcp::app::AskHistoryRequest;
+
+    let (server, client) = start_mock_with_client().await;
+    Mock::given(method("GET"))
+        .and(path("/api/ai/ask-history"))
+        .and(header("authorization", "Bearer test-value"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "query": "why did deploy fail",
+            "total_candidates": 0,
+            "truncated": false,
+            "sessions": [],
+            "context_logs": [],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let req = AskHistoryRequest {
+        query: "why did deploy fail".into(),
+        ..Default::default()
+    };
+    let resp = client
+        .ask_history(&req)
+        .await
+        .expect("ask_history wrapper should succeed");
+    assert_eq!(resp.query, "why did deploy fail");
+    assert_eq!(resp.total_candidates, 0);
+    assert!(resp.sessions.is_empty());
+}
+
+#[tokio::test]
+async fn incident_context_round_trips_typed_response() {
+    use syslog_mcp::app::IncidentContextRequest;
+
+    let (server, client) = start_mock_with_client().await;
+    Mock::given(method("GET"))
+        .and(path("/api/incident-context"))
+        .and(header("authorization", "Bearer test-value"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "window_from": "2026-05-01T00:00:00Z",
+            "window_to":   "2026-05-01T01:00:00Z",
+            "total_logs":  0,
+            "by_severity": [],
+            "by_app":      [],
+            "error_logs":  [],
+            "error_logs_truncated": false,
+            "ai_sessions": [],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let req = IncidentContextRequest {
+        from: "2026-05-01T00:00:00Z".into(),
+        to: "2026-05-01T01:00:00Z".into(),
+        ..Default::default()
+    };
+    let resp = client
+        .incident_context(&req)
+        .await
+        .expect("incident_context wrapper should succeed");
+    assert_eq!(resp.window_from, "2026-05-01T00:00:00Z");
+    assert_eq!(resp.window_to, "2026-05-01T01:00:00Z");
+    assert_eq!(resp.total_logs, 0);
+    assert!(resp.error_logs.is_empty());
+}
+
 // ─── Env var guard ──────────────────────────────────────────────────────────
 //
 // `std::env::set_var` is data-racy across threads. We serialise via the

--- a/src/cli/http_client_tests.rs
+++ b/src/cli/http_client_tests.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 // ─── Discovery: base URL precedence ─────────────────────────────────────────
@@ -525,6 +525,7 @@ async fn similar_incidents_round_trips_typed_response() {
     Mock::given(method("GET"))
         .and(path("/api/similar-incidents"))
         .and(header("authorization", "Bearer test-value"))
+        .and(query_param("query", "disk full"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "query": "disk full",
             "total_clusters": 0,
@@ -562,6 +563,7 @@ async fn ask_history_round_trips_typed_response() {
     Mock::given(method("GET"))
         .and(path("/api/ai/ask-history"))
         .and(header("authorization", "Bearer test-value"))
+        .and(query_param("query", "why did deploy fail"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "query": "why did deploy fail",
             "total_candidates": 0,
@@ -594,6 +596,8 @@ async fn incident_context_round_trips_typed_response() {
     Mock::given(method("GET"))
         .and(path("/api/incident-context"))
         .and(header("authorization", "Bearer test-value"))
+        .and(query_param("from", "2026-05-01T00:00:00Z"))
+        .and(query_param("to", "2026-05-01T01:00:00Z"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "window_from": "2026-05-01T00:00:00Z",
             "window_to":   "2026-05-01T01:00:00Z",

--- a/src/mcp/actions.rs
+++ b/src/mcp/actions.rs
@@ -113,7 +113,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         name: "fleet_state",
         scope: Scope::Read,
         description: "Fleet-wide heartbeat snapshot with pressure flags",
-        cost: Cost::Moderate,
+        cost: Cost::Expensive,
     },
     ActionSpec {
         name: "correlate",

--- a/src/mcp/actions.rs
+++ b/src/mcp/actions.rs
@@ -110,6 +110,12 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         cost: Cost::Moderate,
     },
     ActionSpec {
+        name: "fleet_state",
+        scope: Scope::Read,
+        description: "Fleet-wide heartbeat snapshot with pressure flags",
+        cost: Cost::Moderate,
+    },
+    ActionSpec {
         name: "correlate",
         scope: Scope::Read,
         description: "Correlate events across hosts/services",

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -5,12 +5,12 @@ use serde_json::{json, Value};
 use crate::app::{
     AbuseSearchRequest, AiCorrelateRequest, AiIncidentRequest, AiInvestigateRequest,
     AnomaliesRequest, AskHistoryRequest, ClockSkewRequest, CompareRequest, ContextRequest,
-    CorrelateEventsRequest, FilterLogsRequest, GetErrorsRequest, GetLogRequest, HostStateRequest,
-    IncidentContextRequest, IngestRateRequest, ListAiProjectsRequest, ListAiToolsRequest,
-    ListAppsRequest, ListSessionsRequest, ListSourceIpsRequest, NotificationsRecentRequest,
-    PatternsRequest, ProjectContextRequest, RequestActor, SearchLogsRequest, SearchSessionsRequest,
-    SilentHostsRequest, SimilarIncidentsRequest, TailLogsRequest, TimelineRequest,
-    UsageBlocksRequest,
+    CorrelateEventsRequest, FilterLogsRequest, FleetStateRequest, GetErrorsRequest, GetLogRequest,
+    HostStateRequest, IncidentContextRequest, IngestRateRequest, ListAiProjectsRequest,
+    ListAiToolsRequest, ListAppsRequest, ListSessionsRequest, ListSourceIpsRequest,
+    NotificationsRecentRequest, PatternsRequest, ProjectContextRequest, RequestActor,
+    SearchLogsRequest, SearchSessionsRequest, SilentHostsRequest, SimilarIncidentsRequest,
+    TailLogsRequest, TimelineRequest, UsageBlocksRequest,
 };
 
 use super::actions;
@@ -43,6 +43,7 @@ async fn tool_syslog(
         "errors" => tool_get_errors(state, args).await,
         "hosts" => tool_list_hosts(state, args).await,
         "host_state" => tool_host_state(state, args).await,
+        "fleet_state" => tool_fleet_state(state, args).await,
         "correlate" => tool_correlate_events(state, args).await,
         "stats" => tool_get_stats(state, args).await,
         "status" => tool_get_status(state, args).await,
@@ -177,6 +178,11 @@ async fn tool_list_apps(state: &AppState, args: Value) -> anyhow::Result<Value> 
 async fn tool_host_state(state: &AppState, args: Value) -> anyhow::Result<Value> {
     let req: HostStateRequest = action_payload(args)?;
     Ok(serde_json::to_value(state.service.host_state(req).await?)?)
+}
+
+async fn tool_fleet_state(state: &AppState, args: Value) -> anyhow::Result<Value> {
+    let req: FleetStateRequest = action_payload(args)?;
+    Ok(serde_json::to_value(state.service.fleet_state(req).await?)?)
 }
 
 async fn tool_list_sessions(state: &AppState, args: Value) -> anyhow::Result<Value> {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -949,6 +949,15 @@ Return the latest bounded heartbeat state for one host.
 
 ---
 
+## syslog fleet_state
+Return a fleet-wide heartbeat snapshot with pressure flags and summary counts.
+
+**Parameters:**
+- `include_ok` (boolean, optional) — when `false`, exclude hosts with `status == "ok"` (default `true`)
+- `sort` (string, optional) — sort order: `pressure` (default), `freshness`, or `hostname`
+
+---
+
 ## syslog apps
 List distinct application names with log counts, host counts, and first/last seen timestamps.
 Mirror of `syslog hosts` for the `app_name` dimension.

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -114,6 +114,22 @@ async fn host_state_action_returns_bounded_heartbeat_state() {
 }
 
 #[tokio::test]
+async fn fleet_state_action_returns_fleet_snapshot() {
+    let h = TestHarness::new();
+    let value = execute_tool(&h.state, "syslog", json!({"action": "fleet_state"}), None)
+        .await
+        .unwrap();
+    assert!(
+        value.get("hosts").is_some(),
+        "fleet_state response missing hosts: {value}"
+    );
+    assert!(
+        value.get("summary").is_some(),
+        "fleet_state response missing summary: {value}"
+    );
+}
+
+#[tokio::test]
 async fn host_state_action_reports_ambiguous_hostname() {
     let h = TestHarness::new();
     let conn = h.pool.get().unwrap();

--- a/tests/mcporter/test-tools.sh
+++ b/tests/mcporter/test-tools.sh
@@ -4,7 +4,7 @@
 #
 # Exercises broad non-destructive checks for the action-based syslog MCP tool.
 # Action inventory reference (not every action is exercised below):
-#   syslog search, syslog filter, syslog tail, syslog errors, syslog hosts, syslog host_state, syslog sessions,
+#   syslog search, syslog filter, syslog tail, syslog errors, syslog hosts, syslog host_state, syslog fleet_state, syslog sessions,
 #   syslog search_sessions, syslog abuse, syslog ai_correlate, syslog usage_blocks, syslog project_context,
 #   syslog list_ai_tools, syslog list_ai_projects, syslog correlate, syslog stats, syslog status, syslog apps,
 #   syslog source_ips, syslog timeline, syslog patterns, syslog context,

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -18,7 +18,7 @@
 #   PORT                   Override server port (default: 3100)
 #
 # Action inventory reference (not every action is exercised by this live test):
-#   syslog search, syslog filter, syslog tail, syslog errors, syslog hosts, syslog host_state, syslog sessions,
+#   syslog search, syslog filter, syslog tail, syslog errors, syslog hosts, syslog host_state, syslog fleet_state, syslog sessions,
 #   syslog search_sessions, syslog abuse, syslog ai_correlate, syslog usage_blocks, syslog project_context,
 #   syslog list_ai_tools, syslog list_ai_projects, syslog correlate, syslog stats, syslog status, syslog apps,
 #   syslog source_ips, syslog timeline, syslog patterns, syslog context,


### PR DESCRIPTION
## Summary

Closes the remaining HTTP API parity gaps from the CLI/API/MCP audit. Adds three new GET routes whose actions previously only existed on MCP (or on the service layer with no exposure at all), and unblocks three orphaned routes whose CLI \`--http\` mode was disabled by stale \`bail!\` guards.

## New routes

- \`GET /api/host-state\` — wraps \`SyslogService::host_state\`. 400 if neither \`host_id\` nor \`hostname\`; 404 for unknown host.
- \`GET /api/context\` — pivot-window log context. Accepts \`log_id\` OR (\`hostname\` + \`timestamp\`).
- \`GET /api/fleet-state\` — fleet-wide heartbeat snapshot with pressure flags. Service method existed since \`afd77e4\` but was unexposed.

## Surface coverage

- Registered \`fleet_state\` as a first-class MCP action in \`ACTION_SPECS\` so the new HTTP route does not introduce drift. Documentation and test-fence references (INVENTORY.md, SCHEMA.md, TOOLS.md, TESTS.md, plugin SKILL.md, smoke-test scripts) updated to satisfy the \`public_action_references_cover_schema_registry\` fence.
- Added \`HttpClient::{similar_incidents, ask_history, incident_context}\` wrappers in \`src/cli/http_client.rs\`.
- Removed the three \`bail!(\"...currently runs locally only; omit --http.\")\` guards in \`src/cli/dispatch_ai.rs\` — those routes have existed since the 2026-05-22 surface-parity gap closure; the guards were left in by oversight.

## Known follow-up

\`SyslogService::context\` (service.rs:1648, 1668) uses \`anyhow::anyhow!(...)\` for its \"missing pivot\" and \"unknown log_id\" cases, which the API \`respond()\` helper maps to \`ServiceError::Internal\` → 500. The new \`/api/context\` smoke tests are pinned to the current 500 behavior with \`TODO(follow-up)\` markers; a separate change should reshape those branches to \`ServiceError::InvalidInput\` / \`ServiceError::NotFound\` so the route returns the proper 400/404. The route surface itself is correct.

## Test plan

- [x] \`just test\` — 872 lib tests, 254 integration tests, all green
- [x] \`just lint\` — clippy clean
- [x] \`rtk cargo check\` — clean
- [ ] Live smoke against a running instance (deferred to deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes CLI/API/MCP parity with three new GET routes, registers `fleet_state` in MCP, unblocks three CLI `--http` paths, and bumps version to `0.35.0`. Also fixes `/api/context` status codes and tightens query validation.

- **New Features**
  - Added GET `/api/host-state`, `/api/context`, `/api/fleet-state`.
  - Registered `fleet_state` in MCP `ACTION_SPECS` (cost `Expensive`); docs/help updated.
  - Added `HttpClient` methods for `similar_incidents`, `ask_history`, `incident_context`; removed stale `--http` guards and wrapped calls with `http_or_cancel`.

- **Bug Fixes and Refactors**
  - `/api/context` now returns `400` for missing pivot and `404` for unknown `log_id`.
  - Validated `host_state` `since` via `parse_optional_timestamp` (bad input → `400`).
  - Enforced strict query validation (`deny_unknown_fields`) on `ContextRequest` and `UnaddressedErrorsQuery`, and now deserialize queries directly into `HostStateRequest`/`FleetStateRequest`.
  - Version bumped to `0.35.0`; changelog updated.

<sup>Written for commit 155d55e2b5601ce70ee419f4d0e69e66cd818f20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/56?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fleet_state` MCP action providing fleet-wide heartbeat snapshots with pressure flags and summary counts
  * Introduced three new REST endpoints: `/api/host-state`, `/api/context`, and `/api/fleet-state`
  * Extended HTTP client with wrapper methods for AI operations

* **Improvements**
  * Enhanced request validation with stricter field checking
  * Removed local-only restrictions for AI operations in CLI dispatch

* **Documentation**
  * Updated MCP tools reference and schema documentation with new `fleet_state` action details
  * Added implementation plan for API route parity completion

* **Tests**
  * Added comprehensive test coverage for new REST endpoints and HTTP wrapper methods

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->