### PR TITLE
CLI perf & robustness follow-ups: timeline default centralization, backup hardening, signature query, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,17 @@ tx.commit().await?;
 
 ### Testing
 
+**Prerequisite:** `just test` uses [cargo-nextest](https://nexte.st), which is **not**
+bundled with the Rust toolchain. Fresh checkouts must install it once, or `just test`
+fails with `error: no such subcommand: nextest`:
+
 ```bash
-just test               # Run all unit and integration tests
+cargo install cargo-nextest --locked
+```
+
+```bash
+just test               # Run all unit and integration tests (requires cargo-nextest)
+just test-doc           # Run doc tests (nextest does not execute these)
 just test-live          # Live smoke test against a running server (tests/test_live.sh)
 bash scripts/smoke-test.sh  # Lower-level smoke harness (used by CI; superset of test-live)
 ```

--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,12 @@
+# `set dotenv-load` is GLOBAL (bead i5lx): every recipe below runs with the
+# variables from `.env` injected into its environment — including
+# SYSLOG_API_TOKEN, NO_AUTH, and any OAuth secrets. Two consequences to keep in
+# mind:
+#   1. A local `.env` override silently changes what a recipe tests vs. CI.
+#   2. Test recipes that must exercise the no-auth path explicitly strip the
+#      auth vars (`env -u SYSLOG_API_TOKEN -u NO_AUTH ...`); any new test or
+#      release recipe that runs the suite MUST do the same, or it will test a
+#      different environment than `just test`.
 set dotenv-load
 
 dev:
@@ -178,7 +187,12 @@ publish bump="patch":
     scripts/bump-version.sh "{{bump}}"
     NEW=$(grep -m1 "^version" Cargo.toml | sed "s/.*\"\(.*\)\".*/\1/")
     scripts/check-version-sync.sh --require-changelog
-    cargo test
+    # Mirror `just test` + `just test-doc` exactly (bead ok8c): strip the auth
+    # vars that `set dotenv-load` injects so the release gate exercises the same
+    # (no-auth) environment as `just test`, and keep running doc tests — which
+    # bare `cargo nextest run` does NOT execute.
+    env -u SYSLOG_API_TOKEN -u NO_AUTH cargo nextest run
+    cargo test --doc
     cargo clippy -- -D warnings
     git add -A
     git commit -m "release: v${NEW}"

--- a/Justfile
+++ b/Justfile
@@ -187,13 +187,13 @@ publish bump="patch":
     scripts/bump-version.sh "{{bump}}"
     NEW=$(grep -m1 "^version" Cargo.toml | sed "s/.*\"\(.*\)\".*/\1/")
     scripts/check-version-sync.sh --require-changelog
-    # Mirror `just test` + `just test-doc` exactly (bead ok8c): strip the auth
-    # vars that `set dotenv-load` injects so the release gate exercises the same
-    # (no-auth) environment as `just test`, and keep running doc tests — which
-    # bare `cargo nextest run` does NOT execute.
-    env -u SYSLOG_API_TOKEN -u NO_AUTH cargo nextest run
-    cargo test --doc
-    cargo clippy -- -D warnings
+    # Reuse the canonical gates (bead ok8c) so the release gate can't drift from
+    # them: `test` strips the auth vars `set dotenv-load` injects and runs
+    # nextest, `test-doc` covers doc tests (nextest skips those), `lint` is
+    # clippy -D warnings.
+    just test
+    just test-doc
+    just lint
     git add -A
     git commit -m "release: v${NEW}"
     git tag "v${NEW}"

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,7 +8,6 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::Semaphore;
@@ -500,28 +499,16 @@ async fn timeline(
     State(state): State<ApiState>,
     Query(query): Query<TimelineQuery>,
 ) -> impl IntoResponse {
-    // Default lookback window varies by bucket — wider buckets need longer windows.
-    // Only apply when no time range is given (prevents full table scans).
-    // If `to` is already set, skip the default so we don't create an impossible range.
-    let from = query.from.or_else(|| {
-        if query.to.is_none() {
-            let days = crate::db::Bucket::parse(query.bucket.as_deref().unwrap_or("hour"))
-                .map(|b| b.default_lookback_days())
-                .unwrap_or(30);
-            Utc::now()
-                .checked_sub_signed(chrono::Duration::days(days))
-                .map(|dt| dt.to_rfc3339())
-        } else {
-            None
-        }
-    });
+    // Default lookback is centralized in `SyslogService::timeline` (bead dyqw):
+    // it applies a bucket-sized window only when neither `from` nor `to` is set,
+    // preventing full table scans without recreating the logic per transport.
     respond(
         state
             .service
             .timeline(TimelineRequest {
                 bucket: query.bucket,
                 group_by: query.group_by,
-                from,
+                from: query.from,
                 to: query.to,
                 hostname: query.hostname,
                 app_name: query.app_name,
@@ -1497,10 +1484,17 @@ async fn db_backup(
         }
     };
 
+    // Sanitize before logging (bead xknb.4): `output_path` is attacker-influenced
+    // input; strip CR/LF/ESC so it can't inject newlines or ANSI escapes into log
+    // aggregators or terminals tailing the audit stream.
+    let logged_output_path = req
+        .output_path
+        .as_deref()
+        .map(|p| p.replace(['\n', '\r', '\x1b'], "?"));
     tracing::warn!(
         caller_ip = %peer,
         action = "db_backup",
-        output_path = ?req.output_path,
+        output_path = ?logged_output_path,
         "admin: db_backup invoked"
     );
 

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1569,7 +1569,20 @@ impl SyslogService {
                 ))
             })?,
         };
-        let from = parse_optional_timestamp(req.from.as_deref(), "from")?;
+        // Centralized default lookback (bead dyqw): apply the bucket-sized window
+        // ONLY when neither `from` nor `to` is supplied. This prevents the full
+        // table scan on an unbounded query while preserving the zl9y guard — if
+        // `to` is set but `from` is omitted we must NOT inject a default `from`,
+        // or we'd create an impossible range. All transport call sites (api.rs,
+        // mcp/tools.rs, cli/dispatch_surface.rs) now pass `from`/`to` through
+        // verbatim, so this is the single source of truth.
+        let from_raw = match (req.from, req.to.is_some()) {
+            (None, false) => chrono::Utc::now()
+                .checked_sub_signed(chrono::Duration::days(bucket.default_lookback_days()))
+                .map(|dt| dt.to_rfc3339()),
+            (other, _) => other,
+        };
+        let from = parse_optional_timestamp(from_raw.as_deref(), "from")?;
         let to = parse_optional_timestamp(req.to.as_deref(), "to")?;
         let severity_in = match req.severity_min.as_deref() {
             Some(min) => Some(severity_at_or_above(min)?),

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -548,3 +548,68 @@ async fn ai_service_methods_return_seeded_data() {
         .unwrap();
     assert_eq!(tools.tools[0].tool, "claude");
 }
+
+#[tokio::test]
+async fn timeline_applies_default_lookback_only_when_from_and_to_both_absent() {
+    // Bead dyqw: the bucket-sized default lookback was centralized into
+    // `SyslogService::timeline`. It must apply ONLY when both `from` and `to`
+    // are absent (preventing an unbounded full-table scan), and must be SKIPPED
+    // whenever `to` is supplied — preserving the zl9y guard against injecting a
+    // `from` that would create an impossible range.
+    let (service, pool, _dir) = test_service();
+    let now = chrono::Utc::now();
+    let fmt = |dt: chrono::DateTime<chrono::Utc>| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+    let recent = fmt(now - chrono::Duration::days(2));
+    let old = fmt(now - chrono::Duration::days(400));
+    insert_logs_batch(
+        &pool,
+        &[
+            entry(&recent, "host-a", "info", "recent", "10.0.0.1:514"),
+            entry(&old, "host-a", "info", "old", "10.0.0.1:514"),
+        ],
+    )
+    .unwrap();
+
+    // Both absent → day bucket default (30 days) excludes the 400-day-old log.
+    let resp = service
+        .timeline(TimelineRequest {
+            bucket: Some("day".into()),
+            group_by: None,
+            from: None,
+            to: None,
+            hostname: None,
+            app_name: None,
+            severity_min: None,
+        })
+        .await
+        .unwrap();
+    let total: i64 = resp.points.iter().map(|p| p.count).sum();
+    assert_eq!(
+        total, 1,
+        "default 30-day window must exclude the 400-day-old log"
+    );
+
+    // `to` set (1 day ago), `from` absent → the default MUST be skipped. The
+    // 400-day-old log predates any 30-day default window; it is counted only if
+    // no default `from` was injected. If the guard regressed (default applied
+    // whenever from is None), the range would be [now-30d, now-1d] and the old
+    // log would drop, yielding 1 instead of 2.
+    let to = fmt(now - chrono::Duration::days(1));
+    let resp2 = service
+        .timeline(TimelineRequest {
+            bucket: Some("day".into()),
+            group_by: None,
+            from: None,
+            to: Some(to),
+            hostname: None,
+            app_name: None,
+            severity_min: None,
+        })
+        .await
+        .unwrap();
+    let total2: i64 = resp2.points.iter().map(|p| p.count).sum();
+    assert_eq!(
+        total2, 2,
+        "with `to` set and `from` omitted, the default must be skipped so both logs (<= to) are counted"
+    );
+}

--- a/src/cli/dispatch_db.rs
+++ b/src/cli/dispatch_db.rs
@@ -156,6 +156,22 @@ pub(crate) async fn run_db_backup(mode: &CliMode, args: DbBackupArgs) -> Result<
             // Note: `output_path` is a **server-side** path (e.g.
             // `/data/backup.db` inside the container, visible on the host via
             // the Docker bind-mount). Pass `None` to let the server choose.
+            //
+            // Warn the operator (bead xknb.5): in HTTP mode `--output` is
+            // resolved by the *server* process, not the local shell. A path
+            // like `/tmp/backup.db` lands inside the container, not on the host.
+            if let Some(path) = args.output.as_deref() {
+                // Sanitize before writing to the terminal (same hardening as the
+                // xknb.4 audit log): `--output` is operator-supplied and may carry
+                // CR/LF/ESC; strip them so a crafted path can't inject newlines or
+                // ANSI escapes into stderr.
+                let path = path.replace(['\n', '\r', '\x1b'], "?");
+                eprintln!(
+                    "warning: --output '{path}' is a SERVER-SIDE path resolved inside \
+                     the server process (e.g. the container), not your local shell. \
+                     For a host-visible file use a path under the server's /data mount."
+                );
+            }
             let req = DbBackupRequest {
                 output_path: args.output.clone(),
             };

--- a/src/cli/dispatch_surface.rs
+++ b/src/cli/dispatch_surface.rs
@@ -4,7 +4,6 @@ use super::output_common::print_json;
 use super::sparkline::sparkline;
 
 use anyhow::{bail, Result};
-use chrono::Utc;
 use syslog_mcp::app::{
     AckErrorRequest, IngestRateRequest, ListSourceIpsRequest, PatternsRequest, TimelineRequest,
     UnackErrorRequest, UnaddressedErrorsRequest,
@@ -17,23 +16,6 @@ use super::{
 
 // ─── Surface parity (source-ips, timeline, patterns, ingest-rate, sig, notify) ─
 
-/// Returns the default lookback window (days) for a given bucket string.
-/// Values mirror `Bucket::default_lookback_days` in `src/db/analytics.rs` —
-/// keep in sync if bucket variants change.
-fn timeline_default_days(bucket: &str) -> i64 {
-    // `db` is pub(crate) in the library so Bucket is not reachable from this
-    // binary module. A thin public bridge function (`Bucket::default_lookback_days_str`)
-    // could be added to the app layer in a follow-up (bead llto.2).
-    match bucket {
-        "minute" | "min" | "m" => 1,
-        "hour" | "h" => 7,
-        "day" | "d" => 30,
-        "week" | "w" => 180,
-        "month" => 730,
-        _ => 30,
-    }
-}
-
 impl SourceIpsArgs {
     pub(crate) fn into_request(self) -> ListSourceIpsRequest {
         ListSourceIpsRequest {
@@ -45,23 +27,14 @@ impl SourceIpsArgs {
 
 impl TimelineArgs {
     pub(crate) fn into_request(self) -> TimelineRequest {
-        // Default lookback window varies by bucket — wider buckets need longer windows.
-        // Only apply when no time range is given (prevents full table scans).
-        // If `to` is already set, skip the default so we don't create an impossible range.
-        let from = self.from.or_else(|| {
-            if self.to.is_none() {
-                let days = timeline_default_days(self.bucket.as_deref().unwrap_or("hour"));
-                Utc::now()
-                    .checked_sub_signed(chrono::Duration::days(days))
-                    .map(|dt| dt.to_rfc3339())
-            } else {
-                None
-            }
-        });
+        // Default lookback is centralized in `SyslogService::timeline` (bead dyqw):
+        // it applies a bucket-sized window only when neither `from` nor `to` is set.
+        // Both CLI modes reach that service (local directly, HTTP via the server),
+        // so we pass `from`/`to` through verbatim — no per-binary duplication.
         TimelineRequest {
             bucket: self.bucket,
             group_by: self.group_by,
-            from,
+            from: self.from,
             to: self.to,
             hostname: self.hostname,
             app_name: self.app_name,

--- a/src/cli/dispatch_tests.rs
+++ b/src/cli/dispatch_tests.rs
@@ -1346,10 +1346,14 @@ fn source_ips_args_into_request_default() {
 }
 
 #[test]
-fn timeline_args_into_request_snapshot() {
-    // When no from is specified, the default 30-day window should be applied.
+fn timeline_args_into_request_passes_time_range_through() {
+    // The default-lookback injection now lives in `SyslogService::timeline`
+    // (bead dyqw) so the service is the single source of truth. `into_request`
+    // must therefore pass `from`/`to` through verbatim and NOT inject a default
+    // — verified end-to-end by the service-layer test
+    // `timeline_applies_default_lookback_only_when_from_and_to_both_absent`.
     let args = TimelineArgs {
-        bucket: Some("1h".to_string()),
+        bucket: Some("hour".to_string()),
         group_by: None,
         from: None,
         to: None,
@@ -1359,20 +1363,14 @@ fn timeline_args_into_request_snapshot() {
         json: false,
     };
     let req = args.into_request();
-    assert_eq!(req.bucket.as_deref(), Some("1h"));
+    assert_eq!(req.bucket.as_deref(), Some("hour"));
     assert!(
-        req.from.is_some(),
-        "from should default to last 30 days when not specified"
+        req.from.is_none(),
+        "into_request must not inject a default `from`; the service applies it"
     );
-    // Verify the default is a valid RFC3339 timestamp roughly 30 days ago
-    let from_str = req.from.as_deref().unwrap();
-    let parsed = chrono::DateTime::parse_from_rfc3339(from_str)
-        .expect("default from should be valid RFC3339");
-    let now = chrono::Utc::now();
-    let diff = now.signed_duration_since(parsed.with_timezone(&chrono::Utc));
     assert!(
-        diff.num_days() >= 29 && diff.num_days() <= 31,
-        "default from should be ~30 days ago, got {diff:?}"
+        req.to.is_none(),
+        "into_request must not inject a default `to`"
     );
 }
 

--- a/src/db/analytics.rs
+++ b/src/db/analytics.rs
@@ -538,7 +538,19 @@ impl Bucket {
         }
     }
 
-    pub fn strftime_format(self) -> &'static str {
+    /// SQLite `strftime` pattern for grouping timestamps into this bucket.
+    ///
+    /// `Week` uses `%W` (Monday-based week-of-year, 00–53). Days in early
+    /// January that fall *before* the year's first Monday land in week `00`,
+    /// producing labels like `2026-W00` (bead llto.2). Bucket tests deliberately
+    /// avoid that range. We do NOT use ISO-8601 week-numbering (`%G-%V`, which
+    /// would never emit week 00) because the SQLite version bundled here does
+    /// not support the `%G`/`%V` specifiers.
+    ///
+    /// `pub(crate)` (bead llto.3): the `db` module is `pub(crate)`, so this is
+    /// only reachable within the crate — widening past crate scope serves no
+    /// caller.
+    pub(crate) fn strftime_format(self) -> &'static str {
         match self {
             Self::Minute => "%Y-%m-%dT%H:%M:00Z",
             Self::Hour => "%Y-%m-%dT%H:00:00Z",

--- a/src/db/error_signatures.rs
+++ b/src/db/error_signatures.rs
@@ -264,6 +264,12 @@ pub(crate) fn read_signature_by_hash(
         .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
         .unwrap_or_default();
 
+    // The `USING (...)` join form is load-bearing for performance (bead q2e8):
+    // it lets SQLite push the outer `s.signature_hash = ?1` equality down into
+    // the materialized aggregate subquery, so only this hash's windows are summed
+    // (PK index seek, sub-ms). Rewriting it to an explicit `ON w.x = s.x` defeats
+    // that pushdown and degrades to a full GROUP BY over error_signature_windows
+    // (~100x slower at scale). Keep the `USING` form.
     let mut stmt = conn.prepare(
         "SELECT
              s.signature_hash,
@@ -276,15 +282,15 @@ pub(crate) fn read_signature_by_hash(
              s.first_seen_at,
              s.last_seen_at,
              s.total_count,
-             COALESCE((
-                 SELECT SUM(w.count_in_window)
-                 FROM error_signature_windows w
-                 WHERE w.signature_hash = s.signature_hash
-                   AND w.normalizer_version = s.normalizer_version
-                   AND w.window_end >= ?3
-             ), 0) AS count_last_1h,
+             COALESCE(w.total_1h, 0) AS count_last_1h,
              s.acknowledged_at
          FROM error_signatures s
+         LEFT JOIN (
+             SELECT signature_hash, normalizer_version, SUM(count_in_window) AS total_1h
+             FROM error_signature_windows
+             WHERE window_end >= ?3
+             GROUP BY signature_hash, normalizer_version
+         ) w USING (signature_hash, normalizer_version)
          WHERE s.signature_hash = ?1 AND s.normalizer_version = ?2
          LIMIT 1",
     )?;

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -142,11 +142,11 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 },
                 "from": {
                     "type": "string",
-                    "description": "For action=search, filter, sessions, search_sessions, abuse, abuse_incidents, abuse_investigate, ai_correlate, usage_blocks, list_ai_tools, list_ai_projects, errors, timeline, patterns, apps, similar_incidents, or ask_history: start of time range as ISO 8601/RFC3339. Required for incident_context. For action=timeline: defaults to last 30 days when omitted (prevents full-history scan). Strongly recommended for patterns — omitting from/to causes a full-history scan."
+                    "description": "For action=search, filter, sessions, search_sessions, abuse, abuse_incidents, abuse_investigate, ai_correlate, usage_blocks, list_ai_tools, list_ai_projects, errors, timeline, patterns, apps, similar_incidents, or ask_history: start of time range as ISO 8601/RFC3339. Required for incident_context. For action=timeline: when both from and to are omitted, a bucket-sized default lookback window applies (≈7 days for hour, 30 for day, longer for week/month) — no full-history scan. Strongly recommended for patterns — omitting from/to causes a full-history scan."
                 },
                 "to": {
                     "type": "string",
-                    "description": "For action=search, filter, sessions, search_sessions, abuse, abuse_incidents, abuse_investigate, ai_correlate, usage_blocks, list_ai_tools, list_ai_projects, errors, timeline, patterns, apps, similar_incidents, or ask_history: end of time range as ISO 8601/RFC3339. Required for incident_context. Strongly recommended for timeline and patterns — omitting from/to causes a full-history scan."
+                    "description": "For action=search, filter, sessions, search_sessions, abuse, abuse_incidents, abuse_investigate, ai_correlate, usage_blocks, list_ai_tools, list_ai_projects, errors, timeline, patterns, apps, similar_incidents, or ask_history: end of time range as ISO 8601/RFC3339. Required for incident_context. For action=timeline: a bucket-sized default lookback bounds the query when from/to are omitted (no full-history scan). Strongly recommended for patterns — omitting from/to causes a full-history scan."
                 },
                 "limit": {
                     "type": "integer",
@@ -179,8 +179,8 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 },
                 "bucket": {
                     "type": "string",
-                    "enum": ["minute", "min", "m", "hour", "h", "day", "d"],
-                    "description": "For action=timeline: time bucket size."
+                    "enum": ["minute", "min", "m", "hour", "h", "day", "d", "week", "w", "month"],
+                    "description": "For action=timeline: time bucket size (minute, hour, day, week, month)."
                 },
                 "scan_limit": {
                     "type": "integer",

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -442,28 +442,15 @@ async fn tool_compose_doctor(args: Value) -> anyhow::Result<Value> {
 }
 
 async fn tool_timeline(state: &AppState, args: Value) -> anyhow::Result<Value> {
-    // Default lookback window varies by bucket — wider buckets need longer windows.
-    // Only apply when no time range is given (prevents full table scans).
-    // If `to` is already set, skip the default so we don't create an impossible range.
-    let from = string_arg(&args, "from").or_else(|| {
-        if string_arg(&args, "to").is_none() {
-            let days =
-                crate::db::Bucket::parse(string_arg(&args, "bucket").as_deref().unwrap_or("hour"))
-                    .map(|b| b.default_lookback_days())
-                    .unwrap_or(30);
-            chrono::Utc::now()
-                .checked_sub_signed(chrono::Duration::days(days))
-                .map(|dt| dt.to_rfc3339())
-        } else {
-            None
-        }
-    });
+    // Default lookback is centralized in `SyslogService::timeline` (bead dyqw):
+    // it applies a bucket-sized window only when neither `from` nor `to` is set,
+    // preventing full table scans without recreating the logic per transport.
     let response = state
         .service
         .timeline(TimelineRequest {
             bucket: string_arg(&args, "bucket"),
             group_by: string_arg(&args, "group_by"),
-            from,
+            from: string_arg(&args, "from"),
             to: string_arg(&args, "to"),
             hostname: string_arg(&args, "hostname"),
             app_name: string_arg(&args, "app_name"),


### PR DESCRIPTION
Batch of small follow-up fixes (10 beads) surfaced during review of recent CLI/perf work. Implemented inline, multi-agent reviewed, all green.

## Changes

**Refactor / perf**
- **dyqw** — Centralize the timeline default-lookback window into `SyslogService::timeline` (was triplicated across the api.rs handler, `mcp/tools.rs`, and `cli/dispatch_surface.rs`). The default now applies **only when both `from` and `to` are absent**, preserving the zl9y guard against creating an impossible range when only `to` is set. New transports can no longer silently reintroduce a full-table scan. Invalid bucket strings now return `InvalidInput` instead of a silent 30-day fallback. Test relocated to the service layer, covering both the apply path and the skip path.
- **q2e8** — `read_signature_by_hash`: correlated `SUM()` subquery → LEFT JOIN over a pre-aggregated derived table, matching `read_unaddressed`. Added a comment pinning the `USING (...)` form as load-bearing (it enables SQLite's equality pushdown into the materialized aggregate — verified via EXPLAIN QUERY PLAN; an explicit `ON` form would degrade ~100x at scale).

**Security hardening**
- **xknb.4** — Sanitize `output_path` (strip CR/LF/ESC) before the `db_backup` audit `tracing::warn!`, preventing log/ANSI injection.
- **xknb.5** — Warn (on stderr, sanitized) that `--output` in `--http db backup` mode is a **server-side** path resolved inside the container, not the local shell.

**Schema / docs**
- **zl9y.2** — Correct the timeline `from`/`to` schema descriptions (they no longer cause a full-history scan), and add `week`/`w`/`month` to the `bucket` enum (`Bucket::parse` already accepts them) so MCP clients don't reject valid inputs.
- **llto.2 / llto.3** — Document the `strftime_format` week `%W`/`W00` edge case (and why ISO `%G-%V` isn't used: bundled SQLite lacks the specifiers); reduce visibility `pub` → `pub(crate)`.
- **9hti** — Document `cargo-nextest` as a dev prerequisite in CLAUDE.md.
- **i5lx / ok8c** — Document that `set dotenv-load` is global in the Justfile; the `publish` recipe now uses `env -u SYSLOG_API_TOKEN -u NO_AUTH cargo nextest run` + `cargo test --doc`, mirroring `just test` so the release gate isn't silently weaker (nextest skips doc tests).

## Not done (closed wont_fix)
- **ukpf** — "local backup bypasses MAINTENANCE_PERMIT". Investigated: the in-process `MAINTENANCE_PERMIT` semaphore cannot coordinate the stated cross-process race — `CliMode::Local` backup runs as a separate process (`docker exec` / host CLI) from the container's server. The only bypasser is `CliMode::Local`; no in-process caller invokes `db_backup`/`db_vacuum` outside the permit. SQLite's write lock + xknb's "database is locked" guidance already bound it. Closed with full reasoning on the bead.

## Verification
- `cargo nextest run` (env-stripped): **1197 passed, 1 skipped, 0 failed**
- `cargo clippy -- -D warnings`: clean
- `cargo test --doc`: clean
- 5-agent review (security / correctness / performance / simplicity / silent-failure); 3 introduced findings, all fixed in this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes timeline default-lookback logic in the service to prevent unbounded scans and removes per-transport copies. Also hardens backup logging/UX, speeds up the signature query, and aligns the release gate with the canonical test recipes.

- **Refactors**
  - Move the timeline default lookback into `SyslogService::timeline`. Apply it only when both `from` and `to` are missing; invalid buckets now return `InvalidInput`. API/CLI/MCP now pass times through as-is.
  - Speed up `read_signature_by_hash` via a `LEFT JOIN` over a pre-aggregated table; keep the `USING (...)` form to enable SQLite pushdown.

- **Bug Fixes**
  - Backup hardening: sanitize `output_path` before audit logging, and in HTTP mode warn that `--output` is a server-side path; sanitize stderr output.
  - Schemas/docs/build: fix timeline `from`/`to` descriptions; add `week`/`w`/`month` to the `bucket` enum; document `%W`/`W00` week behavior and make `Bucket::strftime_format` `pub(crate)`; add `cargo-nextest` as a prerequisite; `publish` now calls `just test`, `just test-doc`, and `just lint` (env-stripped) to match the standard gates and avoid drift.

<sup>Written for commit 30c4b1e40190b87c72bf295e8ee212cc6da10978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/syslog-mcp/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `week` and `month` timeline bucket options.

* **Bug Fixes**
  * Timeline queries no longer inject a default lookback when `to` is provided without `from`.

* **Improvements**
  * Centralized default time-window handling across API, CLI, and tools.
  * Backup/publish warnings now sanitize output paths and publish gate reuses canonical local checks.

* **Documentation**
  * Testing docs updated to require installing cargo-nextest and clarify test command behavior.

* **Tests**
  * Added a test verifying default-lookback applies only when both `from` and `to` are absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmagar/syslog-mcp/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->