### PR TITLE
feat(service): add per-action DB timing instrumentation to run_db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-05-28
+
+### Changed
+
+- `run_db` now emits structured `tracing` events on every code path, including
+  acquire-timeout, semaphore-closed, and task-panic early returns that
+  previously returned silently. All ~60 callsites carry an `op` label for
+  correlation in log queries.
+- Ops exceeding 500 ms escalate from `debug` to `warn` level so slow queries
+  are visible at production `RUST_LOG=info` without configuration changes.
+- Fixed silent-failure in `correlate_state.resolve_host`: a `COUNT(*)` query
+  error was previously swallowed via `.unwrap_or(false)`, converting any DB
+  failure into a misleading `NotFound` response.
+- `JoinError` from `spawn_blocking` now distinguishes task-cancelled (graceful
+  shutdown) from task-panic in the log message.
+
 ## [0.35.0] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.1] - 2026-05-29
+
+### Changed
+
+- `run_db` now emits structured `tracing` events on every code path, including
+  acquire-timeout, semaphore-closed, and task-panic early returns that
+  previously returned silently. All ~60 callsites carry an `op` label for
+  correlation in log queries.
+- Ops exceeding 500 ms escalate from `debug` to `warn` level so slow queries
+  are visible at production `RUST_LOG=info` without configuration changes.
+- `JoinError` from `spawn_blocking` now distinguishes task-cancelled (graceful
+  shutdown) from task-panic in the log message.
+
+### Fixed
+
+- Fixed silent-failure in `correlate_state.resolve_host`: a `COUNT(*)` query
+  error was previously swallowed via `.unwrap_or(false)`, converting any DB
+  failure into a misleading `NotFound` response.
+
 ## [0.36.0] - 2026-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,6 +3265,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "url",
  "wiremock",
 ]
@@ -3657,6 +3658,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "syslog-mcp"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,3 +115,4 @@ rmcp = { version = "1.6.0", default-features = false, features = [
 ] }
 # Mock HTTP server for CLI HTTP client tests (bead 0p8r.5).
 wiremock = "0.6"
+tracing-test = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-mcp"
-version = "0.35.0"
+version = "0.35.1"
 edition = "2021"
 rust-version = "1.86"
 description = "Syslog receiver + MCP server for homelab log intelligence"

--- a/docs/sessions/2026-05-28-service-layer-timing-review-fixes.md
+++ b/docs/sessions/2026-05-28-service-layer-timing-review-fixes.md
@@ -1,0 +1,129 @@
+---
+date: 2026-05-28 03:03:03 EST
+repo: git@github.com:jmagar/syslog-mcp.git
+branch: feat/service-layer-timing
+head: a434a78b643ceed57fc5b1aa810575f5084c129c
+plan: docs/superpowers/plans/2026-05-18-service-layer-timing.md
+agent: Claude (claude-sonnet-4-6)
+session id: 1fb487c6-968f-43b0-896c-050d349dbe3b
+transcript: /home/jmagar/.claude/projects/-home-jmagar-workspace-syslog-mcp/1fb487c6-968f-43b0-896c-050d349dbe3b.jsonl
+working directory: /home/jmagar/workspace/syslog-mcp/.worktrees/service-layer-timing
+worktree: /home/jmagar/workspace/syslog-mcp/.worktrees/service-layer-timing a434a78 [feat/service-layer-timing]
+pr: "#57 feat(service): add per-action DB timing instrumentation to run_db — https://github.com/jmagar/syslog-mcp/pull/57"
+---
+
+## User Request
+
+Continue the `work-it` workflow for plan `docs/superpowers/plans/2026-05-18-service-layer-timing.md` from where a prior compacted session left off. The prior session had completed the core implementation and PR creation; this session picks up at the review-fix phase identified by the architecture review.
+
+## Session Overview
+
+Resolved all review findings from the service-layer timing PR (#57): fixed a HIGH-priority silent-failure bug in `correlate_state.resolve_host`, restructured `run_db` to emit timing events on all early-return paths (they were previously silent), added warn-on-slow escalation at 500 ms, renamed an inconsistent op label, extended the test suite to cover the slow+error and semaphore-closed paths, addressed a P1 reviewer comment about version bumping, and pushed 5 follow-up commits to the PR.
+
+## Sequence of Events
+
+1. Read the current `run_db` implementation at `src/app/service.rs:448–479` to confirm the early-return bug described in the prior session's architecture review.
+2. Added `pub(super) const SLOW_DB_MS: u128 = 500` at module level, restructured `run_db` to use explicit `match` blocks so all three early-return paths (timeout, semaphore-closed, JoinError) emit `tracing::warn` before returning, and added the warn-on-slow threshold branch.
+3. Renamed op label `"incident"` → `"incident.search"` at `service.rs:387` for dotted-convention consistency.
+4. Added `run_db_emits_warn_on_slow_op` and `run_db_emits_warn_on_semaphore_closed` tests to `service_tests.rs`; ran `cargo test` — 1178 passed.
+5. Committed and pushed the early-return fix + two new tests; ran two `rustfmt` format passes required by pre-commit hook.
+6. Launched code-simplifier passes 2 (tests) and 3 (docs/config) in parallel.
+   - Simplifier 2 tightened the warn tests: added `permit_ms`/`exec_ms` field assertions to slow-op test; added `matches!(err, ServiceError::Busy(_))` to semaphore-closed test.
+   - Simplifier 3 found no actionable issues.
+7. Committed simplifier improvements; ran `cargo test` again — 1178 passed.
+8. Launched pr-review-toolkit sweep in parallel: silent-failure-hunter, code-reviewer, pr-test-analyzer.
+9. Applied three actionable findings from the sweep:
+   - **CRITICAL (silent-failure-hunter)**: `correlate_state.resolve_host` at `service.rs:682` used `.unwrap_or(false)` to discard `COUNT(*)` errors — changed to `?`.
+   - **MEDIUM (silent-failure-hunter)**: `JoinError` branch logged "db task panic" unconditionally — added `e.is_cancelled()` branch for accurate "db task cancelled" message on graceful-shutdown aborts.
+   - **GAP 1 (pr-test-analyzer)**: Slow+error branch had no test — added `run_db_emits_warn_on_slow_op_with_error`.
+10. Fixed type-inference compile error on the new test (added `let _: ServiceResult<()> =` annotation).
+11. Ran `cargo test` — 1179 passed. Committed and pushed the three fixes.
+12. Committed simplifier test improvements (format-only); pushed.
+13. Fetched PR comments — one P1 comment from automated reviewer requesting version bump for the feature branch.
+14. Bumped `Cargo.toml` from `0.35.0` → `0.35.1`, added `[0.35.1]` section to `CHANGELOG.md`, committed and pushed.
+15. Replied to the inline PR comment confirming the bump was applied.
+16. Saved session to `docs/sessions/`.
+
+## Key Findings
+
+- **Silent early returns in `run_db`** (`service.rs:454–461` before fix): two `?` operators on the timeout and semaphore-closed paths returned before `tracing::debug!` fired — the most critical failure cases (pool saturation) produced no trace event at all.
+- **Silent failure in `correlate_state.resolve_host`** (`service.rs:682` before fix): `.unwrap_or(false)` on a `rusqlite` query silently converted any DB error (locking, schema drift, I/O) into `false`, then fell through to the hostname fallback which also failed, resulting in a misleading `ServiceError::NotFound` with nothing in the logs.
+- **JoinError ambiguity** (`service.rs:487` before fix): `spawn_blocking` cancellation during graceful shutdown emitted "db task panic" — would generate false-positive panic alerts in any alerting built on that log message.
+- **Slow+error branch untested**: the `Err` arm of the `exec_ms > SLOW_DB_MS` block was fully untested; a refactor stripping the `error = %e` field would have passed all tests.
+- **`SLOW_DB_MS` visibility**: made `pub(super)` so tests can reference it directly without hardcoding `500`, protecting against future threshold changes.
+
+## Technical Decisions
+
+- **`SLOW_DB_MS = 500`**: 500 ms is a reasonable threshold for SQLite operations on a homelab; fast enough to catch real slowdowns without constant noise. Made it a named const at module scope (not inside the function) so tests can reference it.
+- **`warn` vs `error` for timeout/semaphore-closed**: used `warn` not `error` because these are operational conditions (transient saturation) not programmer bugs; the caller still receives a `ServiceError::Busy` and can surface it as appropriate.
+- **`?` instead of `.unwrap_or(false)`**: the `map_err(|e| match e { ... other => other })` at `service.rs:701–708` already correctly passes through `ServiceError::Internal` variants that aren't `not_found` or `ambiguous_host`, so the propagated DB error surfaces as an internal error rather than a not-found — correct behavior.
+- **`e.is_cancelled()` branch**: added without changing the `ServiceError::Internal` return type — only the log message differs. Preserves the caller contract while fixing operator confusion during shutdown.
+- **Version bump to patch 0.35.1**: the changes are internal observability improvements (no new user-visible feature), so a patch bump is semantically correct even though the branch name says "feat/".
+
+## Files Modified
+
+| File | Purpose |
+|------|---------|
+| `src/app/service.rs` | Fixed `run_db`: early-return warn paths, SLOW_DB_MS const, warn-on-slow, `incident.search` label rename, `resolve_host` `.unwrap_or(false)` → `?`, JoinError is_cancelled branch |
+| `src/app/service_tests.rs` | Added `run_db_emits_warn_on_slow_op`, `run_db_emits_warn_on_semaphore_closed`, `run_db_emits_warn_on_slow_op_with_error`; tightened existing warn-test assertions |
+| `Cargo.toml` | Version bump 0.35.0 → 0.35.1 |
+| `CHANGELOG.md` | Added `[0.35.1]` section describing all timing observability changes |
+
+## Commands Executed
+
+```bash
+# Verification
+rtk cargo test       # 1179 passed, 1 ignored
+rtk cargo clippy     # No issues found
+
+# Format (required by pre-commit hook)
+cargo fmt
+
+# Git
+rtk git push         # feat/service-layer-timing → origin
+
+# PR comment resolution
+gh api -X POST repos/jmagar/syslog-mcp/pulls/57/reviews \
+  -f body="Version bumped to 0.35.1 in Cargo.toml and CHANGELOG.md..." \
+  -f event="COMMENT"
+```
+
+## Errors Encountered
+
+- **Type inference compile error** on `run_db_emits_warn_on_slow_op_with_error`: `let _ = service.run_db(...)` did not provide enough info for the compiler to infer `T`. Fixed by annotating `let _: ServiceResult<()> = ...`.
+- **Pre-commit hook format failures** (2 occurrences): `rustfmt` reformatted multiline closure calls and `anyhow::anyhow!()` calls. Fixed by running `cargo fmt` and re-staging before each commit.
+
+## Behavior Changes (Before/After)
+
+| Path | Before | After |
+|------|--------|-------|
+| `run_db` acquire timeout | Silent — returns `Busy` with no log event | Emits `tracing::warn!(op, permit_ms, "db acquire timeout")` before returning |
+| `run_db` semaphore closed | Silent — returns `Busy` with no log event | Emits `tracing::warn!(op, permit_ms, "db semaphore closed")` before returning |
+| `run_db` task panic | Emits "db task panic" for both panics AND graceful-shutdown cancellations | Panics emit "db task panic"; cancellations emit "db task cancelled" |
+| `run_db` slow ops (>500ms) | Always logged at `debug` level | Logged at `warn` level — visible at production `RUST_LOG=info` |
+| `correlate_state.resolve_host` DB error | Silently treated as "host not found" → `ServiceError::NotFound` with no log | Propagates as `ServiceError::Internal`, logged at `debug` (or `warn` if slow) |
+
+## Verification Evidence
+
+| Command | Expected | Actual | Status |
+|---------|----------|--------|--------|
+| `rtk cargo test` | 1179 passed | 1179 passed, 1 ignored | ✅ |
+| `rtk cargo clippy` | No issues | No issues | ✅ |
+| `cargo fmt --check` | No diff | No diff (after format pass) | ✅ |
+
+## Risks and Rollback
+
+- **`resolve_host` behavior change**: changing `.unwrap_or(false)` to `?` means a transient DB lock during host resolution now returns `ServiceError::Internal` instead of silently falling through to `NotFound`. This is correct, but callers that previously relied on the silent fallback behavior will now see a 500-class error instead of a 404. Rollback: revert `service.rs:682` to `.unwrap_or(false)`.
+- **Slow-op warn noise**: the 500 ms threshold may generate frequent warns on queries that are acceptably slow in homelab context. If noise is excessive, raise `SLOW_DB_MS` (it's a named const, one-line change).
+
+## Decisions Not Taken
+
+- **Restore `elapsed_ms` to `rmcp_server.rs`**: the architecture review noted that removing INFO-level end-to-end timing from the MCP layer lost coverage for non-DB tools like `run_gemini_assess`. Decision: do not restore; add warn-on-slow in `run_db` instead. The Gemini subprocess case is a separate concern for a future PR.
+- **Timeout-path test**: triggering the `tokio::time::timeout` expiry path requires a service with near-zero `acquire_timeout` and all permits held — the field is private with no test-visible setter. The effort is disproportionate; the semaphore-closed test covers the structurally similar `Ok(Err(_))` arm.
+- **Task-panic test**: would require `spawn_blocking` to panic, achievable but adds complexity for low practical value. Deferred.
+
+## Next Steps
+
+**Follow-on work (not yet started):**
+- Investigate and fix `ai_tool` data consistency bug: `syslog ai projects` shows both `"claude"` and `"claude-code"` because the `ai_tool` column sometimes contains the raw `app_name` value instead of the normalized value from `ai_tool_from_app()` (`src/syslog/enrichment.rs:251–258`). The `GROUP_CONCAT(DISTINCT ai_tool)` in `list_ai_projects()` (`src/db/queries.rs:874`) then surfaces both.
+- Performance: `syslog ai blocks` takes ~3 minutes on 4.9M rows due to a full table scan with heavy GROUP BY and no covering index on `(ai_tool, ai_project, ai_session_id)`.

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "syslog-mcp",
   "display_name": "Syslog MCP",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Query local syslog-mcp SQLite logs through a bundled stdio MCP server.",
   "long_description": "Syslog MCP packages the existing syslog mcp stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/syslog-mcp",
     "source": "github"
   },
-  "version": "0.36.0",
+  "version": "0.36.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.36.0",
+      "identifier": "ghcr.io/jmagar/syslog-mcp:v0.36.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::{TimeDelta, Utc};
 use tokio::sync::Semaphore;
@@ -319,24 +319,30 @@ impl SyslogService {
         path: PathBuf,
         shell: String,
     ) -> ServiceResult<CommandLogImportResult> {
-        self.run_db(move |pool| command_log::import_zsh_history(pool, &path, &shell))
-            .await
+        self.run_db("import_shell_history", move |pool| {
+            command_log::import_zsh_history(pool, &path, &shell)
+        })
+        .await
     }
 
     pub async fn import_atuin_history(
         &self,
         path: PathBuf,
     ) -> ServiceResult<CommandLogImportResult> {
-        self.run_db(move |pool| command_log::import_atuin_history(pool, &path))
-            .await
+        self.run_db("import_atuin_history", move |pool| {
+            command_log::import_atuin_history(pool, &path)
+        })
+        .await
     }
 
     pub async fn import_agent_command_spool(
         &self,
         path: PathBuf,
     ) -> ServiceResult<CommandLogImportResult> {
-        self.run_db(move |pool| command_log::import_agent_command_spool(pool, &path))
-            .await
+        self.run_db("import_agent_command_spool", move |pool| {
+            command_log::import_agent_command_spool(pool, &path)
+        })
+        .await
     }
 
     pub async fn incident(&self, req: IncidentRequest) -> ServiceResult<IncidentResponse> {
@@ -378,7 +384,7 @@ impl SyslogService {
             exclude_ai: false,
         };
         let mut rows = self
-            .run_db(move |pool| db::search_logs(pool, &params))
+            .run_db("incident", move |pool| db::search_logs(pool, &params))
             .await?;
         let mut truncated = rows.len() > limit as usize;
         rows.truncate(limit as usize);
@@ -439,11 +445,12 @@ impl SyslogService {
         })
     }
 
-    async fn run_db<F, T>(&self, f: F) -> ServiceResult<T>
+    async fn run_db<F, T>(&self, op: &'static str, f: F) -> ServiceResult<T>
     where
         F: FnOnce(&DbPool) -> anyhow::Result<T> + Send + 'static,
         T: Send + 'static,
     {
+        let wait_start = Instant::now();
         let permit = tokio::time::timeout(
             self.acquire_timeout,
             Arc::clone(&self.db_permits).acquire_owned(),
@@ -451,18 +458,28 @@ impl SyslogService {
         .await
         .map_err(|_| ServiceError::Busy("database worker limit reached".into()))?
         .map_err(|_| ServiceError::Busy("database worker limit closed".into()))?;
+        let permit_ms = wait_start.elapsed().as_millis();
+
+        let exec_start = Instant::now();
         let pool = Arc::clone(&self.pool);
-        tokio::task::spawn_blocking(move || {
+        let result = tokio::task::spawn_blocking(move || {
             let _permit = permit;
             f(&pool)
         })
         .await
         .map_err(|e| ServiceError::Internal(anyhow::anyhow!("Task join error: {e}")))?
-        .map_err(ServiceError::Internal)
+        .map_err(ServiceError::Internal);
+
+        let exec_ms = exec_start.elapsed().as_millis();
+        match &result {
+            Ok(_) => tracing::debug!(op, permit_ms, exec_ms, "db op ok"),
+            Err(e) => tracing::debug!(op, permit_ms, exec_ms, error = %e, "db op err"),
+        }
+        result
     }
 
     pub async fn health_check(&self) -> ServiceResult<()> {
-        self.run_db(|pool| {
+        self.run_db("health_check", |pool| {
             let conn = pool.get()?;
             conn.query_row("SELECT 1", [], |_| Ok(()))?;
             Ok(())
@@ -475,7 +492,7 @@ impl SyslogService {
         let params = search_request_to_params(req)?;
         let params = SearchParams { query, ..params };
         let logs = self
-            .run_db(move |pool| db::search_logs(pool, &params))
+            .run_db("search_logs", move |pool| db::search_logs(pool, &params))
             .await?;
         let logs: Vec<LogEntry> = logs.into_iter().map(Into::into).collect();
         Ok(SearchLogsResponse {
@@ -503,7 +520,7 @@ impl SyslogService {
         };
         let limit = req.limit.unwrap_or(1).clamp(1, 100) as usize;
         let since = parse_optional_timestamp(req.since.as_deref(), "since")?;
-        self.run_db(move |pool| {
+        self.run_db("host_state", move |pool| {
             db::heartbeat_host_state(pool, lookup, since.as_deref(), limit).map_err(|error| {
                 match error.to_string().as_str() {
                     "not_found" => anyhow::anyhow!("not_found"),
@@ -528,13 +545,17 @@ impl SyslogService {
         let include_ok = req.include_ok.unwrap_or(true);
         let sort = req.sort.clone().unwrap_or_else(|| "pressure".into());
 
-        let entries = self.run_db(db::heartbeat_latest_all).await?;
+        let entries = self
+            .run_db("fleet_state.latest", db::heartbeat_latest_all)
+            .await?;
 
         let mut rows: Vec<FleetStateHostRow> = Vec::with_capacity(entries.len());
         for entry in &entries {
             let hb_id = entry.heartbeat_id;
             let metrics = self
-                .run_db(move |pool| db::heartbeat_metric_snapshot(pool, hb_id))
+                .run_db("fleet_state.metrics", move |pool| {
+                    db::heartbeat_metric_snapshot(pool, hb_id)
+                })
                 .await?;
             let flags = super::heartbeat_flags::from_latest_and_metrics(entry, &metrics);
             let pressure = super::heartbeat_flags::pressure_names(&flags);
@@ -620,7 +641,7 @@ impl SyslogService {
         let host_id: Option<String> = if let Some(host) = req.host.as_deref() {
             let h = host.to_owned();
             let resolved = self
-                .run_db(move |pool| {
+                .run_db("correlate_state.resolve_host", move |pool| {
                     let conn = pool.get()?;
                     // Try host_id first
                     let exists: bool = conn
@@ -667,7 +688,9 @@ impl SyslogService {
         let to2 = to.clone();
         let hid = host_id.clone();
         let heartbeat_summaries = self
-            .run_db(move |pool| db::heartbeat_window_summaries(pool, &from2, &to2, hid.as_deref()))
+            .run_db("correlate_state.heartbeats", move |pool| {
+                db::heartbeat_window_summaries(pool, &from2, &to2, hid.as_deref())
+            })
             .await?;
 
         // Fetch logs for each host in the window
@@ -681,7 +704,7 @@ impl SyslogService {
             let sev_levels = super::correlate::severity_at_or_above(&severity_min)?;
             let fetch_limit = limit + 1;
             let logs = self
-                .run_db(move |pool| {
+                .run_db("correlate_state.logs", move |pool| {
                     db::search_logs(
                         pool,
                         &db::SearchParams {
@@ -727,7 +750,7 @@ impl SyslogService {
     pub async fn filter_logs(&self, req: FilterLogsRequest) -> ServiceResult<SearchLogsResponse> {
         let params = filter_request_to_params(req)?;
         let logs = self
-            .run_db(move |pool| db::search_logs(pool, &params))
+            .run_db("filter_logs", move |pool| db::search_logs(pool, &params))
             .await?;
         let logs: Vec<LogEntry> = logs.into_iter().map(Into::into).collect();
         Ok(SearchLogsResponse {
@@ -742,7 +765,7 @@ impl SyslogService {
             None => None,
         };
         let logs = self
-            .run_db(move |pool| {
+            .run_db("tail_logs", move |pool| {
                 db::tail_logs(
                     pool,
                     req.hostname.as_deref(),
@@ -773,7 +796,7 @@ impl SyslogService {
             }
         };
         let rows = self
-            .run_db(move |pool| {
+            .run_db("get_errors", move |pool| {
                 db::get_error_summary(
                     pool,
                     from.as_deref(),
@@ -789,7 +812,7 @@ impl SyslogService {
     }
 
     pub async fn list_hosts(&self) -> ServiceResult<ListHostsResponse> {
-        let rows = self.run_db(db::list_hosts).await?;
+        let rows = self.run_db("list_hosts", db::list_hosts).await?;
         Ok(ListHostsResponse {
             hosts: rows.into_iter().map(Into::into).collect(),
         })
@@ -810,7 +833,9 @@ impl SyslogService {
             limit: req.limit,
         };
         let rows = self
-            .run_db(move |pool| db::list_ai_sessions(pool, &params))
+            .run_db("list_sessions", move |pool| {
+                db::list_ai_sessions(pool, &params)
+            })
             .await?;
         let sessions: Vec<AiSessionEntry> = rows.into_iter().map(Into::into).collect();
         Ok(ListSessionsResponse {
@@ -852,7 +877,9 @@ impl SyslogService {
             limit: req.limit,
         };
         let result = self
-            .run_db(move |pool| db::search_ai_sessions(pool, &params))
+            .run_db("search_sessions", move |pool| {
+                db::search_ai_sessions(pool, &params)
+            })
             .await?;
         let mut response: SearchSessionsResponse = result.into();
         if let Some(policy) = limit_clamped_to.filter(|policy| policy.report_limit_clamp) {
@@ -895,7 +922,9 @@ impl SyslogService {
             terms: req.terms,
         };
         let result = self
-            .run_db(move |pool| db::search_ai_abuse(pool, &params))
+            .run_db("search_abuse", move |pool| {
+                db::search_ai_abuse(pool, &params)
+            })
             .await?;
         let mut response: AbuseSearchResponse = result.into();
         if let Some(policy) = limit_clamped_to.filter(|policy| policy.report_limit_clamp) {
@@ -912,7 +941,7 @@ impl SyslogService {
         let from = parse_optional_timestamp(req.from.as_deref(), "from")?;
         let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
         let result = self
-            .run_db(move |pool| {
+            .run_db("list_ai_incidents", move |pool| {
                 db::search_ai_incidents(
                     pool,
                     &db::AiIncidentParams {
@@ -944,7 +973,7 @@ impl SyslogService {
         let from = parse_optional_timestamp(req.from.as_deref(), "from")?;
         let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
         let result = self
-            .run_db(move |pool| {
+            .run_db("investigate_ai_incidents", move |pool| {
                 db::investigate_ai_incidents(
                     pool,
                     &db::AiInvestigateParams {
@@ -1017,41 +1046,45 @@ impl SyslogService {
             Vec<db::AiRelatedLogsForAnchor>,
         );
         let (anchors_truncated, anchor_entries, related_by_anchor) = self
-            .run_db(move |pool| -> anyhow::Result<CorrelateDbResult> {
-                let mut anchors = db::search_ai_anchors(pool, &anchor_params)?;
-                let anchors_truncated = anchors.len() > anchor_limit as usize;
-                anchors.truncate(anchor_limit as usize);
+            .run_db(
+                "correlate_ai_logs",
+                move |pool| -> anyhow::Result<CorrelateDbResult> {
+                    let mut anchors = db::search_ai_anchors(pool, &anchor_params)?;
+                    let anchors_truncated = anchors.len() > anchor_limit as usize;
+                    anchors.truncate(anchor_limit as usize);
 
-                let delta = TimeDelta::try_minutes(i64::from(window))
-                    .ok_or_else(|| anyhow::anyhow!("window_minutes overflow"))?;
+                    let delta = TimeDelta::try_minutes(i64::from(window))
+                        .ok_or_else(|| anyhow::anyhow!("window_minutes overflow"))?;
 
-                let mut anchor_entries = Vec::with_capacity(anchors.len());
-                let mut windows = Vec::with_capacity(anchors.len());
-                for (anchor_index, anchor) in anchors.into_iter().enumerate() {
-                    let ref_dt = parse_required_timestamp(&anchor.timestamp, "anchor.timestamp")
-                        .map_err(anyhow::Error::from)?;
-                    let window_from = rfc3339_z(ref_dt - delta);
-                    let window_to = rfc3339_z(ref_dt + delta);
-                    windows.push(db::AiRelatedWindow {
-                        anchor_index,
-                        window_from: window_from.clone(),
-                        window_to: window_to.clone(),
-                    });
-                    anchor_entries.push((anchor, window_from, window_to));
-                }
+                    let mut anchor_entries = Vec::with_capacity(anchors.len());
+                    let mut windows = Vec::with_capacity(anchors.len());
+                    for (anchor_index, anchor) in anchors.into_iter().enumerate() {
+                        let ref_dt =
+                            parse_required_timestamp(&anchor.timestamp, "anchor.timestamp")
+                                .map_err(anyhow::Error::from)?;
+                        let window_from = rfc3339_z(ref_dt - delta);
+                        let window_to = rfc3339_z(ref_dt + delta);
+                        windows.push(db::AiRelatedWindow {
+                            anchor_index,
+                            window_from: window_from.clone(),
+                            window_to: window_to.clone(),
+                        });
+                        anchor_entries.push((anchor, window_from, window_to));
+                    }
 
-                let related_params = db::AiRelatedLogsParams {
-                    windows,
-                    query: log_query,
-                    hostname,
-                    source_ip,
-                    severity_in: severity_levels,
-                    app_name,
-                    limit_per_anchor: related_limit,
-                };
-                let related_by_anchor = db::search_ai_related_logs(pool, &related_params)?;
-                Ok((anchors_truncated, anchor_entries, related_by_anchor))
-            })
+                    let related_params = db::AiRelatedLogsParams {
+                        windows,
+                        query: log_query,
+                        hostname,
+                        source_ip,
+                        severity_in: severity_levels,
+                        app_name,
+                        limit_per_anchor: related_limit,
+                    };
+                    let related_by_anchor = db::search_ai_related_logs(pool, &related_params)?;
+                    Ok((anchors_truncated, anchor_entries, related_by_anchor))
+                },
+            )
             .await?;
 
         let mut by_anchor: std::collections::HashMap<usize, db::AiRelatedLogsForAnchor> =
@@ -1106,7 +1139,9 @@ impl SyslogService {
             to,
         };
         let result = self
-            .run_db(move |pool| db::get_ai_usage_blocks(pool, &params))
+            .run_db("usage_blocks", move |pool| {
+                db::get_ai_usage_blocks(pool, &params)
+            })
             .await?;
         Ok(result.into())
     }
@@ -1121,7 +1156,9 @@ impl SyslogService {
             limit: req.limit,
         };
         let result = self
-            .run_db(move |pool| db::get_ai_project_context(pool, &params))
+            .run_db("project_context", move |pool| {
+                db::get_ai_project_context(pool, &params)
+            })
             .await?;
         Ok(result.into())
     }
@@ -1138,7 +1175,9 @@ impl SyslogService {
             to,
         };
         let result = self
-            .run_db(move |pool| db::list_ai_tools(pool, &params))
+            .run_db("list_ai_tools", move |pool| {
+                db::list_ai_tools(pool, &params)
+            })
             .await?;
         Ok(result.into())
     }
@@ -1155,7 +1194,9 @@ impl SyslogService {
             to,
         };
         let result = self
-            .run_db(move |pool| db::list_ai_projects(pool, &params))
+            .run_db("list_ai_projects", move |pool| {
+                db::list_ai_projects(pool, &params)
+            })
             .await?;
         Ok(result.into())
     }
@@ -1196,7 +1237,9 @@ impl SyslogService {
             exclude_ai: false,
         };
         let mut rows = self
-            .run_db(move |pool| db::search_logs(pool, &params))
+            .run_db("correlate_events", move |pool| {
+                db::search_logs(pool, &params)
+            })
             .await?;
         let truncated = rows.len() > limit as usize;
         rows.truncate(limit as usize);
@@ -1220,7 +1263,7 @@ impl SyslogService {
     pub async fn get_stats(&self) -> ServiceResult<DbStats> {
         let storage = self.storage.clone();
         let stats = self
-            .run_db(move |pool| db::get_stats(pool, &storage))
+            .run_db("get_stats", move |pool| db::get_stats(pool, &storage))
             .await?
             .into();
         Ok(stats)
@@ -1228,7 +1271,7 @@ impl SyslogService {
 
     pub async fn db_status(&self) -> ServiceResult<DbMaintenanceStatus> {
         let storage = self.storage.clone();
-        self.run_db(move |pool| {
+        self.run_db("db_status", move |pool| {
             let page_count = db::db_pragma_i64(pool, db::PragmaName("page_count"))?;
             let freelist_count = db::db_pragma_i64(pool, db::PragmaName("freelist_count"))?;
             let page_size = db::db_pragma_i64(pool, db::PragmaName("page_size"))?;
@@ -1262,7 +1305,7 @@ impl SyslogService {
     }
 
     pub async fn db_integrity(&self, quick: bool) -> ServiceResult<DbIntegrityResult> {
-        self.run_db(move |pool| {
+        self.run_db("db_integrity", move |pool| {
             let messages = db::db_integrity_check(pool, quick)?;
             Ok(DbIntegrityResult {
                 ok: messages.len() == 1 && messages.first().is_some_and(|value| value == "ok"),
@@ -1273,7 +1316,7 @@ impl SyslogService {
     }
 
     async fn db_checkpoint(&self, mode: String) -> ServiceResult<DbCheckpointResult> {
-        self.run_db(move |pool| {
+        self.run_db("db_checkpoint", move |pool| {
             let (busy, log_frames, checkpointed_frames) = db::db_wal_checkpoint(pool, &mode)?;
             Ok(DbCheckpointResult {
                 mode,
@@ -1299,7 +1342,7 @@ impl SyslogService {
     /// startup snapshot (bead 0p8r.17). Cheap enough to call per-request:
     /// two `PRAGMA` reads on a held connection inside `spawn_blocking`.
     pub async fn db_logical_size_bytes(&self) -> ServiceResult<u64> {
-        self.run_db(move |pool| {
+        self.run_db("db_logical_size_bytes", move |pool| {
             let page_count = db::db_pragma_i64(pool, db::PragmaName("page_count"))?;
             let page_size = db::db_pragma_i64(pool, db::PragmaName("page_size"))?;
             Ok((page_count.max(0) as u64).saturating_mul(page_size.max(0) as u64))
@@ -1309,7 +1352,7 @@ impl SyslogService {
 
     async fn db_vacuum(&self, full: bool, incremental_pages: u32) -> ServiceResult<DbVacuumResult> {
         let storage = self.storage.clone();
-        self.run_db(move |pool| {
+        self.run_db("db_vacuum", move |pool| {
             let before_physical_size_bytes = db::physical_size_bytes(&storage.db_path)?;
             if full {
                 db::db_full_vacuum(pool)?;
@@ -1346,7 +1389,7 @@ impl SyslogService {
 
     pub async fn db_backup(&self, output: Option<PathBuf>) -> ServiceResult<DbBackupResult> {
         let db_path = self.storage.db_path.clone();
-        self.run_db(move |_pool| {
+        self.run_db("db_backup", move |_pool| {
             let backup_path = backup_path_for(&db_path, output)?;
             if let Some(parent) = backup_path.parent() {
                 std::fs::create_dir_all(parent)?;
@@ -1400,7 +1443,7 @@ impl SyslogService {
                 })
             })
             .transpose()?;
-        self.run_db(move |pool| {
+        self.run_db("index_ai_roots", move |pool| {
             scanner::index_roots_with_options(
                 pool,
                 scanner::IndexOptions {
@@ -1421,7 +1464,7 @@ impl SyslogService {
         force: bool,
     ) -> ServiceResult<scanner::IndexResult> {
         let storage = self.storage.clone();
-        self.run_db(move |pool| {
+        self.run_db("add_ai_file", move |pool| {
             scanner::index_file_with_options(
                 pool,
                 std::path::Path::new(&file),
@@ -1440,7 +1483,7 @@ impl SyslogService {
         missing_only: bool,
         limit: Option<u32>,
     ) -> ServiceResult<Vec<scanner::CheckpointEntry>> {
-        self.run_db(move |pool| {
+        self.run_db("list_ai_checkpoints", move |pool| {
             scanner::list_checkpoints(
                 pool,
                 &scanner::CheckpointListOptions {
@@ -1457,7 +1500,7 @@ impl SyslogService {
         &self,
         limit: Option<u32>,
     ) -> ServiceResult<Vec<scanner::ParseErrorEntry>> {
-        self.run_db(move |pool| {
+        self.run_db("list_ai_parse_errors", move |pool| {
             scanner::list_parse_errors(pool, &scanner::ParseErrorListOptions { limit })
         })
         .await
@@ -1469,7 +1512,7 @@ impl SyslogService {
         dry_run: bool,
         limit: Option<u32>,
     ) -> ServiceResult<scanner::PruneCheckpointsResult> {
-        self.run_db(move |pool| {
+        self.run_db("prune_ai_checkpoints", move |pool| {
             scanner::prune_checkpoints(
                 pool,
                 &scanner::PruneCheckpointsOptions {
@@ -1493,7 +1536,7 @@ impl SyslogService {
 
     pub async fn ai_doctor(&self) -> ServiceResult<scanner::AiDoctorReport> {
         let db_path = self.storage.db_path.clone();
-        self.run_db(move |pool| scanner::ai_doctor(pool, &db_path))
+        self.run_db("ai_doctor", move |pool| scanner::ai_doctor(pool, &db_path))
             .await
     }
 
@@ -1501,15 +1544,17 @@ impl SyslogService {
         &self,
         process_start_time: Option<String>,
     ) -> ServiceResult<scanner::AiIndexingHealth> {
-        self.run_db(move |pool| scanner::ai_indexing_health(pool, process_start_time.as_deref()))
-            .await
+        self.run_db("ai_indexing_health", move |pool| {
+            scanner::ai_indexing_health(pool, process_start_time.as_deref())
+        })
+        .await
     }
 
     pub async fn list_apps(&self, req: ListAppsRequest) -> ServiceResult<ListAppsResponse> {
         let from = parse_optional_timestamp(req.from.as_deref(), "from")?;
         let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
         let result = self
-            .run_db(move |pool| {
+            .run_db("list_apps", move |pool| {
                 db::list_apps(
                     pool,
                     &db::ListAppsParams {
@@ -1533,7 +1578,7 @@ impl SyslogService {
         req: ListSourceIpsRequest,
     ) -> ServiceResult<ListSourceIpsResponse> {
         let result = self
-            .run_db(move |pool| {
+            .run_db("list_source_ips", move |pool| {
                 db::list_source_ips(
                     pool,
                     &db::ListSourceIpsParams {
@@ -1572,7 +1617,7 @@ impl SyslogService {
         };
         let group_by_label = req.group_by.clone();
         let points = self
-            .run_db(move |pool| {
+            .run_db("timeline", move |pool| {
                 db::timeline(
                     pool,
                     bucket,
@@ -1602,7 +1647,7 @@ impl SyslogService {
         let scan_limit = req.scan_limit.unwrap_or(10_000);
         let top_n = req.top_n.unwrap_or(20).min(200);
         let (patterns, scanned, truncated) = self
-            .run_db(move |pool| {
+            .run_db("patterns", move |pool| {
                 db::patterns(
                     pool,
                     from.as_deref(),
@@ -1641,7 +1686,7 @@ impl SyslogService {
         };
 
         let resolved = self
-            .run_db(move |pool| -> anyhow::Result<_> {
+            .run_db("context", move |pool| -> anyhow::Result<_> {
                 let (reference, hostname, timestamp, id): (LogEntry, String, String, Option<i64>) =
                     if let Some(id) = req.log_id {
                         let row = db::fetch_log_by_id(pool, id)?
@@ -1730,7 +1775,7 @@ impl SyslogService {
     pub async fn get_log(&self, req: GetLogRequest) -> ServiceResult<GetLogResponse> {
         let id = req.id;
         let row = self
-            .run_db(move |pool| db::fetch_log_by_id(pool, id))
+            .run_db("get_log", move |pool| db::fetch_log_by_id(pool, id))
             .await?
             .ok_or_else(|| ServiceError::InvalidInput(format!("No log found for id {id}")))?;
         Ok(GetLogResponse { log: row.into() })
@@ -1750,7 +1795,7 @@ impl SyslogService {
         let cut_5m_q = cut_5m.clone();
         let cut_15m_q = cut_15m.clone();
         let result = self
-            .run_db(move |pool| -> anyhow::Result<_> {
+            .run_db("ingest_rate", move |pool| -> anyhow::Result<_> {
                 let buckets = db::ingest_rate(pool, &now_clone, &cut_1m_q, &cut_5m_q, &cut_15m_q)?;
                 let by_host = if want_by_host {
                     Some(db::ingest_rate_by_host(
@@ -1785,7 +1830,9 @@ impl SyslogService {
         let now_unix = now_dt.timestamp();
         let cutoff_q = cutoff.clone();
         let hosts = self
-            .run_db(move |pool| db::silent_hosts(pool, &cutoff_q, now_unix))
+            .run_db("silent_hosts", move |pool| {
+                db::silent_hosts(pool, &cutoff_q, now_unix)
+            })
             .await?;
         Ok(SilentHostsResponse {
             silent_minutes,
@@ -1805,7 +1852,7 @@ impl SyslogService {
         let q = since_str.clone();
         let limit = req.limit.map(|limit| limit.clamp(1, 100));
         let hosts = self
-            .run_db(move |pool| db::clock_skew(pool, &q, limit))
+            .run_db("clock_skew", move |pool| db::clock_skew(pool, &q, limit))
             .await?;
         Ok(ClockSkewResponse {
             since: since_str,
@@ -1829,7 +1876,7 @@ impl SyslogService {
         let bf = baseline_from.clone();
         let bt = baseline_to.clone();
         let hosts = self
-            .run_db(move |pool| {
+            .run_db("anomalies", move |pool| {
                 db::anomalies(pool, &rf, &rt, &bf, &bt, recent_minutes, baseline_minutes)
             })
             .await?;
@@ -1855,7 +1902,7 @@ impl SyslogService {
         let b_from_q = b_from.clone();
         let b_to_q = b_to.clone();
         let result = self
-            .run_db(move |pool| -> anyhow::Result<_> {
+            .run_db("compare", move |pool| -> anyhow::Result<_> {
                 let a = db::summarize_range(pool, &a_from_q, &a_to_q)?;
                 let b = db::summarize_range(pool, &b_from_q, &b_to_q)?;
                 Ok((a, b))
@@ -1880,7 +1927,7 @@ impl SyslogService {
     ) -> ServiceResult<super::models::UnaddressedErrorsResponse> {
         let limit = req.limit.unwrap_or(50) as i64;
         let include_acked = req.include_acknowledged.unwrap_or(false);
-        self.run_db(move |pool| {
+        self.run_db("unaddressed_errors", move |pool| {
             let rows = crate::db::error_signatures::read_unaddressed(pool, limit, include_acked)?;
             let signatures = rows
                 .into_iter()
@@ -1922,7 +1969,7 @@ impl SyslogService {
         // Check it exists first
         let h = hash.clone();
         let exists = self
-            .run_db(move |pool| {
+            .run_db("ack_error.exists", move |pool| {
                 Ok(crate::db::error_signatures::read_signature_by_hash(
                     pool,
                     &h,
@@ -1943,7 +1990,7 @@ impl SyslogService {
         let now_clone = now.clone();
         let actor_clone = actor_owned.clone();
         let hash_clone = hash.clone();
-        self.run_db(move |pool| {
+        self.run_db("ack_error.commit", move |pool| {
             let mut conn = pool.get()?;
             let tx = conn.transaction()?;
             crate::db::error_signatures::record_ack_event(
@@ -1991,7 +2038,7 @@ impl SyslogService {
         // Check it exists first
         let h = hash.clone();
         let exists = self
-            .run_db(move |pool| {
+            .run_db("unack_error.exists", move |pool| {
                 Ok(crate::db::error_signatures::read_signature_by_hash(
                     pool,
                     &h,
@@ -2011,7 +2058,7 @@ impl SyslogService {
             .to_string();
         let actor_clone = actor_owned.clone();
         let hash_clone = hash.clone();
-        self.run_db(move |pool| {
+        self.run_db("unack_error.commit", move |pool| {
             let mut conn = pool.get()?;
             let tx = conn.transaction()?;
             crate::db::error_signatures::record_ack_event(
@@ -2099,7 +2146,7 @@ impl SyslogService {
         req: NotificationsRecentRequest,
     ) -> ServiceResult<Vec<crate::db::notifications::FiringRow>> {
         let limit = req.effective_limit();
-        self.run_db(move |pool| {
+        self.run_db("notifications_recent", move |pool| {
             let conn = pool.get()?;
             crate::db::notifications::firings_recent(
                 &conn,
@@ -2202,7 +2249,7 @@ impl SyslogService {
         let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
         let severity_min = validate_optional_severity(req.severity_min)?;
         let result = self
-            .run_db(move |pool| {
+            .run_db("similar_incidents", move |pool| {
                 db::similar_incidents_clusters(
                     pool,
                     &db::SimilarIncidentsParams {
@@ -2225,7 +2272,7 @@ impl SyslogService {
         let from = parse_optional_timestamp(req.from.as_deref(), "from")?;
         let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
         let result = self
-            .run_db(move |pool| {
+            .run_db("ask_history", move |pool| {
                 db::ask_history_sessions(
                     pool,
                     &db::AskHistoryParams {
@@ -2250,7 +2297,7 @@ impl SyslogService {
         let from = rfc3339_z(parse_required_timestamp(&req.from, "from")?);
         let to = rfc3339_z(parse_required_timestamp(&req.to, "to")?);
         let result = self
-            .run_db(move |pool| {
+            .run_db("incident_context", move |pool| {
                 db::incident_context_summary(
                     pool,
                     &db::IncidentContextParams {

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -39,7 +39,7 @@ use crate::db::{self, Bucket, ContextRef, DbPool, SearchParams, TimelineGroupBy}
 use crate::scanner;
 
 const DB_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
-pub(super) const SLOW_DB_MS: u128 = 500;
+const SLOW_DB_MS: u128 = 500;
 const SYSLOG_OWNED_USER_SERVICES: &[&str] = &[
     "syslog-ai-watch.service",
     "syslog-ai-index.service",
@@ -498,8 +498,8 @@ impl SyslogService {
 
         if exec_ms > SLOW_DB_MS {
             match &result {
-                Ok(_) => tracing::warn!(op, permit_ms, exec_ms, "slow db op"),
-                Err(e) => tracing::warn!(op, permit_ms, exec_ms, error = %e, "slow db op err"),
+                Ok(_) => tracing::warn!(op, permit_ms, exec_ms, "db op ok"),
+                Err(e) => tracing::warn!(op, permit_ms, exec_ms, error = %e, "db op err"),
             }
         } else {
             match &result {

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -484,7 +484,11 @@ impl SyslogService {
 
         let result = match join_result {
             Err(e) => {
-                tracing::warn!(op, permit_ms, exec_ms, error = %e, "db task panic");
+                if e.is_cancelled() {
+                    tracing::warn!(op, permit_ms, exec_ms, "db task cancelled");
+                } else {
+                    tracing::warn!(op, permit_ms, exec_ms, error = %e, "db task panic");
+                }
                 return Err(ServiceError::Internal(anyhow::anyhow!(
                     "Task join error: {e}"
                 )));
@@ -678,8 +682,7 @@ impl SyslogService {
                             [&h],
                             |row| row.get::<_, i64>(0),
                         )
-                        .map(|c| c > 0)
-                        .unwrap_or(false);
+                        .map(|c| c > 0)?;
                     if exists {
                         return Ok(Some(h));
                     }

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -39,6 +39,7 @@ use crate::db::{self, Bucket, ContextRef, DbPool, SearchParams, TimelineGroupBy}
 use crate::scanner;
 
 const DB_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(5);
+pub(super) const SLOW_DB_MS: u128 = 500;
 const SYSLOG_OWNED_USER_SERVICES: &[&str] = &[
     "syslog-ai-watch.service",
     "syslog-ai-index.service",
@@ -384,7 +385,9 @@ impl SyslogService {
             exclude_ai: false,
         };
         let mut rows = self
-            .run_db("incident", move |pool| db::search_logs(pool, &params))
+            .run_db("incident.search", move |pool| {
+                db::search_logs(pool, &params)
+            })
             .await?;
         let mut truncated = rows.len() > limit as usize;
         rows.truncate(limit as usize);
@@ -451,29 +454,54 @@ impl SyslogService {
         T: Send + 'static,
     {
         let wait_start = Instant::now();
-        let permit = tokio::time::timeout(
+        let permit_result = tokio::time::timeout(
             self.acquire_timeout,
             Arc::clone(&self.db_permits).acquire_owned(),
         )
-        .await
-        .map_err(|_| ServiceError::Busy("database worker limit reached".into()))?
-        .map_err(|_| ServiceError::Busy("database worker limit closed".into()))?;
+        .await;
         let permit_ms = wait_start.elapsed().as_millis();
+
+        let permit = match permit_result {
+            Err(_) => {
+                tracing::warn!(op, permit_ms, "db acquire timeout");
+                return Err(ServiceError::Busy("database worker limit reached".into()));
+            }
+            Ok(Err(_)) => {
+                tracing::warn!(op, permit_ms, "db semaphore closed");
+                return Err(ServiceError::Busy("database worker limit closed".into()));
+            }
+            Ok(Ok(p)) => p,
+        };
 
         let exec_start = Instant::now();
         let pool = Arc::clone(&self.pool);
-        let result = tokio::task::spawn_blocking(move || {
+        let join_result = tokio::task::spawn_blocking(move || {
             let _permit = permit;
             f(&pool)
         })
-        .await
-        .map_err(|e| ServiceError::Internal(anyhow::anyhow!("Task join error: {e}")))?
-        .map_err(ServiceError::Internal);
-
+        .await;
         let exec_ms = exec_start.elapsed().as_millis();
-        match &result {
-            Ok(_) => tracing::debug!(op, permit_ms, exec_ms, "db op ok"),
-            Err(e) => tracing::debug!(op, permit_ms, exec_ms, error = %e, "db op err"),
+
+        let result = match join_result {
+            Err(e) => {
+                tracing::warn!(op, permit_ms, exec_ms, error = %e, "db task panic");
+                return Err(ServiceError::Internal(anyhow::anyhow!(
+                    "Task join error: {e}"
+                )));
+            }
+            Ok(r) => r.map_err(ServiceError::Internal),
+        };
+
+        if exec_ms > SLOW_DB_MS {
+            match &result {
+                Ok(_) => tracing::warn!(op, permit_ms, exec_ms, "slow db op"),
+                Err(e) => tracing::warn!(op, permit_ms, exec_ms, error = %e, "slow db op err"),
+            }
+        } else {
+            match &result {
+                Ok(_) => tracing::debug!(op, permit_ms, exec_ms, "db op ok"),
+                Err(e) => tracing::debug!(op, permit_ms, exec_ms, error = %e, "db op err"),
+            }
         }
         result
     }

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -579,10 +579,11 @@ async fn run_db_emits_warn_on_slow_op() {
         .await
         .unwrap();
 
-    assert!(logs_contain("slow db op"));
+    // Slow ops escalate to WARN level; message stays "db op ok" so aggregators
+    // can filter a single message across all speeds, using exec_ms for the threshold.
+    assert!(logs_contain("WARN"));
+    assert!(logs_contain("db op ok"));
     assert!(logs_contain("op=\"slow_test\""));
-    // The slow-path warn must still carry structured timing so operators can
-    // see how long the op actually took — not just that it was slow.
     assert!(logs_contain("permit_ms"));
     assert!(logs_contain("exec_ms"));
 }
@@ -616,7 +617,8 @@ async fn run_db_emits_warn_on_slow_op_with_error() {
         })
         .await;
 
-    assert!(logs_contain("slow db op err"));
+    assert!(logs_contain("WARN"));
+    assert!(logs_contain("db op err"));
     assert!(logs_contain("op=\"slow_err_test\""));
     assert!(logs_contain("error="));
 }

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -564,3 +564,31 @@ async fn run_db_emits_timing_trace_on_success() {
     assert!(logs_contain("permit_ms"));
     assert!(logs_contain("exec_ms"));
 }
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn run_db_emits_warn_on_slow_op() {
+    use std::time::Duration;
+    let (service, _pool, _dir) = test_service();
+
+    service
+        .run_db("slow_test", |_pool| {
+            std::thread::sleep(Duration::from_millis(SLOW_DB_MS as u64 + 50));
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+    assert!(logs_contain("slow db op"));
+    assert!(logs_contain("op=\"slow_test\""));
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn run_db_emits_warn_on_semaphore_closed() {
+    let (service, _pool, _dir) = test_service();
+    service.db_permits.close();
+    let result = service.run_db("closed_test", |_| Ok(())).await;
+    assert!(result.is_err());
+    assert!(logs_contain("db semaphore closed"));
+}

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -581,6 +581,10 @@ async fn run_db_emits_warn_on_slow_op() {
 
     assert!(logs_contain("slow db op"));
     assert!(logs_contain("op=\"slow_test\""));
+    // The slow-path warn must still carry structured timing so operators can
+    // see how long the op actually took — not just that it was slow.
+    assert!(logs_contain("permit_ms"));
+    assert!(logs_contain("exec_ms"));
 }
 
 #[tokio::test]
@@ -588,7 +592,13 @@ async fn run_db_emits_warn_on_slow_op() {
 async fn run_db_emits_warn_on_semaphore_closed() {
     let (service, _pool, _dir) = test_service();
     service.db_permits.close();
-    let result = service.run_db("closed_test", |_| Ok(())).await;
-    assert!(result.is_err());
+
+    let err = service.run_db("closed_test", |_| Ok(())).await.unwrap_err();
+
+    assert!(
+        matches!(err, ServiceError::Busy(_)),
+        "expected Busy, got {err:?}"
+    );
     assert!(logs_contain("db semaphore closed"));
+    assert!(logs_contain("op=\"closed_test\""));
 }

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -602,3 +602,21 @@ async fn run_db_emits_warn_on_semaphore_closed() {
     assert!(logs_contain("db semaphore closed"));
     assert!(logs_contain("op=\"closed_test\""));
 }
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn run_db_emits_warn_on_slow_op_with_error() {
+    use std::time::Duration;
+    let (service, _pool, _dir) = test_service();
+
+    let _: ServiceResult<()> = service
+        .run_db("slow_err_test", |_pool| {
+            std::thread::sleep(Duration::from_millis(SLOW_DB_MS as u64 + 50));
+            Err(anyhow::anyhow!("simulated slow failure"))
+        })
+        .await;
+
+    assert!(logs_contain("slow db op err"));
+    assert!(logs_contain("op=\"slow_err_test\""));
+    assert!(logs_contain("error="));
+}

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -548,3 +548,19 @@ async fn ai_service_methods_return_seeded_data() {
         .unwrap();
     assert_eq!(tools.tools[0].tool, "claude");
 }
+
+// `tracing_test::traced_test` captures TRACE-level events by default, so the
+// `tracing::debug!` calls emitted by `run_db` are visible to `logs_contain`.
+// We verify both the message tag and the structured timing fields are present.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn run_db_emits_timing_trace_on_success() {
+    let (service, _pool, _dir) = test_service();
+
+    service.health_check().await.unwrap();
+
+    assert!(logs_contain("db op ok"));
+    assert!(logs_contain("op=\"health_check\""));
+    assert!(logs_contain("permit_ms"));
+    assert!(logs_contain("exec_ms"));
+}

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Instant;
 
 use axum::{
     extract::{ConnectInfo, State},
@@ -84,10 +85,25 @@ async fn heartbeat_handler(
 
     let pool = Arc::clone(&state.pool);
     let source_ip = peer.to_string();
-    let result = tokio::task::spawn_blocking(move || insert_heartbeat(&pool, request, &source_ip))
-        .await
+    let exec_start = Instant::now();
+    let join_result =
+        tokio::task::spawn_blocking(move || insert_heartbeat(&pool, request, &source_ip)).await;
+    let exec_ms = exec_start.elapsed().as_millis();
+    let result = join_result
         .map_err(|error| anyhow::anyhow!("heartbeat insert task failed: {error}"))
         .and_then(|result| result);
+    // Two-tier: heartbeat INSERTs target <5ms; warn only above 500ms to avoid noise.
+    if exec_ms > 500 {
+        match &result {
+            Ok(_) => tracing::warn!(op = "heartbeat.insert", exec_ms, "db op ok"),
+            Err(e) => tracing::warn!(op = "heartbeat.insert", exec_ms, error = %e, "db op err"),
+        }
+    } else {
+        match &result {
+            Ok(_) => tracing::debug!(op = "heartbeat.insert", exec_ms, "db op ok"),
+            Err(e) => tracing::debug!(op = "heartbeat.insert", exec_ms, error = %e, "db op err"),
+        }
+    }
 
     match result {
         Ok(response) => (StatusCode::ACCEPTED, Json(response)).into_response(),

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, net::Ipv6Addr, sync::Arc, time::Instant};
+use std::{borrow::Cow, net::Ipv6Addr, sync::Arc};
 
 use lab_auth::AuthContext;
 use rmcp::{
@@ -84,7 +84,6 @@ impl ServerHandler for SyslogRmcpServer {
             .arguments
             .map(Value::Object)
             .unwrap_or_else(|| Value::Object(Map::new()));
-        let started = Instant::now();
         tracing::info!(tool = %tool_name, "MCP tool execution started");
 
         match execute_tool(&self.state, &tool_name, arguments, auth).await {
@@ -92,7 +91,6 @@ impl ServerHandler for SyslogRmcpServer {
                 let result_count = safe_result_count(&result);
                 tracing::info!(
                     tool = %tool_name,
-                    elapsed_ms = started.elapsed().as_millis(),
                     result_count,
                     "MCP tool execution completed"
                 );
@@ -101,7 +99,6 @@ impl ServerHandler for SyslogRmcpServer {
             Err(error) if is_validation_error(&error) => {
                 tracing::warn!(
                     tool = %tool_name,
-                    elapsed_ms = started.elapsed().as_millis(),
                     error_class = "invalid_params",
                     "MCP tool execution rejected invalid params"
                 );
@@ -110,7 +107,6 @@ impl ServerHandler for SyslogRmcpServer {
             Err(error) => {
                 tracing::error!(
                     tool = %tool_name,
-                    elapsed_ms = started.elapsed().as_millis(),
                     error = %error,
                     error_class = "tool_execution",
                     "MCP tool execution failed"

--- a/src/notifications/digest.rs
+++ b/src/notifications/digest.rs
@@ -7,9 +7,13 @@
 //! been reached and hasn't fired today. No cron crate needed.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
 use tokio::sync::Semaphore;
+
+// Digest runs two aggregate queries over a 24h window — allow 5s before warning.
+const SLOW_DB_MS: u128 = 5_000;
 
 use crate::config::NotificationsConfig;
 use crate::db::notifications::{backoff_next_attempt_at, outbox_insert, OutboxInsertParams};
@@ -140,7 +144,8 @@ pub(crate) async fn run_digest(
     let apprise_urls_json =
         serde_json::to_string(&cfg.apprise_urls).unwrap_or_else(|_| "[]".to_string());
 
-    tokio::task::spawn_blocking(move || -> Result<()> {
+    let exec_start = Instant::now();
+    let join_result = tokio::task::spawn_blocking(move || -> Result<()> {
         let conn = pool.get()?;
         let entries = fetch_host_stats(&conn, 24).map_err(anyhow::Error::from)?;
         let body = build_digest_body(&entries, 24);
@@ -165,7 +170,21 @@ pub(crate) async fn run_digest(
         tracing::info!(date = %today, "digest: daily digest queued");
         Ok(())
     })
-    .await??;
+    .await;
+    let exec_ms = exec_start.elapsed().as_millis();
+    let result = join_result.map_err(|e| anyhow::anyhow!("db task join error: {e}"))?;
+    if exec_ms > SLOW_DB_MS {
+        match &result {
+            Ok(_) => tracing::warn!(op = "notif.digest_write", exec_ms, "db op ok"),
+            Err(e) => tracing::warn!(op = "notif.digest_write", exec_ms, error = %e, "db op err"),
+        }
+    } else {
+        match &result {
+            Ok(_) => tracing::debug!(op = "notif.digest_write", exec_ms, "db op ok"),
+            Err(e) => tracing::debug!(op = "notif.digest_write", exec_ms, error = %e, "db op err"),
+        }
+    }
+    result?;
 
     Ok(())
 }

--- a/src/notifications/dispatcher.rs
+++ b/src/notifications/dispatcher.rs
@@ -16,6 +16,7 @@
 //! Security: NEVER log Apprise URLs.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
 use tokio::sync::Semaphore;
@@ -30,23 +31,39 @@ use crate::db::DbPool;
 use crate::notifications::apprise::{AppriseClient, AppriseError, NotifyType};
 
 const CLAIM_LIMIT: i64 = 50;
+const SLOW_DB_MS: u128 = 500;
 
 /// Run a blocking read-only DB operation on a pooled connection.
 ///
 /// Centralizes the `Arc::clone` + `spawn_blocking` + `pool.get()` boilerplate
 /// for operations that do not need a transaction (single reads or single
 /// auto-committed writes).
-async fn db_read<F, T>(pool: &Arc<DbPool>, f: F) -> Result<T>
+async fn db_read<F, T>(pool: &Arc<DbPool>, op: &'static str, f: F) -> Result<T>
 where
     F: FnOnce(&rusqlite::Connection) -> Result<T> + Send + 'static,
     T: Send + 'static,
 {
     let pool = Arc::clone(pool);
-    tokio::task::spawn_blocking(move || -> Result<T> {
+    let exec_start = Instant::now();
+    let join_result = tokio::task::spawn_blocking(move || -> Result<T> {
         let conn = pool.get()?;
         f(&conn)
     })
-    .await?
+    .await;
+    let exec_ms = exec_start.elapsed().as_millis();
+    let result = join_result.map_err(|e| anyhow::anyhow!("db task join error: {e}"))?;
+    if exec_ms > SLOW_DB_MS {
+        match &result {
+            Ok(_) => tracing::warn!(op, exec_ms, "db op ok"),
+            Err(e) => tracing::warn!(op, exec_ms, error = %e, "db op err"),
+        }
+    } else {
+        match &result {
+            Ok(_) => tracing::debug!(op, exec_ms, "db op ok"),
+            Err(e) => tracing::debug!(op, exec_ms, error = %e, "db op err"),
+        }
+    }
+    result
 }
 
 /// Run a blocking DB operation inside an explicit transaction.
@@ -54,19 +71,34 @@ where
 /// Centralizes the `Arc::clone` + `spawn_blocking` + `pool.get()` +
 /// `conn.transaction()` + `tx.commit()` boilerplate for multi-statement
 /// writes that must be atomic.
-async fn db_tx<F>(pool: &Arc<DbPool>, f: F) -> Result<()>
+async fn db_tx<F>(pool: &Arc<DbPool>, op: &'static str, f: F) -> Result<()>
 where
     F: FnOnce(&rusqlite::Transaction<'_>) -> Result<()> + Send + 'static,
 {
     let pool = Arc::clone(pool);
-    tokio::task::spawn_blocking(move || -> Result<()> {
+    let exec_start = Instant::now();
+    let join_result = tokio::task::spawn_blocking(move || -> Result<()> {
         let mut conn = pool.get()?;
         let tx = conn.transaction()?;
         f(&tx)?;
         tx.commit()?;
         Ok(())
     })
-    .await?
+    .await;
+    let exec_ms = exec_start.elapsed().as_millis();
+    let result = join_result.map_err(|e| anyhow::anyhow!("db task join error: {e}"))?;
+    if exec_ms > SLOW_DB_MS {
+        match &result {
+            Ok(_) => tracing::warn!(op, exec_ms, "db op ok"),
+            Err(e) => tracing::warn!(op, exec_ms, error = %e, "db op err"),
+        }
+    } else {
+        match &result {
+            Ok(_) => tracing::debug!(op, exec_ms, "db op ok"),
+            Err(e) => tracing::debug!(op, exec_ms, error = %e, "db op err"),
+        }
+    }
+    result
 }
 
 /// Run one dispatcher cycle.
@@ -77,7 +109,7 @@ pub(crate) async fn run_dispatch_cycle(
     cfg: &NotificationsConfig,
 ) -> Result<u64> {
     // Claim pending rows (read-only, no permit needed)
-    let rows = db_read(&pool, |conn| {
+    let rows = db_read(&pool, "notif.claim_pending", |conn| {
         outbox_claim_pending(conn, CLAIM_LIMIT).map_err(anyhow::Error::from)
     })
     .await?;
@@ -100,7 +132,7 @@ pub(crate) async fn run_dispatch_cycle(
             let hostname = row.hostname.clone();
             let dedup_key = row.dedup_key.clone();
             let dedup_secs = cfg.dedup_window_secs;
-            db_read(&pool, move |conn| {
+            db_read(&pool, "notif.dedup_check", move |conn| {
                 firings_recent_dedup_check(conn, &rule_id, &hostname, &dedup_key, dedup_secs)
                     .map_err(anyhow::Error::from)
             })
@@ -109,7 +141,7 @@ pub(crate) async fn run_dispatch_cycle(
 
         if is_dedup {
             let row_id = row.id;
-            db_read(&pool, move |conn| {
+            db_read(&pool, "notif.mark_dropped", move |conn| {
                 outbox_mark_dropped(conn, row_id, "dedup_suppressed")?;
                 Ok(())
             })
@@ -129,7 +161,7 @@ pub(crate) async fn run_dispatch_cycle(
             if let Some(hash) = row.dedup_key.strip_prefix("error_sig:") {
                 let hash_owned = hash.to_string();
                 let normalizer_version = crate::app::error_detection::NORMALIZER_VERSION;
-                let is_acked = db_read(&pool, move |conn| {
+                let is_acked = db_read(&pool, "notif.sig_acked_check", move |conn| {
                     is_signature_acked(conn, &hash_owned, normalizer_version)
                         .map_err(anyhow::Error::from)
                 })
@@ -137,7 +169,7 @@ pub(crate) async fn run_dispatch_cycle(
 
                 if is_acked {
                     let row_id = row.id;
-                    db_read(&pool, move |conn| {
+                    db_read(&pool, "notif.mark_dropped", move |conn| {
                         outbox_mark_dropped(conn, row_id, "error_signature_acked")?;
                         Ok(())
                     })
@@ -180,7 +212,7 @@ pub(crate) async fn run_dispatch_cycle(
                 break;
             };
             let row_id = row.id;
-            db_read(&pool, move |conn| {
+            db_read(&pool, "notif.mark_dropped", move |conn| {
                 outbox_mark_dropped(conn, row_id, "no_apprise_urls")?;
                 Ok(())
             })
@@ -221,7 +253,7 @@ pub(crate) async fn run_dispatch_cycle(
                     hostname.clone(),
                     dedup_key.clone(),
                 );
-                db_tx(&pool, move |tx| {
+                db_tx(&pool, "notif.mark_sent", move |tx| {
                     outbox_mark_sent(tx, row_id, Some(sc))?;
                     firings_insert(
                         tx,
@@ -256,7 +288,7 @@ pub(crate) async fn run_dispatch_cycle(
                     hostname.clone(),
                     dedup_key.clone(),
                 );
-                db_tx(&pool, move |tx| {
+                db_tx(&pool, "notif.mark_dead", move |tx| {
                     outbox_mark_dead(tx, row_id, Some(code as i64), &error_msg)?;
                     firings_insert(
                         tx,
@@ -298,7 +330,7 @@ pub(crate) async fn run_dispatch_cycle(
                         hostname.clone(),
                         dedup_key.clone(),
                     );
-                    db_tx(&pool, move |tx| {
+                    db_tx(&pool, "notif.mark_dead", move |tx| {
                         outbox_mark_dead(tx, row_id, None, &dead_msg)?;
                         firings_insert(
                             tx,
@@ -329,7 +361,7 @@ pub(crate) async fn run_dispatch_cycle(
                     let next_at = backoff_next_attempt_at(attempt_count);
                     let next_at_log = next_at.clone();
                     let err_clone = error_msg.clone();
-                    db_read(&pool, move |conn| {
+                    db_read(&pool, "notif.schedule_retry", move |conn| {
                         outbox_schedule_retry(conn, row_id, &next_at, &err_clone, None)?;
                         Ok(())
                     })

--- a/src/notifications/evaluator.rs
+++ b/src/notifications/evaluator.rs
@@ -7,9 +7,15 @@
 //! MUST NOT be imported from src/syslog/, src/ingest.rs, or src/syslog/writer.rs.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
 use tokio::sync::Semaphore;
+
+// Phase 1 scans up to 50,000 rows in one blocking call — allow 10s before warning.
+const SLOW_EVAL_SCAN_MS: u128 = 10_000;
+// Phase 2 inserts are bounded by matched rules (typically single-digit rows).
+const SLOW_DB_MS: u128 = 500;
 
 use crate::config::NotificationsConfig;
 use crate::db::DbPool;
@@ -39,7 +45,8 @@ pub(crate) async fn run_evaluation_cycle(
     const BATCH_SIZE: u64 = 1_000;
     const MAX_ROWS: u64 = 50_000;
     let pool_r = Arc::clone(&pool);
-    let all_params = tokio::task::spawn_blocking(
+    let exec_start = Instant::now();
+    let phase1_result = tokio::task::spawn_blocking(
         move || -> Result<Vec<crate::db::notifications::OutboxInsertParams>> {
             let conn = pool_r.get()?;
 
@@ -71,7 +78,25 @@ pub(crate) async fn run_evaluation_cycle(
             Ok(out)
         },
     )
-    .await??;
+    .await;
+    let exec_ms = exec_start.elapsed().as_millis();
+    let phase1_inner = phase1_result.map_err(|e| anyhow::anyhow!("db task join error: {e}"))?;
+    if exec_ms > SLOW_EVAL_SCAN_MS {
+        match &phase1_inner {
+            Ok(_) => tracing::warn!(op = "notif.eval_phase1_scan", exec_ms, "db op ok"),
+            Err(e) => {
+                tracing::warn!(op = "notif.eval_phase1_scan", exec_ms, error = %e, "db op err")
+            }
+        }
+    } else {
+        match &phase1_inner {
+            Ok(_) => tracing::debug!(op = "notif.eval_phase1_scan", exec_ms, "db op ok"),
+            Err(e) => {
+                tracing::debug!(op = "notif.eval_phase1_scan", exec_ms, error = %e, "db op err")
+            }
+        }
+    }
+    let all_params = phase1_inner?;
 
     if all_params.is_empty() {
         return Ok(0);
@@ -84,7 +109,8 @@ pub(crate) async fn run_evaluation_cycle(
     };
 
     let pool_w = Arc::clone(&pool);
-    let count = tokio::task::spawn_blocking(move || -> Result<u64> {
+    let exec_start = Instant::now();
+    let phase2_result = tokio::task::spawn_blocking(move || -> Result<u64> {
         let _permit = _permit; // keep permit alive for the duration of the write block
         let conn = pool_w.get()?;
         let mut total = 0u64;
@@ -106,7 +132,25 @@ pub(crate) async fn run_evaluation_cycle(
         }
         Ok(total)
     })
-    .await??;
+    .await;
+    let exec_ms = exec_start.elapsed().as_millis();
+    let phase2_inner = phase2_result.map_err(|e| anyhow::anyhow!("db task join error: {e}"))?;
+    if exec_ms > SLOW_DB_MS {
+        match &phase2_inner {
+            Ok(_) => tracing::warn!(op = "notif.eval_phase2_insert", exec_ms, "db op ok"),
+            Err(e) => {
+                tracing::warn!(op = "notif.eval_phase2_insert", exec_ms, error = %e, "db op err")
+            }
+        }
+    } else {
+        match &phase2_inner {
+            Ok(_) => tracing::debug!(op = "notif.eval_phase2_insert", exec_ms, "db op ok"),
+            Err(e) => {
+                tracing::debug!(op = "notif.eval_phase2_insert", exec_ms, error = %e, "db op err")
+            }
+        }
+    }
+    let count = phase2_inner?;
 
     Ok(count)
 }


### PR DESCRIPTION
## Summary

- Adds `op: &'static str` parameter to `SyslogService::run_db` and instruments it with two `tracing::debug!` timing probes: `permit_ms` (semaphore-wait contention signal) and `exec_ms` (query execution speed signal)
- Labels all ~60 `run_db` callsites with descriptive op names (e.g. `"ai_correlate.anchors"`, `"list_ai_projects"`, `"usage_blocks"`) so every DB operation is identifiable in trace output
- Adds `tracing-test = "0.2"` dev dependency and a `#[traced_test]` verification test confirming the timing fields are actually emitted
- Removes the now-redundant `elapsed_ms` field from MCP-layer tracing in `rmcp_server.rs` — DB latency is now covered at the source

Closes syslog-mcp-dkmq

## Motivation

`syslog ai projects` and `syslog ai blocks` were taking ~3 minutes with no visibility into which DB operation was the bottleneck. This gives every action a named, structured trace event with permit-wait and execution duration so slow queries can be identified without guesswork.

## Changes

| File | Change |
|------|--------|
| `src/app/service.rs` | `run_db` gains `op` param + two `Instant` probes; ~60 callsites labeled |
| `src/app/service_tests.rs` | `run_db_emits_timing_trace_on_success` traced test |
| `Cargo.toml` | `tracing-test = "0.2"` dev dep |
| `src/mcp/rmcp_server.rs` | Removed `elapsed_ms` and `Instant` import |

## Test plan

- [ ] `cargo test` — 1176 passed, 1 ignored (pre-existing)
- [ ] `RUST_LOG=debug syslog ai projects` — confirm `db op ok op="list_ai_projects" permit_ms=... exec_ms=...` appears in trace output
- [ ] `RUST_LOG=debug syslog ai blocks` — same, with `op="usage_blocks"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-action DB timing to `SyslogService::run_db` with op labels, WARN-on-slow logging, and early-return coverage; extends the same instrumentation to notifications and heartbeat to surface DB bottlenecks fast. Unifies log messages and bumps to 0.36.1 (Linear: syslog-mcp-dkmq, syslog-mcp-8fih).

- **New Features**
  - `run_db(op, f)` emits `permit_ms` and `exec_ms`; warns on slow ops (>500ms) and early returns (acquire timeout, semaphore closed, task cancelled/panic). Unified logs to "db op ok"/"db op err"; removed `elapsed_ms` from `rmcp_server.rs`.
  - Labeled ~60 callsites (e.g. "incident.search"). Added timing to notifications (`notif.*`) and heartbeat (`heartbeat.insert`) with thresholds: 500ms for DB ops, 10s for eval phase-1 scan, 5s for daily digest write.
  - Added `tracing-test` and tests covering ok, slow, semaphore-closed, and slow+error paths.

- **Bug Fixes**
  - `correlate_state.resolve_host` now propagates DB errors instead of masking them as `not_found`.
  - Join error logging distinguishes task cancellation from panic.

<sup>Written for commit 06ab9ba15ca3129389b9e117ef22484e526ec91e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a test-only tracing dependency to improve test diagnostics.

* **Tests**
  * Added tests to verify DB operation timing and slow/error logging behavior.

* **Observability**
  * DB operations now emit structured timing metrics and raise slow-query logs to warn when exceeding the slow threshold.
  * Tool execution logs no longer include elapsed-time fields.

* **Fixes**
  * Corrected a DB error path so certain DB failures are no longer misreported as NotFound.

* **Release**
  * Bumped package and server versions to 0.36.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->