### PR TITLE
feat(inventory): project homelab topology into graph

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Syslog management via MCP",
   "author": {
     "name": "jmagar"

--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,50 @@ CORTEX_DOCKER_INGEST_ENABLED=false
 # CORTEX_DOCKER_RECONNECT_INITIAL_MS=1000
 # CORTEX_DOCKER_RECONNECT_MAX_MS=30000
 
+# --- Homelab inventory / map ---
+
+# Private cache root; defaults to ~/.cortex/inventory for local runs.
+# CORTEX_INVENTORY_DIR=/home/cortex/.cortex/inventory
+
+# Local config artifact sources. Compose YAMLs and reverse-proxy confs are
+# copied into the private inventory cache after redaction.
+# CORTEX_INVENTORY_COMPOSE_PATHS=/opt/edge/compose.yaml,/opt/media/compose.yaml
+# CORTEX_INVENTORY_PROXY_PATHS=/opt/swag/nginx/proxy-confs
+
+# SSH remote collection. If CORTEX_INVENTORY_SSH_HOSTS is unset, concrete Host
+# aliases from CORTEX_INVENTORY_SSH_CONFIG are used.
+# CORTEX_INVENTORY_SSH_CONFIG=/home/cortex/.ssh/config
+# CORTEX_INVENTORY_SSH_HOSTS=host-a,host-b
+
+# Background refresh defaults to every 5 minutes. Local compose/proxy file
+# changes and remote Docker container events over SSH also trigger refreshes.
+# CORTEX_INVENTORY_REFRESH_INTERVAL_SECS=300
+# CORTEX_INVENTORY_WATCH_ENABLED=true
+# CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=true
+
+# Optional API collectors. Leave unset to skip that provider.
+# CORTEX_UNRAID_URL=https://unraid.example
+# CORTEX_UNRAID_API_KEY=
+# CORTEX_UNIFI_URL=https://unifi.example
+# CORTEX_UNIFI_API_KEY=
+# CORTEX_SONARR_URL=http://sonarr:8989
+# CORTEX_SONARR_API_KEY=
+# CORTEX_RADARR_URL=http://radarr:7878
+# CORTEX_RADARR_API_KEY=
+# CORTEX_PROWLARR_URL=http://prowlarr:9696
+# CORTEX_PROWLARR_API_KEY=
+# CORTEX_SABNZBD_URL=http://sabnzbd:8080
+# CORTEX_SABNZBD_API_KEY=
+# CORTEX_QBITTORRENT_URL=http://qbittorrent:8080
+# CORTEX_QBITTORRENT_USERNAME=
+# CORTEX_QBITTORRENT_PASSWORD=
+# CORTEX_PLEX_URL=http://plex:32400
+# CORTEX_PLEX_TOKEN=
+# CORTEX_TAUTULLI_URL=http://tautulli:8181
+# CORTEX_TAUTULLI_API_KEY=
+# CORTEX_OVERSEERR_URL=http://overseerr:5055
+# CORTEX_OVERSEERR_API_KEY=
+
 # --- Container ---
 
 # Container runtime user/group for bind-mounted data directories.

--- a/.env.example
+++ b/.env.example
@@ -121,10 +121,11 @@ CORTEX_DOCKER_INGEST_ENABLED=false
 # CORTEX_INVENTORY_SSH_HOSTS=host-a,host-b
 
 # Background refresh defaults to every 5 minutes. Local compose/proxy file
-# changes and remote Docker container events over SSH also trigger refreshes.
+# changes also trigger refreshes. Remote Docker event streams over SSH are
+# opt-in because they maintain one persistent SSH session per selected host.
 # CORTEX_INVENTORY_REFRESH_INTERVAL_SECS=300
 # CORTEX_INVENTORY_WATCH_ENABLED=true
-# CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=true
+# CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=false
 
 # Optional API collectors. Leave unset to skip that provider.
 # CORTEX_UNRAID_URL=https://unraid.example
@@ -140,8 +141,6 @@ CORTEX_DOCKER_INGEST_ENABLED=false
 # CORTEX_SABNZBD_URL=http://sabnzbd:8080
 # CORTEX_SABNZBD_API_KEY=
 # CORTEX_QBITTORRENT_URL=http://qbittorrent:8080
-# CORTEX_QBITTORRENT_USERNAME=
-# CORTEX_QBITTORRENT_PASSWORD=
 # CORTEX_PLEX_URL=http://plex:32400
 # CORTEX_PLEX_TOKEN=
 # CORTEX_TAUTULLI_URL=http://tautulli:8181

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-06-04
+
+### Fixed
+
+- Hardened inventory graph projection so inventory refreshes no longer mark the
+  full graph projection lifecycle as ready or overwrite log-derived entity
+  ownership metadata.
+- Scoped Compose project and Docker network graph keys by source host, avoided
+  ambiguous bare service-name links, and kept raw config/cache paths out of
+  graph labels, aliases, source ids, and evidence excerpts.
+- Made remote Docker event streams opt-in and serialized background inventory
+  projection through the maintenance limiter.
+
 ## [1.13.0] - 2026-06-04
 
 ### Added
@@ -15,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   evidence-backed topology nodes for Compose projects, reverse proxies, domains,
   networks, storage, and redacted config artifacts.
 - Added server-side inventory refresh triggers from local Compose/proxy config
-  file watchers and remote Docker `events` streams over SSH, while preserving
-  the 5-minute polling baseline.
+  file watchers, plus opt-in remote Docker `events` streams over SSH, while
+  preserving the 5-minute polling baseline.
 
 ### Changed
 
@@ -2023,7 +2036,11 @@ start and verify with `cortex --http db status`.
 
 ---
 
-[Unreleased]: https://github.com/jmagar/cortex/compare/v1.10.1...HEAD
+[Unreleased]: https://github.com/jmagar/cortex/compare/v1.13.1...HEAD
+[1.13.1]: https://github.com/jmagar/cortex/compare/v1.13.0...v1.13.1
+[1.13.0]: https://github.com/jmagar/cortex/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/jmagar/cortex/compare/v1.11.0...v1.12.0
+[1.11.0]: https://github.com/jmagar/cortex/compare/v1.10.1...v1.11.0
 [1.10.1]: https://github.com/jmagar/cortex/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/jmagar/cortex/compare/v1.9.1...v1.10.0
 [1.9.1]: https://github.com/jmagar/cortex/compare/v1.9.0...v1.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-06-04
+
+### Added
+
+- Projected the cached homelab inventory into the investigation graph with
+  evidence-backed topology nodes for Compose projects, reverse proxies, domains,
+  networks, storage, and redacted config artifacts.
+- Added server-side inventory refresh triggers from local Compose/proxy config
+  file watchers and remote Docker `events` streams over SSH, while preserving
+  the 5-minute polling baseline.
+
+### Changed
+
+- Expanded graph vocabulary and schema constraints for inventory topology
+  relationships such as `defines_service`, `routes_to`, `exposes_domain`,
+  `attached_to`, `mounts`, `backed_by`, and `has_artifact`.
+- Documented optional inventory collector env vars, realtime refresh toggles,
+  and media API collector configuration in the env example and inventory docs.
+
 ## [1.12.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.2] - 2026-06-04
+
+### Fixed
+
+- Tightened inventory graph projection failure handling so optional inventory
+  cache failures report degraded metadata without aborting explicit graph
+  rebuilds, successful inventory projection clears only stale inventory
+  degradation, and cache misses are distinguished from unreadable cache files.
+
 ## [1.13.1] - 2026-06-04
 
 ### Fixed
@@ -2036,7 +2045,8 @@ start and verify with `cortex --http db status`.
 
 ---
 
-[Unreleased]: https://github.com/jmagar/cortex/compare/v1.13.1...HEAD
+[Unreleased]: https://github.com/jmagar/cortex/compare/v1.13.2...HEAD
+[1.13.2]: https://github.com/jmagar/cortex/compare/v1.13.1...v1.13.2
 [1.13.1]: https://github.com/jmagar/cortex/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/jmagar/cortex/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/jmagar/cortex/compare/v1.11.0...v1.12.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **Syslog Intelligence for Homelabs** — Receives RFC 3164/5424 syslog from all homelab hosts (UDP/TCP), ingests Docker logs via socket proxy, stores everything in SQLite with FTS5, and exposes a comprehensive `cortex` MCP tool for AI agents.
 
 **Status**: Active development, Production-ready
-**Version**: 1.13.1
+**Version**: 1.13.2
 
 ## Key Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **Syslog Intelligence for Homelabs** — Receives RFC 3164/5424 syslog from all homelab hosts (UDP/TCP), ingests Docker logs via socket proxy, stores everything in SQLite with FTS5, and exposes a comprehensive `cortex` MCP tool for AI agents.
 
 **Status**: Active development, Production-ready
-**Version**: 1.12.0
+**Version**: 1.13.1
 
 ## Key Files
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.13.1"
+version = "1.13.2"
 edition = "2021"
 rust-version = "1.86"
 description = "Homelab intelligence platform — syslog/OTLP/Docker log aggregation, fleet awareness, and AI agent coordination over MCP, CLI, and HTTP"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 rust-version = "1.86"
 description = "Homelab intelligence platform — syslog/OTLP/Docker log aggregation, fleet awareness, and AI agent coordination over MCP, CLI, and HTTP"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 rust-version = "1.86"
 description = "Homelab intelligence platform — syslog/OTLP/Docker log aggregation, fleet awareness, and AI agent coordination over MCP, CLI, and HTTP"

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ or returns raw artifact bodies.
 
 When the server is running, inventory refresh also projects topology evidence
 into the investigation graph. The baseline refresh interval is 5 minutes, with
-local Compose/proxy config watchers and remote Docker `events` streams over SSH
-used as lower-latency refresh triggers when available.
+local Compose/proxy config watchers as lower-latency refresh triggers. Remote
+Docker `events` streams over SSH are opt-in via
+`CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=true`.
 
 On first run, before `normalized/homelab.json` exists, `map` and
 `cortex inventory status --json` report `cache_status: "missing"`. Run

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ opening SQLite. The MCP `map` action is read-only: it reads the normalized cache
 and overlays bounded live Cortex host/heartbeat data, but never triggers refresh
 or returns raw artifact bodies.
 
+When the server is running, inventory refresh also projects topology evidence
+into the investigation graph. The baseline refresh interval is 5 minutes, with
+local Compose/proxy config watchers and remote Docker `events` streams over SSH
+used as lower-latency refresh triggers when available.
+
 On first run, before `normalized/homelab.json` exists, `map` and
 `cortex inventory status --json` report `cache_status: "missing"`. Run
 `cortex inventory refresh --json` to seed `~/.cortex/inventory` and clear that

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -127,8 +127,8 @@ reads only the cache metadata and does not open SQLite.
 
 Server-side refresh additionally projects the normalized inventory into the
 investigation graph. It runs on the 5-minute baseline cadence and reacts to
-local Compose/proxy config changes plus remote Docker container events over SSH
-when available.
+local Compose/proxy config changes. Remote Docker container event streams over
+SSH can be enabled explicitly with `CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=true`.
 
 ### `cortex sessions`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -125,6 +125,11 @@ UniFi, media services, and configured local project roots. Missing provider
 credentials are warnings, not fatal errors for unrelated collectors. `status`
 reads only the cache metadata and does not open SQLite.
 
+Server-side refresh additionally projects the normalized inventory into the
+investigation graph. It runs on the 5-minute baseline cadence and reacts to
+local Compose/proxy config changes plus remote Docker container events over SSH
+when available.
+
 ### `cortex sessions`
 
 List AI transcript sessions grouped by project.

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -139,7 +139,7 @@ methods as the MCP actions.
 | `CORTEX_INVENTORY_PROJECT_ROOTS` | no | `~/workspace` | no |
 | `CORTEX_INVENTORY_REFRESH_INTERVAL_SECS` | no | `300` (`0` disables server-side periodic refresh) | no |
 | `CORTEX_INVENTORY_WATCH_ENABLED` | no | `true` | no |
-| `CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS` | no | `true` | no |
+| `CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS` | no | `false` | no |
 | `CORTEX_UNRAID_URL` | no | (none) | no |
 | `CORTEX_UNRAID_API_KEY` | no | (none) | yes |
 | `CORTEX_UNIFI_URL` | no | (none) | no |
@@ -157,10 +157,10 @@ disable background refresh.
 
 When background refresh is enabled, Cortex also watches local configured
 Compose/proxy config paths and refreshes after a short debounce when they
-change. For SSH hosts that can run Docker, Cortex opens `docker events` streams
-over SSH and uses container events as refresh triggers. Set
-`CORTEX_INVENTORY_WATCH_ENABLED=false` or
-`CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=false` to disable either trigger.
+change. Set `CORTEX_INVENTORY_WATCH_ENABLED=false` to disable local file
+watching. To use container events as refresh triggers, explicitly set
+`CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=true`; Cortex then opens `docker events`
+streams over SSH for selected hosts.
 
 Remote collection is SSH-backed and uses concrete aliases from `~/.ssh/config`
 unless `CORTEX_INVENTORY_SSH_HOSTS` is set. It collects host facts, listener

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -138,10 +138,14 @@ methods as the MCP actions.
 | `CORTEX_INVENTORY_SSH_HOSTS` | no | all concrete `Host` aliases in SSH config except wildcard patterns and `github.com` | no |
 | `CORTEX_INVENTORY_PROJECT_ROOTS` | no | `~/workspace` | no |
 | `CORTEX_INVENTORY_REFRESH_INTERVAL_SECS` | no | `300` (`0` disables server-side periodic refresh) | no |
+| `CORTEX_INVENTORY_WATCH_ENABLED` | no | `true` | no |
+| `CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS` | no | `true` | no |
 | `CORTEX_UNRAID_URL` | no | (none) | no |
 | `CORTEX_UNRAID_API_KEY` | no | (none) | yes |
 | `CORTEX_UNIFI_URL` | no | (none) | no |
 | `CORTEX_UNIFI_API_KEY` | no | (none) | yes |
+| `CORTEX_<MEDIA>_URL` | no | (none) | no |
+| `CORTEX_<MEDIA>_API_KEY` / `TOKEN` / `USERNAME` / `PASSWORD` | no | (none) | yes |
 
 ## Homelab inventory refresh
 
@@ -151,12 +155,23 @@ automatically: one refresh runs shortly after startup, then every
 `CORTEX_INVENTORY_REFRESH_INTERVAL_SECS` seconds. Set the interval to `0` to
 disable background refresh.
 
+When background refresh is enabled, Cortex also watches local configured
+Compose/proxy config paths and refreshes after a short debounce when they
+change. For SSH hosts that can run Docker, Cortex opens `docker events` streams
+over SSH and uses container events as refresh triggers. Set
+`CORTEX_INVENTORY_WATCH_ENABLED=false` or
+`CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=false` to disable either trigger.
+
 Remote collection is SSH-backed and uses concrete aliases from `~/.ssh/config`
 unless `CORTEX_INVENTORY_SSH_HOSTS` is set. It collects host facts, listener
 ports, storage summaries, Compose YAML artifacts, reverse proxy conf artifacts,
 and compact Docker inspect data including container status/health, image,
 published ports, networks, mounts, compose/route labels, and environment key
 names only. It does not store environment values.
+
+Optional provider collectors are activated only when their URL/credential env
+vars are present. Supported media prefixes are `SONARR`, `RADARR`, `PROWLARR`,
+`SABNZBD`, `QBITTORRENT`, `PLEX`, `TAUTULLI`, and `OVERSEERR`.
 
 ## Plugin surfaces
 

--- a/docs/contracts/current-schema.sql
+++ b/docs/contracts/current-schema.sql
@@ -86,8 +86,8 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 
 
 -- ---------------------------------------------------------------------------
--- 2.1.1 `graph_*` — derived investigation graph projection (migration 27)
--- Source: init_pool() migration 27.
+-- 2.1.1 `graph_*` — derived investigation graph projection (migrations 27, 30)
+-- Source: init_pool() migration 27 plus migration 30 vocabulary widening.
 --
 -- Invariants:
 --   - Rebuildable projection only; raw source tables remain authoritative.

--- a/docs/contracts/current-schema.sql
+++ b/docs/contracts/current-schema.sql
@@ -102,7 +102,8 @@ CREATE TABLE IF NOT EXISTS graph_entities (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     entity_type   TEXT NOT NULL CHECK (entity_type IN (
         'host', 'container', 'service', 'app', 'source_ip',
-        'ai_project', 'ai_session', 'error_signature'
+        'ai_project', 'ai_session', 'error_signature', 'compose_project',
+        'reverse_proxy', 'domain', 'network', 'storage', 'config_artifact'
     )),
     canonical_key TEXT NOT NULL,
     display_label TEXT NOT NULL,
@@ -147,12 +148,17 @@ CREATE TABLE IF NOT EXISTS graph_relationships (
     src_entity_id     INTEGER NOT NULL,
     dst_entity_id     INTEGER NOT NULL,
     relationship_type TEXT NOT NULL CHECK (relationship_type IN (
-        'observed_as', 'runs_on', 'emitted_by', 'worked_on', 'matches_signature'
+        'observed_as', 'runs_on', 'emitted_by', 'worked_on',
+        'matches_signature', 'defines_service', 'routes_to',
+        'exposes_domain', 'attached_to', 'mounts', 'backed_by',
+        'has_artifact'
     )),
     reason_code       TEXT NOT NULL CHECK (reason_code IN (
         'syslog_claimed_hostname', 'log_app_name', 'docker_container_id',
         'docker_service_label', 'ai_session_project', 'heartbeat_host_state',
-        'error_signature_match'
+        'error_signature_match', 'inventory_node', 'inventory_service',
+        'compose_config', 'reverse_proxy_config', 'docker_network',
+        'storage_probe', 'config_artifact'
     )),
     trust_level       TEXT NOT NULL CHECK (trust_level IN (
         'verified', 'claimed', 'inferred', 'correlated'
@@ -186,7 +192,9 @@ CREATE TABLE IF NOT EXISTS graph_relationship_evidence (
     reason_code           TEXT NOT NULL CHECK (reason_code IN (
         'syslog_claimed_hostname', 'log_app_name', 'docker_container_id',
         'docker_service_label', 'ai_session_project', 'heartbeat_host_state',
-        'error_signature_match'
+        'error_signature_match', 'inventory_node', 'inventory_service',
+        'compose_config', 'reverse_proxy_config', 'docker_network',
+        'storage_probe', 'config_artifact'
     )),
     reason_text           TEXT,
     confidence_delta      REAL NOT NULL DEFAULT 0.0 CHECK (confidence_delta >= -1.0 AND confidence_delta <= 1.0),

--- a/docs/contracts/investigation-graph.md
+++ b/docs/contracts/investigation-graph.md
@@ -104,6 +104,12 @@ source_ip
 ai_project
 ai_session
 error_signature
+compose_project
+reverse_proxy
+domain
+network
+storage
+config_artifact
 ```
 
 Unknown entity types MUST be rejected on public lookup surfaces.
@@ -118,6 +124,13 @@ runs_on
 emitted_by
 worked_on
 matches_signature
+defines_service
+routes_to
+exposes_domain
+attached_to
+mounts
+backed_by
+has_artifact
 ```
 
 ### 4.3 Trust Levels
@@ -177,10 +190,20 @@ docker_service_label
 ai_session_project
 heartbeat_host_state
 error_signature_match
+inventory_node
+inventory_service
+compose_config
+reverse_proxy_config
+docker_network
+storage_probe
+config_artifact
 ```
 
 `heartbeat_host_state` is reserved for heartbeat-derived relationship evidence.
 The current v1 implementation uses heartbeat rows for host identity/aliases.
+Inventory projections use `source_inventory` and `app_inventory` evidence to
+link hosts, services, Compose projects, reverse proxy routes, domains, Docker
+networks, storage mounts, and redacted config artifacts.
 
 ## 5. Entity Construction Contract
 

--- a/docs/contracts/investigation-graph.md
+++ b/docs/contracts/investigation-graph.md
@@ -428,7 +428,7 @@ Fields:
 
 | Relationship | Reason Code | Trust | Confidence | Evidence Kind |
 | --- | --- | --- | --- | --- |
-| `service runs_on host` | `inventory_service` | source trust | `0.85` | `app_inventory` |
+| `service runs_on host` | `inventory_service` | `inferred` | `0.85` | `app_inventory` |
 | `compose_project defines_service service` | `compose_config` | `verified` | `0.90` | `app_inventory` |
 | `compose_project has_artifact config_artifact` | `config_artifact` | `verified` | `0.95` | `app_inventory` |
 | `reverse_proxy exposes_domain domain` | `reverse_proxy_config` | `verified` | `0.95` | `app_inventory` |

--- a/docs/contracts/investigation-graph.md
+++ b/docs/contracts/investigation-graph.md
@@ -173,6 +173,8 @@ The current v1 projection emits evidence rows for:
 ```text
 log
 error_signature
+source_inventory
+app_inventory
 ```
 
 Heartbeat currently contributes host entities and aliases, not relationship
@@ -396,6 +398,48 @@ Fields:
 | `evidence.source_kind` | `error_signature` | `error_signature` |
 | `evidence.source_signature_hash` | signature hash | signature hash |
 | `evidence.metadata_path` | `error_signatures` | `error_signatures` |
+
+### 7.7 Inventory Topology Links
+
+Input:
+
+- normalized `HomelabInventory.nodes`,
+- normalized `HomelabInventory.services`,
+- normalized `HomelabInventory.compose_projects`,
+- normalized `HomelabInventory.reverse_proxies`,
+- normalized `HomelabInventory.networks`,
+- normalized `HomelabInventory.storage`,
+- normalized redacted `HomelabInventory.artifact_refs`.
+
+Outputs:
+
+```text
+service runs_on host
+compose_project defines_service service
+compose_project has_artifact config_artifact
+reverse_proxy exposes_domain domain
+reverse_proxy routes_to service
+service attached_to network
+service mounts storage
+host backed_by storage
+```
+
+Fields:
+
+| Relationship | Reason Code | Trust | Confidence | Evidence Kind |
+| --- | --- | --- | --- | --- |
+| `service runs_on host` | `inventory_service` | source trust | `0.85` | `app_inventory` |
+| `compose_project defines_service service` | `compose_config` | `verified` | `0.90` | `app_inventory` |
+| `compose_project has_artifact config_artifact` | `config_artifact` | `verified` | `0.95` | `app_inventory` |
+| `reverse_proxy exposes_domain domain` | `reverse_proxy_config` | `verified` | `0.95` | `app_inventory` |
+| `reverse_proxy routes_to service` | `reverse_proxy_config` | `verified` | `0.85` | `app_inventory` |
+| `service attached_to network` | `docker_network` | `verified` | `0.80` | `app_inventory` |
+| `service mounts storage` | `storage_probe` | `inferred` | `0.65` | `app_inventory` |
+| `host backed_by storage` | `storage_probe` | `verified` | `0.75` | `source_inventory` |
+
+Bare service-name matches are valid only when the service name is unique across
+the inventory snapshot. Ambiguous service names MUST be matched through a
+host-scoped key or left unlinked.
 
 ## 8. Evidence Contract
 

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -98,6 +98,9 @@ Required argument: `action = "hosts"`
 Return a bounded homelab infrastructure snapshot from `~/.cortex/inventory`
 plus live Cortex host/heartbeat overlay. The action is read-only and never
 triggers refresh; raw Compose/proxy artifact bodies are omitted by default.
+Server-side inventory refresh keeps the cache current on a 5-minute baseline
+cadence, reacts to local Compose/proxy config changes and remote Docker events
+over SSH, and projects topology evidence into the graph.
 
 Required argument: `action = "map"`
 

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -99,8 +99,8 @@ Return a bounded homelab infrastructure snapshot from `~/.cortex/inventory`
 plus live Cortex host/heartbeat overlay. The action is read-only and never
 triggers refresh; raw Compose/proxy artifact bodies are omitted by default.
 Server-side inventory refresh keeps the cache current on a 5-minute baseline
-cadence, reacts to local Compose/proxy config changes and remote Docker events
-over SSH, and projects topology evidence into the graph.
+cadence, reacts to local Compose/proxy config changes, can opt into remote
+Docker event streams over SSH, and projects topology evidence into the graph.
 
 Required argument: `action = "map"`
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.13.1",
+  "version": "1.13.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.13.1",
+      "identifier": "ghcr.io/jmagar/cortex:v1.13.2",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.13.0",
+  "version": "1.13.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.13.0",
+      "identifier": "ghcr.io/jmagar/cortex:v1.13.1",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.12.0",
+  "version": "1.13.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.12.0",
+      "identifier": "ghcr.io/jmagar/cortex:v1.13.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/app/services/graph.rs
+++ b/src/app/services/graph.rs
@@ -440,7 +440,6 @@ impl CortexService {
                                 "graph rebuild failed to mark inventory projection degraded"
                             );
                         }
-                        return Err(error);
                     }
                     if let db::graph::GraphRebuildOutcome::Rebuilt(stats) = &mut outcome {
                         let final_status = self
@@ -451,7 +450,7 @@ impl CortexService {
                         stats.evidence_count = final_status.evidence_count;
                     }
                 }
-                Err(error) if !cache_path.exists() => {
+                Err(error) if crate::inventory::is_not_found_error(&error) => {
                     tracing::debug!(
                         %error,
                         path = %cache_path.display(),
@@ -464,7 +463,21 @@ impl CortexService {
                         path = %cache_path.display(),
                         "graph rebuild failed to read inventory cache"
                     );
-                    return Err(error.into());
+                    let error_message = error.to_string();
+                    if let Err(mark_error) = self
+                        .run_db("graph.inventory_cache_failed", move |pool| {
+                            db::graph_inventory::mark_inventory_projection_failed(
+                                pool,
+                                &error_message,
+                            )
+                        })
+                        .await
+                    {
+                        tracing::warn!(
+                            %mark_error,
+                            "graph rebuild failed to mark inventory projection degraded"
+                        );
+                    }
                 }
             }
         }

--- a/src/app/services/graph.rs
+++ b/src/app/services/graph.rs
@@ -412,6 +412,25 @@ impl CortexService {
         let outcome = self
             .run_db("graph.rebuild", db::graph::refresh_graph_projection)
             .await?;
+        if matches!(&outcome, db::graph::GraphRebuildOutcome::Rebuilt(_)) {
+            let config = crate::inventory::InventoryConfig::from_env();
+            match crate::inventory::read_inventory_cache(&config) {
+                Ok(inventory) => {
+                    let project_result = self
+                        .run_db("graph.inventory_project", move |pool| {
+                            db::graph_inventory::project_inventory(pool, &inventory)
+                        })
+                        .await;
+                    if let Err(error) = project_result {
+                        tracing::warn!(%error, "graph rebuild inventory projection failed");
+                    }
+                }
+                Err(error) => tracing::debug!(
+                    %error,
+                    "graph rebuild skipped inventory projection; cache unavailable"
+                ),
+            }
+        }
         let status = self.graph_projection_status().await?;
         let (outcome, stats) = match outcome {
             db::graph::GraphRebuildOutcome::Rebuilt(stats) => (

--- a/src/app/services/graph.rs
+++ b/src/app/services/graph.rs
@@ -409,11 +409,13 @@ impl CortexService {
     }
 
     pub async fn graph_rebuild(&self) -> ServiceResult<GraphRebuildResponse> {
-        let outcome = self
+        let mut outcome = self
             .run_db("graph.rebuild", db::graph::refresh_graph_projection)
             .await?;
         if matches!(&outcome, db::graph::GraphRebuildOutcome::Rebuilt(_)) {
             let config = crate::inventory::InventoryConfig::from_env();
+            let cache_path =
+                crate::inventory::storage::InventoryPaths::new(config.root.clone()).normalized_json;
             match crate::inventory::read_inventory_cache(&config) {
                 Ok(inventory) => {
                     let project_result = self
@@ -423,12 +425,47 @@ impl CortexService {
                         .await;
                     if let Err(error) = project_result {
                         tracing::warn!(%error, "graph rebuild inventory projection failed");
+                        let error_message = error.to_string();
+                        let mark_result = self
+                            .run_db("graph.inventory_project_failed", move |pool| {
+                                db::graph_inventory::mark_inventory_projection_failed(
+                                    pool,
+                                    &error_message,
+                                )
+                            })
+                            .await;
+                        if let Err(mark_error) = mark_result {
+                            tracing::warn!(
+                                %mark_error,
+                                "graph rebuild failed to mark inventory projection degraded"
+                            );
+                        }
+                        return Err(error);
+                    }
+                    if let db::graph::GraphRebuildOutcome::Rebuilt(stats) = &mut outcome {
+                        let final_status = self
+                            .run_db("graph.status", db::graph::graph_projection_status)
+                            .await?;
+                        stats.entity_count = final_status.entity_count;
+                        stats.relationship_count = final_status.relationship_count;
+                        stats.evidence_count = final_status.evidence_count;
                     }
                 }
-                Err(error) => tracing::debug!(
-                    %error,
-                    "graph rebuild skipped inventory projection; cache unavailable"
-                ),
+                Err(error) if !cache_path.exists() => {
+                    tracing::debug!(
+                        %error,
+                        path = %cache_path.display(),
+                        "graph rebuild skipped inventory projection; cache unavailable"
+                    );
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        path = %cache_path.display(),
+                        "graph rebuild failed to read inventory cache"
+                    );
+                    return Err(error.into());
+                }
             }
         }
         let status = self.graph_projection_status().await?;

--- a/src/cli/commands/graph.rs
+++ b/src/cli/commands/graph.rs
@@ -18,6 +18,12 @@ const GRAPH_ENTITY_TYPES: &[&str] = &[
     "ai_project",
     "ai_session",
     "error_signature",
+    "compose_project",
+    "reverse_proxy",
+    "domain",
+    "network",
+    "storage",
+    "config_artifact",
 ];
 
 pub(crate) fn parse_entity(args: &[String]) -> Result<CliCommand> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,6 +3,7 @@
 mod analytics;
 pub(crate) mod error_signatures;
 pub mod graph;
+pub mod graph_inventory;
 mod heartbeat;
 mod ingest;
 mod maintenance;

--- a/src/db/graph.rs
+++ b/src/db/graph.rs
@@ -30,6 +30,12 @@ pub const ENTITY_TYPE_SOURCE_IP: &str = "source_ip";
 pub const ENTITY_TYPE_AI_PROJECT: &str = "ai_project";
 pub const ENTITY_TYPE_AI_SESSION: &str = "ai_session";
 pub const ENTITY_TYPE_ERROR_SIGNATURE: &str = "error_signature";
+pub const ENTITY_TYPE_COMPOSE_PROJECT: &str = "compose_project";
+pub const ENTITY_TYPE_REVERSE_PROXY: &str = "reverse_proxy";
+pub const ENTITY_TYPE_DOMAIN: &str = "domain";
+pub const ENTITY_TYPE_NETWORK: &str = "network";
+pub const ENTITY_TYPE_STORAGE: &str = "storage";
+pub const ENTITY_TYPE_CONFIG_ARTIFACT: &str = "config_artifact";
 
 pub const ENTITY_TYPES: &[&str] = &[
     ENTITY_TYPE_HOST,
@@ -40,6 +46,12 @@ pub const ENTITY_TYPES: &[&str] = &[
     ENTITY_TYPE_AI_PROJECT,
     ENTITY_TYPE_AI_SESSION,
     ENTITY_TYPE_ERROR_SIGNATURE,
+    ENTITY_TYPE_COMPOSE_PROJECT,
+    ENTITY_TYPE_REVERSE_PROXY,
+    ENTITY_TYPE_DOMAIN,
+    ENTITY_TYPE_NETWORK,
+    ENTITY_TYPE_STORAGE,
+    ENTITY_TYPE_CONFIG_ARTIFACT,
 ];
 
 pub const REL_OBSERVED_AS: &str = "observed_as";
@@ -47,6 +59,13 @@ pub const REL_RUNS_ON: &str = "runs_on";
 pub const REL_EMITTED_BY: &str = "emitted_by";
 pub const REL_WORKED_ON: &str = "worked_on";
 pub const REL_MATCHES_SIGNATURE: &str = "matches_signature";
+pub const REL_DEFINES_SERVICE: &str = "defines_service";
+pub const REL_ROUTES_TO: &str = "routes_to";
+pub const REL_EXPOSES_DOMAIN: &str = "exposes_domain";
+pub const REL_ATTACHED_TO: &str = "attached_to";
+pub const REL_MOUNTS: &str = "mounts";
+pub const REL_BACKED_BY: &str = "backed_by";
+pub const REL_HAS_ARTIFACT: &str = "has_artifact";
 
 pub const RELATIONSHIP_TYPES: &[&str] = &[
     REL_OBSERVED_AS,
@@ -54,6 +73,13 @@ pub const RELATIONSHIP_TYPES: &[&str] = &[
     REL_EMITTED_BY,
     REL_WORKED_ON,
     REL_MATCHES_SIGNATURE,
+    REL_DEFINES_SERVICE,
+    REL_ROUTES_TO,
+    REL_EXPOSES_DOMAIN,
+    REL_ATTACHED_TO,
+    REL_MOUNTS,
+    REL_BACKED_BY,
+    REL_HAS_ARTIFACT,
 ];
 
 pub const TRUST_VERIFIED: &str = "verified";
@@ -91,6 +117,13 @@ pub const REASON_DOCKER_SERVICE_LABEL: &str = "docker_service_label";
 pub const REASON_AI_SESSION_PROJECT: &str = "ai_session_project";
 pub const REASON_HEARTBEAT_HOST_STATE: &str = "heartbeat_host_state";
 pub const REASON_ERROR_SIGNATURE_MATCH: &str = "error_signature_match";
+pub const REASON_INVENTORY_NODE: &str = "inventory_node";
+pub const REASON_INVENTORY_SERVICE: &str = "inventory_service";
+pub const REASON_COMPOSE_CONFIG: &str = "compose_config";
+pub const REASON_REVERSE_PROXY_CONFIG: &str = "reverse_proxy_config";
+pub const REASON_DOCKER_NETWORK: &str = "docker_network";
+pub const REASON_STORAGE_PROBE: &str = "storage_probe";
+pub const REASON_CONFIG_ARTIFACT: &str = "config_artifact";
 
 pub const REASON_CODES: &[&str] = &[
     REASON_SYSLOG_CLAIMED_HOSTNAME,
@@ -100,6 +133,13 @@ pub const REASON_CODES: &[&str] = &[
     REASON_AI_SESSION_PROJECT,
     REASON_HEARTBEAT_HOST_STATE,
     REASON_ERROR_SIGNATURE_MATCH,
+    REASON_INVENTORY_NODE,
+    REASON_INVENTORY_SERVICE,
+    REASON_COMPOSE_CONFIG,
+    REASON_REVERSE_PROXY_CONFIG,
+    REASON_DOCKER_NETWORK,
+    REASON_STORAGE_PROBE,
+    REASON_CONFIG_ARTIFACT,
 ];
 
 pub const PROJECTION_STATUS_NEVER_BUILT: &str = "never_built";

--- a/src/db/graph_inventory.rs
+++ b/src/db/graph_inventory.rs
@@ -1,0 +1,307 @@
+mod sql;
+#[cfg(test)]
+#[path = "graph_inventory_tests.rs"]
+mod tests;
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+
+use crate::db::graph;
+use crate::db::{write_lock, DbPool};
+use crate::inventory::schema::HomelabInventory;
+
+use self::sql::{
+    add_alias, add_relationship, canonical, canonical_or_raw, graph_counts, match_upstream,
+    prune_previous_inventory_projection, service_key, trust, update_projection_meta,
+    upsert_artifact, upsert_entity, upsert_service, upsert_storage,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InventoryGraphStats {
+    pub source_row_count: i64,
+    pub entity_count: i64,
+    pub relationship_count: i64,
+    pub evidence_count: i64,
+}
+
+pub fn project_inventory(
+    pool: &DbPool,
+    inventory: &HomelabInventory,
+) -> Result<InventoryGraphStats> {
+    let mut conn = pool.get().context("borrow sqlite connection")?;
+    let _guard = write_lock();
+    let tx = conn
+        .transaction()
+        .context("start inventory graph transaction")?;
+
+    prune_previous_inventory_projection(&tx)?;
+
+    let mut hosts = BTreeMap::new();
+    for node in &inventory.nodes {
+        let Some(key) = canonical(&node.hostname) else {
+            continue;
+        };
+        let entity = upsert_entity(
+            &tx,
+            graph::ENTITY_TYPE_HOST,
+            &key,
+            &node.hostname,
+            graph::SOURCE_KIND_SOURCE_INVENTORY,
+            &node.id,
+            trust(&node.trust_level),
+            &node.provenance.collected_at,
+        )?;
+        add_alias(
+            &tx,
+            entity.id,
+            "hostname",
+            &key,
+            &node.hostname,
+            graph::SOURCE_KIND_SOURCE_INVENTORY,
+            trust(&node.trust_level),
+            &node.provenance.collected_at,
+        )?;
+        for ip in &node.ips {
+            if let Some(alias_key) = canonical(ip) {
+                add_alias(
+                    &tx,
+                    entity.id,
+                    "ip",
+                    &alias_key,
+                    ip,
+                    graph::SOURCE_KIND_SOURCE_INVENTORY,
+                    trust(&node.trust_level),
+                    &node.provenance.collected_at,
+                )?;
+            }
+        }
+        hosts.insert(key, entity);
+    }
+
+    let mut services = BTreeMap::new();
+    for service in &inventory.services {
+        let service_entity = upsert_service(&tx, service)?;
+        services.insert(service_key(service), service_entity.clone());
+        services.insert(canonical_or_raw(&service.name), service_entity.clone());
+
+        for domain in &service.domains {
+            if let Some(alias_key) = canonical(domain) {
+                add_alias(
+                    &tx,
+                    service_entity.id,
+                    "domain",
+                    &alias_key,
+                    domain,
+                    graph::SOURCE_KIND_APP_INVENTORY,
+                    trust(&service.trust_level),
+                    &service.provenance.collected_at,
+                )?;
+            }
+        }
+
+        if let Some(host) = service
+            .host
+            .as_ref()
+            .and_then(|h| hosts.get(&canonical_or_raw(h)))
+        {
+            add_relationship(
+                &tx,
+                &service_entity,
+                host,
+                graph::REL_RUNS_ON,
+                graph::REASON_INVENTORY_SERVICE,
+                graph::SOURCE_KIND_APP_INVENTORY,
+                &service.id,
+                &service.provenance.collected_at,
+                trust(&service.trust_level),
+                0.85,
+                &format!("{} observed on {}", service.name, host.key),
+            )?;
+        }
+
+        for mount in &service.mounts {
+            let storage_key = canonical_or_raw(&format!(
+                "{}:{}",
+                service.host.as_deref().unwrap_or("unknown"),
+                mount.target
+            ));
+            let storage = upsert_entity(
+                &tx,
+                graph::ENTITY_TYPE_STORAGE,
+                &storage_key,
+                &mount.target,
+                graph::SOURCE_KIND_APP_INVENTORY,
+                &storage_key,
+                graph::TRUST_INFERRED,
+                &service.provenance.collected_at,
+            )?;
+            add_relationship(
+                &tx,
+                &service_entity,
+                &storage,
+                graph::REL_MOUNTS,
+                graph::REASON_STORAGE_PROBE,
+                graph::SOURCE_KIND_APP_INVENTORY,
+                &service.id,
+                &service.provenance.collected_at,
+                graph::TRUST_INFERRED,
+                0.65,
+                &format!("{} mounts {}", service.name, mount.target),
+            )?;
+        }
+    }
+
+    let mut artifacts = BTreeMap::new();
+    for artifact in &inventory.artifact_refs {
+        let entity = upsert_artifact(&tx, artifact, &inventory.generated_at)?;
+        artifacts.insert(artifact.id.clone(), entity.clone());
+        if let Some(path) = &artifact.source_path {
+            artifacts.insert(path.clone(), entity);
+        }
+    }
+
+    for project in &inventory.compose_projects {
+        let project_key = canonical_or_raw(&project.name);
+        let project_entity = upsert_entity(
+            &tx,
+            graph::ENTITY_TYPE_COMPOSE_PROJECT,
+            &project_key,
+            &project.name,
+            graph::SOURCE_KIND_APP_INVENTORY,
+            &project.provenance.source,
+            graph::TRUST_VERIFIED,
+            &project.provenance.collected_at,
+        )?;
+        for service_name in &project.services {
+            if let Some(service_entity) = services.get(&canonical_or_raw(service_name)) {
+                add_relationship(
+                    &tx,
+                    &project_entity,
+                    service_entity,
+                    graph::REL_DEFINES_SERVICE,
+                    graph::REASON_COMPOSE_CONFIG,
+                    graph::SOURCE_KIND_APP_INVENTORY,
+                    &project.provenance.source,
+                    &project.provenance.collected_at,
+                    graph::TRUST_VERIFIED,
+                    0.90,
+                    &format!("compose project {} defines {}", project.name, service_name),
+                )?;
+            }
+        }
+        for compose_file in &project.compose_files {
+            if let Some(artifact) = artifacts.get(compose_file) {
+                add_relationship(
+                    &tx,
+                    &project_entity,
+                    artifact,
+                    graph::REL_HAS_ARTIFACT,
+                    graph::REASON_CONFIG_ARTIFACT,
+                    graph::SOURCE_KIND_APP_INVENTORY,
+                    &project.provenance.source,
+                    &project.provenance.collected_at,
+                    graph::TRUST_VERIFIED,
+                    0.95,
+                    &format!("compose artifact {}", compose_file),
+                )?;
+            }
+        }
+    }
+
+    for route in &inventory.reverse_proxies {
+        let proxy_key = canonical_or_raw(&route.id);
+        let proxy = upsert_entity(
+            &tx,
+            graph::ENTITY_TYPE_REVERSE_PROXY,
+            &proxy_key,
+            route.server_names.first().unwrap_or(&route.id),
+            graph::SOURCE_KIND_APP_INVENTORY,
+            &route.id,
+            graph::TRUST_VERIFIED,
+            &route.provenance.collected_at,
+        )?;
+        for domain in &route.server_names {
+            let domain_key = canonical_or_raw(domain);
+            let domain_entity = upsert_entity(
+                &tx,
+                graph::ENTITY_TYPE_DOMAIN,
+                &domain_key,
+                domain,
+                graph::SOURCE_KIND_APP_INVENTORY,
+                &route.id,
+                graph::TRUST_VERIFIED,
+                &route.provenance.collected_at,
+            )?;
+            add_relationship(
+                &tx,
+                &proxy,
+                &domain_entity,
+                graph::REL_EXPOSES_DOMAIN,
+                graph::REASON_REVERSE_PROXY_CONFIG,
+                graph::SOURCE_KIND_APP_INVENTORY,
+                &route.id,
+                &route.provenance.collected_at,
+                graph::TRUST_VERIFIED,
+                0.95,
+                &format!("proxy exposes {}", domain),
+            )?;
+        }
+        for upstream in &route.upstreams {
+            if let Some(service) = match_upstream(upstream, &services) {
+                add_relationship(
+                    &tx,
+                    &proxy,
+                    service,
+                    graph::REL_ROUTES_TO,
+                    graph::REASON_REVERSE_PROXY_CONFIG,
+                    graph::SOURCE_KIND_APP_INVENTORY,
+                    &route.id,
+                    &route.provenance.collected_at,
+                    graph::TRUST_VERIFIED,
+                    0.85,
+                    &format!("proxy routes to {}", upstream),
+                )?;
+            }
+        }
+    }
+
+    for network in &inventory.networks {
+        let network_entity = upsert_entity(
+            &tx,
+            graph::ENTITY_TYPE_NETWORK,
+            &canonical_or_raw(&network.name),
+            &network.name,
+            graph::SOURCE_KIND_APP_INVENTORY,
+            &network.provenance.source,
+            graph::TRUST_VERIFIED,
+            &network.provenance.collected_at,
+        )?;
+        for member in &network.members {
+            if let Some(service) = services.get(&canonical_or_raw(member)) {
+                add_relationship(
+                    &tx,
+                    service,
+                    &network_entity,
+                    graph::REL_ATTACHED_TO,
+                    graph::REASON_DOCKER_NETWORK,
+                    graph::SOURCE_KIND_APP_INVENTORY,
+                    &network.provenance.source,
+                    &network.provenance.collected_at,
+                    graph::TRUST_VERIFIED,
+                    0.80,
+                    &format!("{} attached to network {}", member, network.name),
+                )?;
+            }
+        }
+    }
+
+    for storage in &inventory.storage {
+        upsert_storage(&tx, storage, &hosts)?;
+    }
+
+    let stats = graph_counts(&tx)?;
+    update_projection_meta(&tx, inventory, &stats)?;
+    tx.commit().context("commit inventory graph projection")?;
+    Ok(stats)
+}

--- a/src/db/graph_inventory.rs
+++ b/src/db/graph_inventory.rs
@@ -121,7 +121,7 @@ pub fn project_inventory(
                 graph::SOURCE_KIND_APP_INVENTORY,
                 &service.id,
                 &service.provenance.collected_at,
-                trust(&service.trust_level),
+                graph::TRUST_INFERRED,
                 0.85,
                 &format!("{} observed on {}", service.name, host.key),
             )?;

--- a/src/db/graph_inventory.rs
+++ b/src/db/graph_inventory.rs
@@ -3,7 +3,7 @@ mod sql;
 #[path = "graph_inventory_tests.rs"]
 mod tests;
 
-use std::collections::BTreeMap;
+use std::collections::{btree_map::Entry, BTreeMap};
 
 use anyhow::{Context, Result};
 
@@ -12,9 +12,10 @@ use crate::db::{write_lock, DbPool};
 use crate::inventory::schema::HomelabInventory;
 
 use self::sql::{
-    add_alias, add_relationship, canonical, canonical_or_raw, graph_counts, match_upstream,
-    prune_previous_inventory_projection, service_key, trust, update_projection_meta,
-    upsert_artifact, upsert_entity, upsert_service, upsert_storage,
+    add_alias, add_relationship, canonical, canonical_or_raw, graph_counts, match_service_name,
+    match_upstream, prune_previous_inventory_projection, safe_inventory_source_id,
+    scoped_inventory_key, service_key, trust, update_projection_meta, upsert_artifact,
+    upsert_entity, upsert_service, upsert_storage,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -80,10 +81,16 @@ pub fn project_inventory(
     }
 
     let mut services = BTreeMap::new();
+    let mut unique_service_aliases = BTreeMap::new();
     for service in &inventory.services {
         let service_entity = upsert_service(&tx, service)?;
-        services.insert(service_key(service), service_entity.clone());
-        services.insert(canonical_or_raw(&service.name), service_entity.clone());
+        let scoped_key = service_key(service);
+        services.insert(scoped_key, service_entity.clone());
+        insert_unique_alias(
+            &mut unique_service_aliases,
+            canonical_or_raw(&service.name),
+            service_entity.clone(),
+        );
 
         for domain in &service.domains {
             if let Some(alias_key) = canonical(domain) {
@@ -151,6 +158,11 @@ pub fn project_inventory(
             )?;
         }
     }
+    services.extend(
+        unique_service_aliases
+            .into_iter()
+            .filter_map(|(key, service)| service.map(|service| (key, service))),
+    );
 
     let mut artifacts = BTreeMap::new();
     for artifact in &inventory.artifact_refs {
@@ -162,19 +174,22 @@ pub fn project_inventory(
     }
 
     for project in &inventory.compose_projects {
-        let project_key = canonical_or_raw(&project.name);
+        let project_key = scoped_inventory_key(&project.provenance.source, &project.name);
+        let project_source = safe_inventory_source_id(&project.provenance.source);
         let project_entity = upsert_entity(
             &tx,
             graph::ENTITY_TYPE_COMPOSE_PROJECT,
             &project_key,
             &project.name,
             graph::SOURCE_KIND_APP_INVENTORY,
-            &project.provenance.source,
+            &project_source,
             graph::TRUST_VERIFIED,
             &project.provenance.collected_at,
         )?;
         for service_name in &project.services {
-            if let Some(service_entity) = services.get(&canonical_or_raw(service_name)) {
+            if let Some(service_entity) =
+                match_service_name(service_name, &project.provenance.source, &services)
+            {
                 add_relationship(
                     &tx,
                     &project_entity,
@@ -182,7 +197,7 @@ pub fn project_inventory(
                     graph::REL_DEFINES_SERVICE,
                     graph::REASON_COMPOSE_CONFIG,
                     graph::SOURCE_KIND_APP_INVENTORY,
-                    &project.provenance.source,
+                    &project_source,
                     &project.provenance.collected_at,
                     graph::TRUST_VERIFIED,
                     0.90,
@@ -192,6 +207,7 @@ pub fn project_inventory(
         }
         for compose_file in &project.compose_files {
             if let Some(artifact) = artifacts.get(compose_file) {
+                let artifact_id = artifact.key.clone();
                 add_relationship(
                     &tx,
                     &project_entity,
@@ -199,11 +215,11 @@ pub fn project_inventory(
                     graph::REL_HAS_ARTIFACT,
                     graph::REASON_CONFIG_ARTIFACT,
                     graph::SOURCE_KIND_APP_INVENTORY,
-                    &project.provenance.source,
+                    &project_source,
                     &project.provenance.collected_at,
                     graph::TRUST_VERIFIED,
                     0.95,
-                    &format!("compose artifact {}", compose_file),
+                    &format!("compose artifact {}", artifact_id),
                 )?;
             }
         }
@@ -248,7 +264,7 @@ pub fn project_inventory(
             )?;
         }
         for upstream in &route.upstreams {
-            if let Some(service) = match_upstream(upstream, &services) {
+            if let Some(service) = match_upstream(upstream, &route.provenance.source, &services) {
                 add_relationship(
                     &tx,
                     &proxy,
@@ -267,18 +283,20 @@ pub fn project_inventory(
     }
 
     for network in &inventory.networks {
+        let network_source = safe_inventory_source_id(&network.provenance.source);
         let network_entity = upsert_entity(
             &tx,
             graph::ENTITY_TYPE_NETWORK,
-            &canonical_or_raw(&network.name),
+            &scoped_inventory_key(&network.provenance.source, &network.name),
             &network.name,
             graph::SOURCE_KIND_APP_INVENTORY,
-            &network.provenance.source,
+            &network_source,
             graph::TRUST_VERIFIED,
             &network.provenance.collected_at,
         )?;
         for member in &network.members {
-            if let Some(service) = services.get(&canonical_or_raw(member)) {
+            if let Some(service) = match_service_name(member, &network.provenance.source, &services)
+            {
                 add_relationship(
                     &tx,
                     service,
@@ -286,7 +304,7 @@ pub fn project_inventory(
                     graph::REL_ATTACHED_TO,
                     graph::REASON_DOCKER_NETWORK,
                     graph::SOURCE_KIND_APP_INVENTORY,
-                    &network.provenance.source,
+                    &network_source,
                     &network.provenance.collected_at,
                     graph::TRUST_VERIFIED,
                     0.80,
@@ -300,8 +318,36 @@ pub fn project_inventory(
         upsert_storage(&tx, storage, &hosts)?;
     }
 
+    let counts = graph_counts(&tx)?;
+    update_projection_meta(&tx, &counts)?;
     let stats = graph_counts(&tx)?;
-    update_projection_meta(&tx, inventory, &stats)?;
     tx.commit().context("commit inventory graph projection")?;
     Ok(stats)
+}
+
+pub fn mark_inventory_projection_failed(pool: &DbPool, error: &str) -> Result<()> {
+    let conn = pool.get().context("borrow sqlite connection")?;
+    let _guard = write_lock();
+    sql::mark_projection_degraded(&conn, error)
+}
+
+fn insert_unique_alias(
+    aliases: &mut BTreeMap<String, Option<sql::EntityRef>>,
+    key: String,
+    service: sql::EntityRef,
+) {
+    match aliases.entry(key) {
+        Entry::Vacant(entry) => {
+            entry.insert(Some(service));
+        }
+        Entry::Occupied(mut entry) => {
+            if entry
+                .get()
+                .as_ref()
+                .is_some_and(|existing| existing.id != service.id)
+            {
+                entry.insert(None);
+            }
+        }
+    }
 }

--- a/src/db/graph_inventory/sql.rs
+++ b/src/db/graph_inventory/sql.rs
@@ -1,0 +1,397 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+
+use crate::db::graph;
+use crate::inventory::schema::{
+    ArtifactRef, HomelabInventory, InventoryService, StorageSummary, TrustLevel,
+};
+
+use super::InventoryGraphStats;
+
+#[derive(Debug, Clone)]
+pub(super) struct EntityRef {
+    pub(super) id: i64,
+    pub(super) kind: &'static str,
+    pub(super) key: String,
+}
+
+pub(super) fn prune_previous_inventory_projection(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "DELETE FROM graph_relationship_evidence
+          WHERE source_kind IN ('source_inventory', 'app_inventory')",
+        [],
+    )?;
+    conn.execute(
+        "DELETE FROM graph_relationships
+          WHERE reason_code IN (
+              'inventory_node', 'inventory_service', 'compose_config',
+              'reverse_proxy_config', 'docker_network', 'storage_probe',
+              'config_artifact'
+          )",
+        [],
+    )?;
+    conn.execute(
+        "DELETE FROM graph_entity_aliases
+          WHERE source_kind IN ('source_inventory', 'app_inventory')",
+        [],
+    )?;
+    conn.execute(
+        "DELETE FROM graph_entities
+          WHERE source_kind IN ('source_inventory', 'app_inventory')
+            AND id NOT IN (SELECT src_entity_id FROM graph_relationships)
+            AND id NOT IN (SELECT dst_entity_id FROM graph_relationships)",
+        [],
+    )?;
+    Ok(())
+}
+
+pub(super) fn upsert_service(conn: &Connection, service: &InventoryService) -> Result<EntityRef> {
+    upsert_entity(
+        conn,
+        graph::ENTITY_TYPE_SERVICE,
+        &service_key(service),
+        &service.name,
+        graph::SOURCE_KIND_APP_INVENTORY,
+        &service.id,
+        trust(&service.trust_level),
+        &service.provenance.collected_at,
+    )
+}
+
+pub(super) fn upsert_artifact(
+    conn: &Connection,
+    artifact: &ArtifactRef,
+    observed_at: &str,
+) -> Result<EntityRef> {
+    let display = artifact
+        .source_path
+        .as_deref()
+        .unwrap_or(artifact.cache_path.as_str());
+    let entity = upsert_entity(
+        conn,
+        graph::ENTITY_TYPE_CONFIG_ARTIFACT,
+        &canonical_or_raw(&artifact.id),
+        display,
+        graph::SOURCE_KIND_APP_INVENTORY,
+        &artifact.id,
+        graph::TRUST_VERIFIED,
+        observed_at,
+    )?;
+    if let Some(path) = &artifact.source_path {
+        add_alias(
+            conn,
+            entity.id,
+            "path",
+            &canonical_or_raw(path),
+            path,
+            graph::SOURCE_KIND_APP_INVENTORY,
+            graph::TRUST_VERIFIED,
+            observed_at,
+        )?;
+    }
+    Ok(entity)
+}
+
+pub(super) fn upsert_storage(
+    conn: &Connection,
+    storage: &StorageSummary,
+    hosts: &BTreeMap<String, EntityRef>,
+) -> Result<()> {
+    let entity = upsert_entity(
+        conn,
+        graph::ENTITY_TYPE_STORAGE,
+        &canonical_or_raw(&storage.id),
+        &storage.mount,
+        graph::SOURCE_KIND_SOURCE_INVENTORY,
+        &storage.id,
+        graph::TRUST_VERIFIED,
+        &storage.provenance.collected_at,
+    )?;
+    if let Some(host) = storage
+        .id
+        .split(':')
+        .nth(1)
+        .and_then(|host| hosts.get(&canonical_or_raw(host)))
+    {
+        add_relationship(
+            conn,
+            host,
+            &entity,
+            graph::REL_BACKED_BY,
+            graph::REASON_STORAGE_PROBE,
+            graph::SOURCE_KIND_SOURCE_INVENTORY,
+            &storage.id,
+            &storage.provenance.collected_at,
+            graph::TRUST_VERIFIED,
+            0.75,
+            &format!("{} storage mounted at {}", host.key, storage.mount),
+        )?;
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn upsert_entity(
+    conn: &Connection,
+    entity_type: &'static str,
+    canonical_key: &str,
+    display_label: &str,
+    source_kind: &str,
+    source_id: &str,
+    trust_level: &str,
+    observed_at: &str,
+) -> Result<EntityRef> {
+    conn.execute(
+        "INSERT INTO graph_entities
+             (entity_type, canonical_key, display_label, source_kind, source_id,
+              trust_level, first_seen_at, last_seen_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)
+         ON CONFLICT(entity_type, canonical_key) DO UPDATE SET
+             display_label = excluded.display_label,
+             source_kind = excluded.source_kind,
+             source_id = excluded.source_id,
+             trust_level = excluded.trust_level,
+             last_seen_at = excluded.last_seen_at,
+             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+        params![
+            entity_type,
+            canonical_key,
+            display_label,
+            source_kind,
+            source_id,
+            trust_level,
+            observed_at
+        ],
+    )?;
+    let id = conn.query_row(
+        "SELECT id FROM graph_entities WHERE entity_type = ?1 AND canonical_key = ?2",
+        params![entity_type, canonical_key],
+        |row| row.get(0),
+    )?;
+    Ok(EntityRef {
+        id,
+        kind: entity_type,
+        key: canonical_key.to_string(),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn add_alias(
+    conn: &Connection,
+    entity_id: i64,
+    alias_type: &str,
+    alias_key: &str,
+    alias_value: &str,
+    source_kind: &str,
+    trust_level: &str,
+    observed_at: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO graph_entity_aliases
+             (entity_id, alias_type, alias_key, alias_value, source_kind,
+              trust_level, first_seen_at, last_seen_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)
+         ON CONFLICT(entity_id, alias_type, alias_key, source_kind) DO UPDATE SET
+             alias_value = excluded.alias_value,
+             trust_level = excluded.trust_level,
+             last_seen_at = excluded.last_seen_at,
+             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+        params![
+            entity_id,
+            alias_type,
+            alias_key,
+            alias_value,
+            source_kind,
+            trust_level,
+            observed_at
+        ],
+    )?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn add_relationship(
+    conn: &Connection,
+    src: &EntityRef,
+    dst: &EntityRef,
+    relationship_type: &str,
+    reason_code: &str,
+    source_kind: &str,
+    source_id: &str,
+    observed_at: &str,
+    trust_level: &str,
+    confidence: f64,
+    safe_excerpt: &str,
+) -> Result<()> {
+    let key = format!(
+        "{}:{}->{}:{}:{}",
+        src.kind, src.key, dst.kind, dst.key, relationship_type
+    );
+    conn.execute(
+        "INSERT INTO graph_relationships
+             (relationship_key, src_entity_id, dst_entity_id, relationship_type,
+              reason_code, trust_level, confidence, evidence_count, first_seen_at, last_seen_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1, ?8, ?8)
+         ON CONFLICT(src_entity_id, dst_entity_id, relationship_type, relationship_key)
+         DO UPDATE SET
+             reason_code = excluded.reason_code,
+             trust_level = excluded.trust_level,
+             confidence = MAX(graph_relationships.confidence, excluded.confidence),
+             last_seen_at = excluded.last_seen_at,
+             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+        params![
+            key,
+            src.id,
+            dst.id,
+            relationship_type,
+            reason_code,
+            trust_level,
+            confidence,
+            observed_at
+        ],
+    )?;
+    let rel_id: i64 = conn.query_row(
+        "SELECT id FROM graph_relationships WHERE relationship_key = ?1",
+        [&key],
+        |row| row.get(0),
+    )?;
+    conn.execute(
+        "INSERT INTO graph_relationship_evidence
+             (relationship_id, evidence_key, source_kind, source_id, observed_at,
+              reason_code, reason_text, confidence_delta, trust_level, safe_excerpt,
+              evidence_count)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1)
+         ON CONFLICT(relationship_id, evidence_key) DO UPDATE SET
+             observed_at = excluded.observed_at,
+             reason_text = excluded.reason_text,
+             confidence_delta = excluded.confidence_delta,
+             trust_level = excluded.trust_level,
+             safe_excerpt = excluded.safe_excerpt,
+             evidence_count = excluded.evidence_count",
+        params![
+            rel_id,
+            format!(
+                "{source_kind}:{source_id}:{reason_code}:{}:{}",
+                src.key, dst.key
+            ),
+            source_kind,
+            source_id,
+            observed_at,
+            reason_code,
+            reason_code.replace('_', " "),
+            confidence,
+            trust_level,
+            truncate_excerpt(safe_excerpt)
+        ],
+    )?;
+    conn.execute(
+        "UPDATE graph_relationships
+            SET evidence_count = (
+                SELECT COALESCE(SUM(evidence_count), 0)
+                  FROM graph_relationship_evidence
+                 WHERE relationship_id = ?1
+            )
+          WHERE id = ?1",
+        [rel_id],
+    )?;
+    Ok(())
+}
+
+pub(super) fn update_projection_meta(
+    conn: &Connection,
+    inventory: &HomelabInventory,
+    counts: &InventoryGraphStats,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE graph_projection_meta
+            SET projection_status = 'ready',
+                last_completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                source_watermark = ?1,
+                source_row_count = ?2,
+                entity_count = ?3,
+                relationship_count = ?4,
+                evidence_count = ?5,
+                is_degraded = 0,
+                last_error = NULL,
+                updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+          WHERE id = 1",
+        params![
+            format!("inventory:{}", inventory.run_id),
+            inventory.summary.nodes as i64
+                + inventory.summary.services as i64
+                + inventory.summary.compose_projects as i64
+                + inventory.summary.reverse_proxies as i64
+                + inventory.summary.networks as i64
+                + inventory.summary.storage as i64
+                + inventory.summary.artifacts as i64,
+            counts.entity_count,
+            counts.relationship_count,
+            counts.evidence_count
+        ],
+    )?;
+    Ok(())
+}
+
+pub(super) fn graph_counts(conn: &Connection) -> Result<InventoryGraphStats> {
+    Ok(InventoryGraphStats {
+        source_row_count: 0,
+        entity_count: table_count(conn, "graph_entities")?,
+        relationship_count: table_count(conn, "graph_relationships")?,
+        evidence_count: table_count(conn, "graph_relationship_evidence")?,
+    })
+}
+
+fn table_count(conn: &Connection, table: &str) -> Result<i64> {
+    conn.query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+        row.get(0)
+    })
+    .with_context(|| format!("count {table}"))
+}
+
+pub(super) fn match_upstream<'a>(
+    upstream: &str,
+    services: &'a BTreeMap<String, EntityRef>,
+) -> Option<&'a EntityRef> {
+    let normalized = canonical_or_raw(upstream);
+    let prefix = upstream
+        .split([':', '/', '@'])
+        .find(|part| !part.is_empty() && !part.starts_with("http"))
+        .map(canonical_or_raw);
+    prefix
+        .and_then(|key| services.get(&key))
+        .or_else(|| services.get(&normalized))
+}
+
+pub(super) fn service_key(service: &InventoryService) -> String {
+    canonical_or_raw(&format!(
+        "{}:{}",
+        service.host.as_deref().unwrap_or("unknown"),
+        service.name
+    ))
+}
+
+pub(super) fn canonical_or_raw(value: &str) -> String {
+    canonical(value).unwrap_or_else(|| value.trim().to_ascii_lowercase())
+}
+
+pub(super) fn canonical(value: &str) -> Option<String> {
+    graph::canonical_graph_key(value)
+}
+
+pub(super) fn trust(value: &TrustLevel) -> &'static str {
+    match value {
+        TrustLevel::Verified | TrustLevel::Observed => graph::TRUST_VERIFIED,
+        TrustLevel::Claimed => graph::TRUST_CLAIMED,
+        TrustLevel::Inferred => graph::TRUST_INFERRED,
+    }
+}
+
+fn truncate_excerpt(value: &str) -> String {
+    const MAX: usize = 512;
+    if value.len() <= MAX {
+        return value.to_string();
+    }
+    value.chars().take(MAX).collect()
+}

--- a/src/db/graph_inventory/sql.rs
+++ b/src/db/graph_inventory/sql.rs
@@ -65,32 +65,17 @@ pub(super) fn upsert_artifact(
     artifact: &ArtifactRef,
     observed_at: &str,
 ) -> Result<EntityRef> {
-    let display = artifact
-        .source_path
-        .as_deref()
-        .unwrap_or(artifact.cache_path.as_str());
+    let display = format!("{} artifact {}", artifact.kind, artifact.id);
     let entity = upsert_entity(
         conn,
         graph::ENTITY_TYPE_CONFIG_ARTIFACT,
         &canonical_or_raw(&artifact.id),
-        display,
+        &display,
         graph::SOURCE_KIND_APP_INVENTORY,
         &artifact.id,
         graph::TRUST_VERIFIED,
         observed_at,
     )?;
-    if let Some(path) = &artifact.source_path {
-        add_alias(
-            conn,
-            entity.id,
-            "path",
-            &canonical_or_raw(path),
-            path,
-            graph::SOURCE_KIND_APP_INVENTORY,
-            graph::TRUST_VERIFIED,
-            observed_at,
-        )?;
-    }
     Ok(entity)
 }
 
@@ -150,9 +135,6 @@ pub(super) fn upsert_entity(
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7)
          ON CONFLICT(entity_type, canonical_key) DO UPDATE SET
              display_label = excluded.display_label,
-             source_kind = excluded.source_kind,
-             source_id = excluded.source_id,
-             trust_level = excluded.trust_level,
              last_seen_at = excluded.last_seen_at,
              updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
         params![
@@ -301,31 +283,16 @@ pub(super) fn add_relationship(
 
 pub(super) fn update_projection_meta(
     conn: &Connection,
-    inventory: &HomelabInventory,
     counts: &InventoryGraphStats,
 ) -> Result<()> {
     conn.execute(
         "UPDATE graph_projection_meta
-            SET projection_status = 'ready',
-                last_completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-                source_watermark = ?1,
-                source_row_count = ?2,
-                entity_count = ?3,
-                relationship_count = ?4,
-                evidence_count = ?5,
-                is_degraded = 0,
-                last_error = NULL,
+            SET entity_count = ?1,
+                relationship_count = ?2,
+                evidence_count = ?3,
                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
           WHERE id = 1",
         params![
-            format!("inventory:{}", inventory.run_id),
-            inventory.summary.nodes as i64
-                + inventory.summary.services as i64
-                + inventory.summary.compose_projects as i64
-                + inventory.summary.reverse_proxies as i64
-                + inventory.summary.networks as i64
-                + inventory.summary.storage as i64
-                + inventory.summary.artifacts as i64,
             counts.entity_count,
             counts.relationship_count,
             counts.evidence_count
@@ -336,11 +303,29 @@ pub(super) fn update_projection_meta(
 
 pub(super) fn graph_counts(conn: &Connection) -> Result<InventoryGraphStats> {
     Ok(InventoryGraphStats {
-        source_row_count: 0,
+        source_row_count: conn
+            .query_row(
+                "SELECT source_row_count FROM graph_projection_meta WHERE id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(0),
         entity_count: table_count(conn, "graph_entities")?,
         relationship_count: table_count(conn, "graph_relationships")?,
         evidence_count: table_count(conn, "graph_relationship_evidence")?,
     })
+}
+
+pub(super) fn mark_projection_degraded(conn: &Connection, error: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE graph_projection_meta
+            SET is_degraded = 1,
+                last_error = ?1,
+                updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+          WHERE id = 1",
+        [truncate_excerpt(error)],
+    )?;
+    Ok(())
 }
 
 fn table_count(conn: &Connection, table: &str) -> Result<i64> {
@@ -352,6 +337,7 @@ fn table_count(conn: &Connection, table: &str) -> Result<i64> {
 
 pub(super) fn match_upstream<'a>(
     upstream: &str,
+    source: &str,
     services: &'a BTreeMap<String, EntityRef>,
 ) -> Option<&'a EntityRef> {
     let normalized = canonical_or_raw(upstream);
@@ -360,8 +346,39 @@ pub(super) fn match_upstream<'a>(
         .find(|part| !part.is_empty() && !part.starts_with("http"))
         .map(canonical_or_raw);
     prefix
-        .and_then(|key| services.get(&key))
-        .or_else(|| services.get(&normalized))
+        .and_then(|key| match_service_name(&key, source, services))
+        .or_else(|| match_service_name(&normalized, source, services))
+}
+
+pub(super) fn match_service_name<'a>(
+    name: &str,
+    source: &str,
+    services: &'a BTreeMap<String, EntityRef>,
+) -> Option<&'a EntityRef> {
+    source_host(source)
+        .and_then(|host| services.get(&canonical_or_raw(&format!("{host}:{name}"))))
+        .or_else(|| services.get(&canonical_or_raw(name)))
+}
+
+pub(super) fn scoped_inventory_key(source: &str, name: &str) -> String {
+    let scope = source_host(source).unwrap_or("unknown");
+    canonical_or_raw(&format!("{scope}:{name}"))
+}
+
+pub(super) fn safe_inventory_source_id(source: &str) -> String {
+    match source_host(source) {
+        Some(host) => format!(
+            "{}:{}",
+            source.split(':').next().unwrap_or("inventory").trim(),
+            host
+        ),
+        None => source
+            .split(':')
+            .next()
+            .filter(|collector| !collector.trim().is_empty())
+            .unwrap_or("inventory")
+            .to_string(),
+    }
 }
 
 pub(super) fn service_key(service: &InventoryService) -> String {
@@ -378,6 +395,17 @@ pub(super) fn canonical_or_raw(value: &str) -> String {
 
 pub(super) fn canonical(value: &str) -> Option<String> {
     graph::canonical_graph_key(value)
+}
+
+fn source_host(source: &str) -> Option<&str> {
+    let mut parts = source.split(':');
+    let _collector = parts.next()?;
+    let host = parts.next()?.trim();
+    if host.is_empty() || host.starts_with('/') {
+        None
+    } else {
+        Some(host)
+    }
 }
 
 pub(super) fn trust(value: &TrustLevel) -> &'static str {

--- a/src/db/graph_inventory/sql.rs
+++ b/src/db/graph_inventory/sql.rs
@@ -290,6 +290,14 @@ pub(super) fn update_projection_meta(
             SET entity_count = ?1,
                 relationship_count = ?2,
                 evidence_count = ?3,
+                is_degraded = CASE
+                    WHEN projection_status = 'failed' THEN is_degraded
+                    ELSE 0
+                END,
+                last_error = CASE
+                    WHEN projection_status = 'failed' THEN last_error
+                    ELSE NULL
+                END,
                 updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
           WHERE id = 1",
         params![

--- a/src/db/graph_inventory_tests.rs
+++ b/src/db/graph_inventory_tests.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::config::StorageConfig;
 use crate::db::{graph, init_pool};
 use crate::inventory::schema::{
-    ArtifactRef, ComposeProject, HomelabInventory, InventoryNode, InventoryService, PortMapping,
-    Provenance, RedactionStatus, ReverseProxyRoute, TrustLevel,
+    ArtifactRef, ComposeProject, HomelabInventory, InventoryNode, InventoryService, NetworkSegment,
+    PortMapping, Provenance, RedactionStatus, ReverseProxyRoute, TrustLevel,
 };
 
 fn count(conn: &rusqlite::Connection, sql: &str) -> i64 {
@@ -103,6 +103,7 @@ fn project_inventory_adds_topology_entities_relationships_and_evidence() {
     });
 
     let stats = project_inventory(&pool, &inventory).unwrap();
+    assert_eq!(stats.source_row_count, 0);
     assert!(stats.entity_count >= 6);
     assert!(stats.relationship_count >= 4);
     assert!(stats.evidence_count >= 4);
@@ -136,7 +137,7 @@ fn project_inventory_adds_topology_entities_relationships_and_evidence() {
         count(
             &conn,
             "SELECT COUNT(*) FROM graph_entities
-             WHERE entity_type = 'compose_project' AND canonical_key = 'edge'"
+             WHERE entity_type = 'compose_project' AND canonical_key = 'squirts:edge'"
         ),
         1
     );
@@ -189,5 +190,249 @@ fn project_inventory_adds_topology_entities_relationships_and_evidence() {
              WHERE source_kind IN ('source_inventory', 'app_inventory')"
         ),
         5
+    );
+}
+
+#[test]
+fn project_inventory_preserves_existing_entity_ownership_and_hides_config_paths() {
+    let _guard = graph::GRAPH_TEST_LOCK.lock();
+    let dir = tempfile::tempdir().unwrap();
+    let pool = init_pool(&StorageConfig::for_test(
+        dir.path().join("inventory-graph-ownership.db"),
+    ))
+    .unwrap();
+    let conn = pool.get().unwrap();
+    conn.execute(
+        "INSERT INTO graph_entities
+            (entity_type, canonical_key, display_label, source_kind, source_id, trust_level)
+         VALUES ('host', 'squirts', 'squirts', 'log', '42', 'claimed')",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let mut inventory =
+        HomelabInventory::empty("inv-test".to_string(), "2026-01-01T00:00:00Z".to_string());
+    inventory.nodes.push(InventoryNode {
+        id: "node:squirts".to_string(),
+        hostname: "squirts".to_string(),
+        trust_level: TrustLevel::Observed,
+        provenance: provenance("ssh:squirts", "source_inventory"),
+        roles: Vec::new(),
+        ips: Vec::new(),
+        os: None,
+        cpu: None,
+        memory: None,
+        listeners: Vec::new(),
+        storage: Vec::new(),
+        extras: Default::default(),
+    });
+    inventory.artifact_refs.push(ArtifactRef {
+        id: "artifact:compose:squirts:edge".to_string(),
+        kind: "compose".to_string(),
+        collector: "raw_configs".to_string(),
+        source_host: Some("squirts".to_string()),
+        source_path: Some("/opt/edge/compose.yaml".to_string()),
+        cache_path: "/home/jmagar/.cortex/inventory/raw/inv/edge.txt".to_string(),
+        redaction: RedactionStatus::Redacted,
+        byte_len: 42,
+        truncated: false,
+    });
+    inventory.compose_projects.push(ComposeProject {
+        name: "edge".to_string(),
+        provenance: provenance("compose:squirts:/opt/edge/compose.yaml", "app_inventory"),
+        services: Vec::new(),
+        compose_files: vec!["/opt/edge/compose.yaml".to_string()],
+        domains: Vec::new(),
+        ports: Vec::new(),
+    });
+
+    project_inventory(&pool, &inventory).unwrap();
+    let conn = pool.get().unwrap();
+    let (source_kind, source_id, trust_level): (String, String, String) = conn
+        .query_row(
+            "SELECT source_kind, source_id, trust_level
+               FROM graph_entities
+              WHERE entity_type = 'host' AND canonical_key = 'squirts'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(source_kind, "log");
+    assert_eq!(source_id, "42");
+    assert_eq!(trust_level, "claimed");
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entities
+              WHERE entity_type = 'config_artifact'
+                AND (display_label LIKE '%/opt/%' OR display_label LIKE '%/.cortex/%')"
+        ),
+        0
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entity_aliases
+              WHERE alias_type = 'path'
+                 OR alias_value LIKE '%/opt/%'
+                 OR alias_value LIKE '%/.cortex/%'"
+        ),
+        0
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_relationship_evidence
+              WHERE source_id LIKE '%/opt/%'
+                 OR safe_excerpt LIKE '%/opt/%'"
+        ),
+        0
+    );
+}
+
+#[test]
+fn project_inventory_does_not_route_to_ambiguous_service_name() {
+    let _guard = graph::GRAPH_TEST_LOCK.lock();
+    let dir = tempfile::tempdir().unwrap();
+    let pool = init_pool(&StorageConfig::for_test(
+        dir.path().join("inventory-graph-ambiguous.db"),
+    ))
+    .unwrap();
+    graph::refresh_graph_projection(&pool).unwrap();
+
+    let mut inventory =
+        HomelabInventory::empty("inv-test".to_string(), "2026-01-01T00:00:00Z".to_string());
+    for host in ["squirts", "tootie"] {
+        inventory.nodes.push(InventoryNode {
+            id: format!("node:{host}"),
+            hostname: host.to_string(),
+            trust_level: TrustLevel::Observed,
+            provenance: provenance(&format!("ssh:{host}"), "source_inventory"),
+            roles: Vec::new(),
+            ips: Vec::new(),
+            os: None,
+            cpu: None,
+            memory: None,
+            listeners: Vec::new(),
+            storage: Vec::new(),
+            extras: Default::default(),
+        });
+        inventory.services.push(InventoryService {
+            id: format!("container:{host}:swag"),
+            name: "swag".to_string(),
+            kind: "container".to_string(),
+            trust_level: TrustLevel::Observed,
+            provenance: provenance(&format!("docker:{host}"), "app_inventory"),
+            host: Some(host.to_string()),
+            image: None,
+            status: Some("running".to_string()),
+            domains: Vec::new(),
+            ports: Vec::new(),
+            mounts: Vec::new(),
+            env_keys: Vec::new(),
+            labels: Default::default(),
+        });
+    }
+    inventory.reverse_proxies.push(ReverseProxyRoute {
+        id: "proxy:ambiguous.tootie.tv".to_string(),
+        server_names: vec!["ambiguous.tootie.tv".to_string()],
+        upstreams: vec!["swag:443".to_string()],
+        provenance: provenance("swag:/config/nginx/proxy.conf", "app_inventory"),
+    });
+
+    project_inventory(&pool, &inventory).unwrap();
+    let conn = pool.get().unwrap();
+    assert_eq!(relationship_count(&conn, "runs_on", "inventory_service"), 2);
+    assert_eq!(
+        relationship_count(&conn, "routes_to", "reverse_proxy_config"),
+        0
+    );
+}
+
+#[test]
+fn project_inventory_scopes_compose_projects_and_networks_by_source_host() {
+    let _guard = graph::GRAPH_TEST_LOCK.lock();
+    let dir = tempfile::tempdir().unwrap();
+    let pool = init_pool(&StorageConfig::for_test(
+        dir.path().join("inventory-graph-scoped.db"),
+    ))
+    .unwrap();
+    graph::refresh_graph_projection(&pool).unwrap();
+
+    let mut inventory =
+        HomelabInventory::empty("inv-test".to_string(), "2026-01-01T00:00:00Z".to_string());
+    for host in ["squirts", "tootie"] {
+        inventory.nodes.push(InventoryNode {
+            id: format!("node:{host}"),
+            hostname: host.to_string(),
+            trust_level: TrustLevel::Observed,
+            provenance: provenance(&format!("ssh:{host}"), "source_inventory"),
+            roles: Vec::new(),
+            ips: Vec::new(),
+            os: None,
+            cpu: None,
+            memory: None,
+            listeners: Vec::new(),
+            storage: Vec::new(),
+            extras: Default::default(),
+        });
+        inventory.services.push(InventoryService {
+            id: format!("container:{host}:swag"),
+            name: "swag".to_string(),
+            kind: "container".to_string(),
+            trust_level: TrustLevel::Observed,
+            provenance: provenance(&format!("docker:{host}"), "app_inventory"),
+            host: Some(host.to_string()),
+            image: None,
+            status: Some("running".to_string()),
+            domains: Vec::new(),
+            ports: Vec::new(),
+            mounts: Vec::new(),
+            env_keys: Vec::new(),
+            labels: Default::default(),
+        });
+        inventory.compose_projects.push(ComposeProject {
+            name: "edge".to_string(),
+            provenance: provenance(
+                &format!("compose:{host}:/opt/edge/compose.yaml"),
+                "app_inventory",
+            ),
+            services: vec!["swag".to_string()],
+            compose_files: Vec::new(),
+            domains: Vec::new(),
+            ports: Vec::new(),
+        });
+        inventory.networks.push(NetworkSegment {
+            name: "bridge".to_string(),
+            kind: "docker".to_string(),
+            members: vec!["swag".to_string()],
+            provenance: provenance(&format!("docker:{host}"), "app_inventory"),
+        });
+    }
+
+    project_inventory(&pool, &inventory).unwrap();
+    let conn = pool.get().unwrap();
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entities WHERE entity_type = 'compose_project'"
+        ),
+        2
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entities WHERE entity_type = 'network'"
+        ),
+        2
+    );
+    assert_eq!(
+        relationship_count(&conn, "defines_service", "compose_config"),
+        2
+    );
+    assert_eq!(
+        relationship_count(&conn, "attached_to", "docker_network"),
+        2
     );
 }

--- a/src/db/graph_inventory_tests.rs
+++ b/src/db/graph_inventory_tests.rs
@@ -1,0 +1,193 @@
+use super::*;
+use crate::config::StorageConfig;
+use crate::db::{graph, init_pool};
+use crate::inventory::schema::{
+    ArtifactRef, ComposeProject, HomelabInventory, InventoryNode, InventoryService, PortMapping,
+    Provenance, RedactionStatus, ReverseProxyRoute, TrustLevel,
+};
+
+fn count(conn: &rusqlite::Connection, sql: &str) -> i64 {
+    conn.query_row(sql, [], |row| row.get(0)).unwrap()
+}
+
+fn relationship_count(conn: &rusqlite::Connection, rel_type: &str, reason: &str) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*)
+           FROM graph_relationships r
+           JOIN graph_entities src ON src.id = r.src_entity_id
+           JOIN graph_entities dst ON dst.id = r.dst_entity_id
+          WHERE r.relationship_type = ?1
+            AND r.reason_code = ?2
+            AND src.canonical_key <> ''
+            AND dst.canonical_key <> ''",
+        rusqlite::params![rel_type, reason],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+fn provenance(source: &str, kind: &str) -> Provenance {
+    Provenance::new(source, kind, "2026-01-01T00:00:00Z".to_string())
+}
+
+#[test]
+fn project_inventory_adds_topology_entities_relationships_and_evidence() {
+    let _guard = graph::GRAPH_TEST_LOCK.lock();
+    let dir = tempfile::tempdir().unwrap();
+    let pool = init_pool(&StorageConfig::for_test(
+        dir.path().join("inventory-graph.db"),
+    ))
+    .unwrap();
+    graph::refresh_graph_projection(&pool).unwrap();
+
+    let mut inventory =
+        HomelabInventory::empty("inv-test".to_string(), "2026-01-01T00:00:00Z".to_string());
+    inventory.nodes.push(InventoryNode {
+        id: "node:squirts".to_string(),
+        hostname: "squirts".to_string(),
+        trust_level: TrustLevel::Observed,
+        provenance: provenance("ssh:squirts", "source_inventory"),
+        roles: vec!["edge".to_string()],
+        ips: vec!["10.1.0.8".to_string()],
+        os: Some("Ubuntu".to_string()),
+        cpu: None,
+        memory: None,
+        listeners: Vec::new(),
+        storage: Vec::new(),
+        extras: Default::default(),
+    });
+    inventory.services.push(InventoryService {
+        id: "container:squirts:swag".to_string(),
+        name: "swag".to_string(),
+        kind: "container".to_string(),
+        trust_level: TrustLevel::Observed,
+        provenance: provenance("docker:squirts", "app_inventory"),
+        host: Some("squirts".to_string()),
+        image: Some("lscr.io/linuxserver/swag:latest".to_string()),
+        status: Some("running".to_string()),
+        domains: vec!["example.tootie.tv".to_string()],
+        ports: vec![PortMapping {
+            host_ip: Some("0.0.0.0".to_string()),
+            host_port: Some(443),
+            container_port: Some(443),
+            protocol: "tcp".to_string(),
+        }],
+        mounts: Vec::new(),
+        env_keys: vec!["URL".to_string()],
+        labels: Default::default(),
+    });
+    inventory.compose_projects.push(ComposeProject {
+        name: "edge".to_string(),
+        provenance: provenance("compose:squirts:/opt/edge/compose.yaml", "app_inventory"),
+        services: vec!["swag".to_string()],
+        compose_files: vec!["/opt/edge/compose.yaml".to_string()],
+        domains: vec!["example.tootie.tv".to_string()],
+        ports: Vec::new(),
+    });
+    inventory.reverse_proxies.push(ReverseProxyRoute {
+        id: "proxy:example.tootie.tv".to_string(),
+        server_names: vec!["example.tootie.tv".to_string()],
+        upstreams: vec!["swag:443".to_string()],
+        provenance: provenance("swag:squirts:/config/nginx/proxy.conf", "app_inventory"),
+    });
+    inventory.artifact_refs.push(ArtifactRef {
+        id: "artifact:compose:squirts:edge".to_string(),
+        kind: "compose".to_string(),
+        collector: "raw_configs".to_string(),
+        source_host: Some("squirts".to_string()),
+        source_path: Some("/opt/edge/compose.yaml".to_string()),
+        cache_path: "/home/jmagar/.cortex/inventory/artifacts/edge.yaml".to_string(),
+        redaction: RedactionStatus::Redacted,
+        byte_len: 42,
+        truncated: false,
+    });
+
+    let stats = project_inventory(&pool, &inventory).unwrap();
+    assert!(stats.entity_count >= 6);
+    assert!(stats.relationship_count >= 4);
+    assert!(stats.evidence_count >= 4);
+
+    let conn = pool.get().unwrap();
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entities
+             WHERE entity_type = 'host' AND canonical_key = 'squirts'"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entity_aliases
+             WHERE alias_type = 'ip' AND alias_key = '10.1.0.8'"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entity_aliases
+             WHERE alias_type = 'domain' AND alias_key = 'example.tootie.tv'"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entities
+             WHERE entity_type = 'compose_project' AND canonical_key = 'edge'"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entities
+             WHERE entity_type = 'reverse_proxy' AND canonical_key = 'proxy:example.tootie.tv'"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entities
+             WHERE entity_type = 'domain' AND canonical_key = 'example.tootie.tv'"
+        ),
+        1
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_entities
+             WHERE entity_type = 'config_artifact'
+               AND canonical_key = 'artifact:compose:squirts:edge'"
+        ),
+        1
+    );
+    assert_eq!(relationship_count(&conn, "runs_on", "inventory_service"), 1);
+    assert_eq!(
+        relationship_count(&conn, "defines_service", "compose_config"),
+        1
+    );
+    assert_eq!(
+        relationship_count(&conn, "routes_to", "reverse_proxy_config"),
+        1
+    );
+    assert_eq!(
+        relationship_count(&conn, "exposes_domain", "reverse_proxy_config"),
+        1
+    );
+    assert_eq!(
+        relationship_count(&conn, "has_artifact", "config_artifact"),
+        1
+    );
+    assert_eq!(
+        count(
+            &conn,
+            "SELECT COUNT(*) FROM graph_relationship_evidence
+             WHERE source_kind IN ('source_inventory', 'app_inventory')"
+        ),
+        5
+    );
+}

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -24,7 +24,7 @@ pub fn write_lock() -> parking_lot::ReentrantMutexGuard<'static, ()> {
     WRITE_LOCK.lock()
 }
 
-pub const KNOWN_SCHEMA_VERSION: i64 = 29;
+pub const KNOWN_SCHEMA_VERSION: i64 = 30;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SchemaVersionInfo {
@@ -933,7 +933,9 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
                  id            INTEGER PRIMARY KEY AUTOINCREMENT,
                  entity_type   TEXT NOT NULL CHECK (entity_type IN (
                      'host', 'container', 'service', 'app', 'source_ip',
-                     'ai_project', 'ai_session', 'error_signature'
+                     'ai_project', 'ai_session', 'error_signature',
+                     'compose_project', 'reverse_proxy', 'domain', 'network',
+                     'storage', 'config_artifact'
                  )),
                  canonical_key TEXT NOT NULL,
                  display_label TEXT NOT NULL,
@@ -979,13 +981,18 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
                  dst_entity_id     INTEGER NOT NULL,
                  relationship_type TEXT NOT NULL CHECK (relationship_type IN (
                      'observed_as', 'runs_on', 'emitted_by', 'worked_on',
-                     'matches_signature'
+                     'matches_signature', 'defines_service', 'routes_to',
+                     'exposes_domain', 'attached_to', 'mounts', 'backed_by',
+                     'has_artifact'
                  )),
                  reason_code       TEXT NOT NULL CHECK (reason_code IN (
                      'syslog_claimed_hostname', 'log_app_name',
                      'docker_container_id', 'docker_service_label',
                      'ai_session_project', 'heartbeat_host_state',
-                     'error_signature_match'
+                     'error_signature_match', 'inventory_node',
+                     'inventory_service', 'compose_config',
+                     'reverse_proxy_config', 'docker_network', 'storage_probe',
+                     'config_artifact'
                  )),
                  trust_level       TEXT NOT NULL CHECK (trust_level IN (
                      'verified', 'claimed', 'inferred', 'correlated'
@@ -1020,7 +1027,10 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
                      'syslog_claimed_hostname', 'log_app_name',
                      'docker_container_id', 'docker_service_label',
                      'ai_session_project', 'heartbeat_host_state',
-                     'error_signature_match'
+                     'error_signature_match', 'inventory_node',
+                     'inventory_service', 'compose_config',
+                     'reverse_proxy_config', 'docker_network', 'storage_probe',
+                     'config_artifact'
                  )),
                  reason_text        TEXT,
                  confidence_delta   REAL NOT NULL DEFAULT 0.0 CHECK (confidence_delta >= -1.0 AND confidence_delta <= 1.0),
@@ -1110,6 +1120,162 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
              INSERT OR IGNORE INTO schema_migrations (version) VALUES (29);",
         )?;
         tracing::info!("Migration 29: added covering indexes for error_summary, tail_logs, and ai_session sort");
+    }
+
+    // Migration 30: widen graph vocabulary for homelab inventory topology.
+    //
+    // SQLite CHECK constraints are part of the table definition, so adding
+    // entity/relationship/reason values requires rebuilding the constrained
+    // graph tables. The migration is a strict superset and preserves existing
+    // ids so aliases and evidence references remain valid.
+    if !migration_applied(&conn, 30)? {
+        conn.execute_batch(
+            "BEGIN IMMEDIATE;
+
+             CREATE TABLE graph_entities_new (
+                 id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                 entity_type   TEXT NOT NULL CHECK (entity_type IN (
+                     'host', 'container', 'service', 'app', 'source_ip',
+                     'ai_project', 'ai_session', 'error_signature',
+                     'compose_project', 'reverse_proxy', 'domain', 'network',
+                     'storage', 'config_artifact'
+                 )),
+                 canonical_key TEXT NOT NULL,
+                 display_label TEXT NOT NULL,
+                 source_kind   TEXT NOT NULL DEFAULT '',
+                 source_id     TEXT NOT NULL DEFAULT '',
+                 trust_level   TEXT NOT NULL CHECK (trust_level IN (
+                     'verified', 'claimed', 'inferred', 'correlated'
+                 )),
+                 first_seen_at TEXT,
+                 last_seen_at  TEXT,
+                 created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 UNIQUE(entity_type, canonical_key)
+             );
+             INSERT INTO graph_entities_new
+                 (id, entity_type, canonical_key, display_label, source_kind,
+                  source_id, trust_level, first_seen_at, last_seen_at,
+                  created_at, updated_at)
+             SELECT id, entity_type, canonical_key, display_label, source_kind,
+                    source_id, trust_level, first_seen_at, last_seen_at,
+                    created_at, updated_at
+               FROM graph_entities;
+             DROP TABLE graph_entities;
+             ALTER TABLE graph_entities_new RENAME TO graph_entities;
+             CREATE INDEX idx_graph_entities_type_key
+                 ON graph_entities(entity_type, canonical_key);
+
+             CREATE TABLE graph_relationships_new (
+                 id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                 relationship_key  TEXT NOT NULL UNIQUE,
+                 src_entity_id     INTEGER NOT NULL,
+                 dst_entity_id     INTEGER NOT NULL,
+                 relationship_type TEXT NOT NULL CHECK (relationship_type IN (
+                     'observed_as', 'runs_on', 'emitted_by', 'worked_on',
+                     'matches_signature', 'defines_service', 'routes_to',
+                     'exposes_domain', 'attached_to', 'mounts', 'backed_by',
+                     'has_artifact'
+                 )),
+                 reason_code       TEXT NOT NULL CHECK (reason_code IN (
+                     'syslog_claimed_hostname', 'log_app_name',
+                     'docker_container_id', 'docker_service_label',
+                     'ai_session_project', 'heartbeat_host_state',
+                     'error_signature_match', 'inventory_node',
+                     'inventory_service', 'compose_config',
+                     'reverse_proxy_config', 'docker_network', 'storage_probe',
+                     'config_artifact'
+                 )),
+                 trust_level       TEXT NOT NULL CHECK (trust_level IN (
+                     'verified', 'claimed', 'inferred', 'correlated'
+                 )),
+                 confidence        REAL NOT NULL DEFAULT 0.0 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+                 evidence_count    INTEGER NOT NULL DEFAULT 0 CHECK (evidence_count >= 0),
+                 first_seen_at     TEXT,
+                 last_seen_at      TEXT,
+                 created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 updated_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 UNIQUE(src_entity_id, dst_entity_id, relationship_type, relationship_key)
+             );
+             INSERT INTO graph_relationships_new
+                 (id, relationship_key, src_entity_id, dst_entity_id,
+                  relationship_type, reason_code, trust_level, confidence,
+                  evidence_count, first_seen_at, last_seen_at, created_at,
+                  updated_at)
+             SELECT id, relationship_key, src_entity_id, dst_entity_id,
+                    relationship_type, reason_code, trust_level, confidence,
+                    evidence_count, first_seen_at, last_seen_at, created_at,
+                    updated_at
+               FROM graph_relationships;
+             DROP TABLE graph_relationships;
+             ALTER TABLE graph_relationships_new RENAME TO graph_relationships;
+             CREATE INDEX idx_graph_relationships_src_type_seen
+                 ON graph_relationships(src_entity_id, relationship_type, last_seen_at DESC);
+             CREATE INDEX idx_graph_relationships_dst_type_seen
+                 ON graph_relationships(dst_entity_id, relationship_type, last_seen_at DESC);
+
+             CREATE TABLE graph_relationship_evidence_new (
+                 id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                 relationship_id    INTEGER NOT NULL,
+                 evidence_key       TEXT NOT NULL,
+                 source_kind        TEXT NOT NULL CHECK (source_kind IN (
+                     'log', 'heartbeat', 'ai_session_rollup', 'source_inventory',
+                     'app_inventory', 'error_signature'
+                 )),
+                 source_id          TEXT NOT NULL DEFAULT '',
+                 source_log_id      INTEGER,
+                 source_heartbeat_id INTEGER,
+                 source_signature_hash TEXT,
+                 observed_at        TEXT NOT NULL,
+                 reason_code        TEXT NOT NULL CHECK (reason_code IN (
+                     'syslog_claimed_hostname', 'log_app_name',
+                     'docker_container_id', 'docker_service_label',
+                     'ai_session_project', 'heartbeat_host_state',
+                     'error_signature_match', 'inventory_node',
+                     'inventory_service', 'compose_config',
+                     'reverse_proxy_config', 'docker_network', 'storage_probe',
+                     'config_artifact'
+                 )),
+                 reason_text        TEXT,
+                 confidence_delta   REAL NOT NULL DEFAULT 0.0 CHECK (confidence_delta >= -1.0 AND confidence_delta <= 1.0),
+                 trust_level        TEXT NOT NULL CHECK (trust_level IN (
+                     'verified', 'claimed', 'inferred', 'correlated'
+                 )),
+                 safe_excerpt       TEXT CHECK (safe_excerpt IS NULL OR length(safe_excerpt) <= 512),
+                 metadata_path      TEXT,
+                 evidence_count     INTEGER NOT NULL DEFAULT 1 CHECK (evidence_count >= 1),
+                 created_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 UNIQUE(relationship_id, evidence_key)
+             );
+             INSERT INTO graph_relationship_evidence_new
+                 (id, relationship_id, evidence_key, source_kind, source_id,
+                  source_log_id, source_heartbeat_id, source_signature_hash,
+                  observed_at, reason_code, reason_text, confidence_delta,
+                  trust_level, safe_excerpt, metadata_path, evidence_count,
+                  created_at)
+             SELECT id, relationship_id, evidence_key, source_kind, source_id,
+                    source_log_id, source_heartbeat_id, source_signature_hash,
+                    observed_at, reason_code, reason_text, confidence_delta,
+                    trust_level, safe_excerpt, metadata_path, evidence_count,
+                    created_at
+               FROM graph_relationship_evidence;
+             DROP TABLE graph_relationship_evidence;
+             ALTER TABLE graph_relationship_evidence_new RENAME TO graph_relationship_evidence;
+             CREATE INDEX idx_graph_evidence_relationship_seen
+                 ON graph_relationship_evidence(relationship_id, observed_at DESC);
+             CREATE INDEX idx_graph_evidence_source_ref
+                 ON graph_relationship_evidence(source_kind, source_id);
+             CREATE INDEX idx_graph_evidence_log_id
+                 ON graph_relationship_evidence(source_log_id)
+                 WHERE source_log_id IS NOT NULL;
+             CREATE INDEX idx_graph_evidence_heartbeat_id
+                 ON graph_relationship_evidence(source_heartbeat_id)
+                 WHERE source_heartbeat_id IS NOT NULL;
+
+             INSERT OR IGNORE INTO schema_migrations (version) VALUES (30);
+             COMMIT;",
+        )?;
+        tracing::info!("Migration 30: widened graph vocabulary for inventory topology");
     }
 
     // A server crash/restart mid-check leaves an orphaned 'running' maintenance

--- a/src/db/pool_tests.rs
+++ b/src/db/pool_tests.rs
@@ -685,14 +685,22 @@ fn migration_30_widens_old_graph_constraints_and_preserves_rows() {
         [],
     )
     .unwrap();
+    let relationship_id = conn
+        .query_row(
+            "SELECT id FROM graph_relationships
+              WHERE relationship_key = 'source_ip:10.0.0.1:514->host:claimed-host'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap();
     conn.execute(
         "INSERT INTO graph_relationship_evidence
             (relationship_id, evidence_key, source_kind, source_id, observed_at,
              reason_code, trust_level, safe_excerpt, evidence_count)
-         VALUES (1, 'inventory:route', 'app_inventory', 'proxy:squirts',
+         VALUES (?1, 'inventory:route', 'app_inventory', 'proxy:squirts',
              '2026-01-01T00:00:00Z', 'reverse_proxy_config',
              'verified', 'proxy route', 1)",
-        [],
+        rusqlite::params![relationship_id],
     )
     .unwrap();
 }

--- a/src/db/pool_tests.rs
+++ b/src/db/pool_tests.rs
@@ -360,6 +360,22 @@ fn graph_schema_enforces_vocabulary_and_dedup_keys() {
         [],
     )
     .unwrap();
+    conn.execute(
+        "INSERT INTO graph_entities
+            (entity_type, canonical_key, display_label, source_kind, source_id, trust_level)
+         VALUES ('reverse_proxy', 'proxy:example.tootie.tv', 'example.tootie.tv',
+             'app_inventory', 'proxy:example.tootie.tv', 'verified')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO graph_entities
+            (entity_type, canonical_key, display_label, source_kind, source_id, trust_level)
+         VALUES ('domain', 'example.tootie.tv', 'example.tootie.tv',
+             'app_inventory', 'example.tootie.tv', 'verified')",
+        [],
+    )
+    .unwrap();
     let source_id: i64 = conn
         .query_row(
             "SELECT id FROM graph_entities WHERE entity_type = 'source_ip'",
@@ -370,6 +386,20 @@ fn graph_schema_enforces_vocabulary_and_dedup_keys() {
     let host_id: i64 = conn
         .query_row(
             "SELECT id FROM graph_entities WHERE entity_type = 'host'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let proxy_id: i64 = conn
+        .query_row(
+            "SELECT id FROM graph_entities WHERE entity_type = 'reverse_proxy'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let domain_id: i64 = conn
+        .query_row(
+            "SELECT id FROM graph_entities WHERE entity_type = 'domain'",
             [],
             |row| row.get(0),
         )
@@ -399,6 +429,16 @@ fn graph_schema_enforces_vocabulary_and_dedup_keys() {
         rusqlite::params![source_id, host_id],
     )
     .unwrap();
+    conn.execute(
+        "INSERT INTO graph_relationships
+            (relationship_key, src_entity_id, dst_entity_id, relationship_type,
+             reason_code, trust_level, confidence, evidence_count)
+         VALUES ('reverse_proxy:example.tootie.tv->domain:example.tootie.tv',
+             ?1, ?2, 'exposes_domain', 'reverse_proxy_config',
+             'verified', 0.90, 1)",
+        rusqlite::params![proxy_id, domain_id],
+    )
+    .unwrap();
     let duplicate_rel = conn.execute(
         "INSERT INTO graph_relationships
             (relationship_key, src_entity_id, dst_entity_id, relationship_type,
@@ -419,6 +459,17 @@ fn graph_schema_enforces_vocabulary_and_dedup_keys() {
          VALUES (?1, 'log:1:hostname:2026-01-01T00', 'log', '1',
              '2026-01-01T00:00:00Z', 'syslog_claimed_hostname',
              'claimed', 'claimed-host', 3)",
+        [rel_id],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO graph_relationship_evidence
+            (relationship_id, evidence_key, source_kind, source_id, observed_at,
+             reason_code, trust_level, safe_excerpt, evidence_count)
+         VALUES (?1, 'proxy:example.tootie.tv:route',
+             'app_inventory', 'proxy:example.tootie.tv',
+             '2026-01-01T00:00:00Z', 'reverse_proxy_config',
+             'verified', 'example.tootie.tv routes through proxy config', 1)",
         [rel_id],
     )
     .unwrap();

--- a/src/db/pool_tests.rs
+++ b/src/db/pool_tests.rs
@@ -450,7 +450,12 @@ fn graph_schema_enforces_vocabulary_and_dedup_keys() {
     assert!(duplicate_rel.is_err(), "relationship key must dedupe");
 
     let rel_id: i64 = conn
-        .query_row("SELECT id FROM graph_relationships", [], |row| row.get(0))
+        .query_row(
+            "SELECT id FROM graph_relationships
+             WHERE relationship_key = 'source_ip:10.0.0.1:514->host:claimed-host'",
+            [],
+            |row| row.get(0),
+        )
         .unwrap();
     conn.execute(
         "INSERT INTO graph_relationship_evidence
@@ -462,6 +467,14 @@ fn graph_schema_enforces_vocabulary_and_dedup_keys() {
         [rel_id],
     )
     .unwrap();
+    let proxy_rel_id: i64 = conn
+        .query_row(
+            "SELECT id FROM graph_relationships
+             WHERE relationship_key = 'reverse_proxy:example.tootie.tv->domain:example.tootie.tv'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
     conn.execute(
         "INSERT INTO graph_relationship_evidence
             (relationship_id, evidence_key, source_kind, source_id, observed_at,
@@ -470,7 +483,7 @@ fn graph_schema_enforces_vocabulary_and_dedup_keys() {
              'app_inventory', 'proxy:example.tootie.tv',
              '2026-01-01T00:00:00Z', 'reverse_proxy_config',
              'verified', 'example.tootie.tv routes through proxy config', 1)",
-        [rel_id],
+        [proxy_rel_id],
     )
     .unwrap();
     let duplicate_evidence = conn.execute(
@@ -499,6 +512,189 @@ fn graph_schema_enforces_vocabulary_and_dedup_keys() {
         bad_same_window.is_err(),
         "same_window must not be a persisted v1 relationship type"
     );
+}
+
+#[test]
+fn migration_30_widens_old_graph_constraints_and_preserves_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("graph-migration-30.db");
+    {
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_migrations (
+                 version INTEGER PRIMARY KEY,
+                 applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+             );
+             WITH RECURSIVE versions(version) AS (
+                 SELECT 1 UNION ALL SELECT version + 1 FROM versions WHERE version < 29
+             )
+             INSERT INTO schema_migrations(version) SELECT version FROM versions;
+             CREATE TABLE maintenance_jobs (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 kind TEXT NOT NULL,
+                 status TEXT NOT NULL,
+                 started_at TEXT NOT NULL,
+                 finished_at TEXT,
+                 result_json TEXT
+             );
+             CREATE TABLE graph_entities (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 entity_type TEXT NOT NULL CHECK (entity_type IN (
+                     'host', 'container', 'service', 'app', 'source_ip',
+                     'ai_project', 'ai_session', 'error_signature'
+                 )),
+                 canonical_key TEXT NOT NULL,
+                 display_label TEXT NOT NULL,
+                 source_kind TEXT NOT NULL DEFAULT '',
+                 source_id TEXT NOT NULL DEFAULT '',
+                 trust_level TEXT NOT NULL CHECK (trust_level IN (
+                     'verified', 'claimed', 'inferred', 'correlated'
+                 )),
+                 first_seen_at TEXT,
+                 last_seen_at TEXT,
+                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 UNIQUE(entity_type, canonical_key)
+             );
+             CREATE TABLE graph_entity_aliases (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 entity_id INTEGER NOT NULL,
+                 alias_type TEXT NOT NULL,
+                 alias_key TEXT NOT NULL,
+                 alias_value TEXT NOT NULL,
+                 source_kind TEXT NOT NULL DEFAULT '',
+                 trust_level TEXT NOT NULL CHECK (trust_level IN (
+                     'verified', 'claimed', 'inferred', 'correlated'
+                 )),
+                 first_seen_at TEXT,
+                 last_seen_at TEXT,
+                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 UNIQUE(entity_id, alias_type, alias_key, source_kind)
+             );
+             CREATE TABLE graph_relationships (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 relationship_key TEXT NOT NULL UNIQUE,
+                 src_entity_id INTEGER NOT NULL,
+                 dst_entity_id INTEGER NOT NULL,
+                 relationship_type TEXT NOT NULL CHECK (relationship_type IN (
+                     'observed_as', 'runs_on', 'emitted_by', 'worked_on',
+                     'matches_signature'
+                 )),
+                 reason_code TEXT NOT NULL CHECK (reason_code IN (
+                     'syslog_claimed_hostname', 'log_app_name',
+                     'docker_container_id', 'docker_service_label',
+                     'ai_session_project', 'heartbeat_host_state',
+                     'error_signature_match'
+                 )),
+                 trust_level TEXT NOT NULL CHECK (trust_level IN (
+                     'verified', 'claimed', 'inferred', 'correlated'
+                 )),
+                 confidence REAL NOT NULL DEFAULT 0.0 CHECK (confidence >= 0.0 AND confidence <= 1.0),
+                 evidence_count INTEGER NOT NULL DEFAULT 0 CHECK (evidence_count >= 0),
+                 first_seen_at TEXT,
+                 last_seen_at TEXT,
+                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 UNIQUE(src_entity_id, dst_entity_id, relationship_type, relationship_key)
+             );
+             CREATE TABLE graph_relationship_evidence (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 relationship_id INTEGER NOT NULL,
+                 evidence_key TEXT NOT NULL,
+                 source_kind TEXT NOT NULL CHECK (source_kind IN (
+                     'log', 'heartbeat', 'ai_session_rollup', 'error_signature'
+                 )),
+                 source_id TEXT NOT NULL DEFAULT '',
+                 source_log_id INTEGER,
+                 source_heartbeat_id INTEGER,
+                 source_signature_hash TEXT,
+                 observed_at TEXT NOT NULL,
+                 reason_code TEXT NOT NULL CHECK (reason_code IN (
+                     'syslog_claimed_hostname', 'log_app_name',
+                     'docker_container_id', 'docker_service_label',
+                     'ai_session_project', 'heartbeat_host_state',
+                     'error_signature_match'
+                 )),
+                 reason_text TEXT,
+                 confidence_delta REAL NOT NULL DEFAULT 0.0 CHECK (confidence_delta >= 0.0 AND confidence_delta <= 1.0),
+                 trust_level TEXT NOT NULL CHECK (trust_level IN (
+                     'verified', 'claimed', 'inferred', 'correlated'
+                 )),
+                 safe_excerpt TEXT,
+                 metadata_path TEXT,
+                 evidence_count INTEGER NOT NULL DEFAULT 1 CHECK (evidence_count >= 1),
+                 created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                 UNIQUE(relationship_id, evidence_key)
+             );
+             CREATE TABLE graph_projection_meta (
+                 id INTEGER PRIMARY KEY CHECK (id = 1),
+                 projection_status TEXT NOT NULL DEFAULT 'pending',
+                 last_started_at TEXT,
+                 last_completed_at TEXT,
+                 source_watermark TEXT NOT NULL DEFAULT '',
+                 source_row_count INTEGER NOT NULL DEFAULT 0 CHECK (source_row_count >= 0),
+                 entity_count INTEGER NOT NULL DEFAULT 0 CHECK (entity_count >= 0),
+                 relationship_count INTEGER NOT NULL DEFAULT 0 CHECK (relationship_count >= 0),
+                 evidence_count INTEGER NOT NULL DEFAULT 0 CHECK (evidence_count >= 0),
+                 is_degraded INTEGER NOT NULL DEFAULT 0 CHECK (is_degraded IN (0, 1)),
+                 last_error TEXT,
+                 last_runtime_ms INTEGER NOT NULL DEFAULT 0 CHECK (last_runtime_ms >= 0),
+                 last_chunk_count INTEGER NOT NULL DEFAULT 0 CHECK (last_chunk_count >= 0),
+                 updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+             );
+             INSERT INTO graph_projection_meta(id) VALUES (1);
+             INSERT INTO graph_entities
+                 (id, entity_type, canonical_key, display_label, source_kind, source_id, trust_level)
+             VALUES
+                 (1, 'source_ip', '10.0.0.1:514', '10.0.0.1:514', 'log', '1', 'verified'),
+                 (2, 'host', 'claimed-host', 'claimed-host', 'log', '1', 'claimed');
+             INSERT INTO graph_entity_aliases
+                 (id, entity_id, alias_type, alias_key, alias_value, source_kind, trust_level)
+             VALUES (1, 2, 'hostname', 'claimed-host', 'claimed-host', 'log', 'claimed');
+             INSERT INTO graph_relationships
+                 (id, relationship_key, src_entity_id, dst_entity_id, relationship_type,
+                  reason_code, trust_level, confidence, evidence_count)
+             VALUES (1, 'source_ip:10.0.0.1:514->host:claimed-host', 1, 2,
+                 'observed_as', 'syslog_claimed_hostname', 'claimed', 0.60, 1);
+             INSERT INTO graph_relationship_evidence
+                 (id, relationship_id, evidence_key, source_kind, source_id, observed_at,
+                  reason_code, trust_level, safe_excerpt, evidence_count)
+             VALUES (1, 1, 'log:1:hostname', 'log', '1', '2026-01-01T00:00:00Z',
+                 'syslog_claimed_hostname', 'claimed', 'claimed-host', 1);",
+        )
+        .unwrap();
+    }
+
+    let pool = init_pool(&test_storage_config(db_path)).unwrap();
+    let conn = pool.get().unwrap();
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM graph_relationship_evidence WHERE evidence_key = 'log:1:hostname'",
+            [],
+            |row| row.get::<_, i64>(0)
+        )
+        .unwrap(),
+        1
+    );
+    conn.execute(
+        "INSERT INTO graph_entities
+            (entity_type, canonical_key, display_label, source_kind, source_id, trust_level)
+         VALUES ('compose_project', 'squirts:edge', 'edge',
+             'app_inventory', 'compose:squirts', 'verified')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO graph_relationship_evidence
+            (relationship_id, evidence_key, source_kind, source_id, observed_at,
+             reason_code, trust_level, safe_excerpt, evidence_count)
+         VALUES (1, 'inventory:route', 'app_inventory', 'proxy:squirts',
+             '2026-01-01T00:00:00Z', 'reverse_proxy_config',
+             'verified', 'proxy route', 1)",
+        [],
+    )
+    .unwrap();
 }
 
 #[test]

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -21,6 +21,6 @@ pub mod tailscale;
 pub mod unifi;
 pub mod unraid;
 
-pub use cache::{inventory_status, read_inventory_cache, InventoryCacheStatus};
+pub use cache::{inventory_status, is_not_found_error, read_inventory_cache, InventoryCacheStatus};
 pub use config::InventoryConfig;
 pub use orchestrator::{refresh_inventory, InventoryRefreshReport};

--- a/src/inventory/cache.rs
+++ b/src/inventory/cache.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
+use std::io;
 
 use crate::inventory::config::InventoryConfig;
 use crate::inventory::schema::{CollectionState, HomelabInventory};
@@ -33,6 +34,13 @@ struct InventoryFreshnessMetadata {
 pub fn read_inventory_cache(config: &InventoryConfig) -> Result<HomelabInventory> {
     let paths = InventoryPaths::new(config.root.clone());
     read_json(&paths.normalized_json)
+}
+
+pub fn is_not_found_error(error: &anyhow::Error) -> bool {
+    error
+        .root_cause()
+        .downcast_ref::<io::Error>()
+        .is_some_and(|io_error| io_error.kind() == io::ErrorKind::NotFound)
 }
 
 pub fn inventory_status(config: &InventoryConfig) -> InventoryCacheStatus {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -318,7 +318,7 @@ impl RuntimeCore {
         let notification_dispatcher = self.spawn_notification_dispatcher(token.clone());
         let notification_evaluator = self.spawn_notification_evaluator(token.clone());
         let notification_digest = self.spawn_notification_digest(token.clone());
-        let inventory_refresh = inventory_refresh::spawn(token.clone());
+        let inventory_refresh = inventory_refresh::spawn(token.clone(), Arc::clone(&self.pool));
         let inventory_backfill = self.spawn_inventory_backfill_task(token.clone());
         let session_rollup = self.spawn_session_rollup_task(token.clone());
         let timeline_rollup = self.spawn_timeline_rollup_task(token.clone());

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -318,7 +318,11 @@ impl RuntimeCore {
         let notification_dispatcher = self.spawn_notification_dispatcher(token.clone());
         let notification_evaluator = self.spawn_notification_evaluator(token.clone());
         let notification_digest = self.spawn_notification_digest(token.clone());
-        let inventory_refresh = inventory_refresh::spawn(token.clone(), Arc::clone(&self.pool));
+        let inventory_refresh = inventory_refresh::spawn(
+            token.clone(),
+            Arc::clone(&self.pool),
+            Arc::clone(&self.maintenance_permit),
+        );
         let inventory_backfill = self.spawn_inventory_backfill_task(token.clone());
         let session_rollup = self.spawn_session_rollup_task(token.clone());
         let timeline_rollup = self.spawn_timeline_rollup_task(token.clone());

--- a/src/runtime/inventory_refresh.rs
+++ b/src/runtime/inventory_refresh.rs
@@ -102,10 +102,25 @@ async fn refresh_and_project(pool: &DbPool, maintenance_limiter: &Arc<Semaphore>
                     "inventory_refresh: cache refresh and graph projection complete"
                 ),
                 Err(error) => {
-                    let _ = crate::db::graph_inventory::mark_inventory_projection_failed(
-                        &projection_pool,
-                        &error.to_string(),
-                    );
+                    let projection_error = error.to_string();
+                    let mark_result = tokio::task::spawn_blocking(move || {
+                        crate::db::graph_inventory::mark_inventory_projection_failed(
+                            &projection_pool,
+                            &projection_error,
+                        )
+                    })
+                    .await
+                    .unwrap_or_else(|join_error| {
+                        Err(anyhow::Error::new(join_error)
+                            .context("join projection failure marker task"))
+                    });
+                    if let Err(mark_error) = mark_result {
+                        tracing::error!(
+                            projection_error = %error,
+                            mark_error = %mark_error,
+                            "inventory_refresh: failed to persist projection degraded state"
+                        );
+                    }
                     tracing::warn!(
                         %error,
                         status = %report.status,

--- a/src/runtime/inventory_refresh.rs
+++ b/src/runtime/inventory_refresh.rs
@@ -1,21 +1,39 @@
-use std::time::Instant;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
+use notify::{
+    Config as NotifyConfig, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+
+use crate::db::DbPool;
 
 use super::background_interval;
 
 /// Default cadence for refreshing the private homelab inventory cache consumed
 /// by `cortex map`. Set `CORTEX_INVENTORY_REFRESH_INTERVAL_SECS=0` to disable.
 const INVENTORY_REFRESH_INTERVAL_SECS: u64 = 300;
+const INVENTORY_WATCH_DEBOUNCE_SECS: u64 = 3;
+const REMOTE_DOCKER_EVENT_RECONNECT_SECS: u64 = 10;
 
-pub fn spawn(token: CancellationToken) -> Option<JoinHandle<()>> {
+pub fn spawn(token: CancellationToken, pool: Arc<DbPool>) -> Option<JoinHandle<()>> {
     let interval_secs = inventory_refresh_interval_secs();
     if interval_secs == 0 {
         tracing::info!("inventory_refresh: disabled");
         return None;
     }
     Some(tokio::spawn(async move {
+        let watch_config = crate::inventory::InventoryConfig::from_env();
+        let (watch_tx, mut watch_rx) = mpsc::channel(64);
+        let _watcher = start_config_watcher(&watch_config, watch_tx.clone());
+        let _docker_event_tasks =
+            spawn_remote_docker_event_tasks(&watch_config, watch_tx, token.clone());
         let mut interval = background_interval(tokio::time::Duration::from_secs(interval_secs));
         let mut eager = true;
         loop {
@@ -36,28 +54,201 @@ pub fn spawn(token: CancellationToken) -> Option<JoinHandle<()>> {
                         tracing::debug!("inventory_refresh: cooperative shutdown");
                         break;
                     }
+                    Some(()) = watch_rx.recv() => {
+                        debounce_watch_events(&mut watch_rx).await;
+                    }
                     _ = interval.tick() => {}
                 }
             }
-            let started = Instant::now();
-            match crate::inventory::refresh_inventory(crate::inventory::InventoryConfig::from_env())
-                .await
-            {
-                Ok(report) => tracing::info!(
+            refresh_and_project(&pool).await;
+        }
+    }))
+}
+
+async fn refresh_and_project(pool: &DbPool) {
+    let started = Instant::now();
+    let config = crate::inventory::InventoryConfig::from_env();
+    match crate::inventory::refresh_inventory(config.clone()).await {
+        Ok(report) => {
+            let projection = match crate::inventory::read_inventory_cache(&config) {
+                Ok(inventory) => crate::db::graph_inventory::project_inventory(pool, &inventory),
+                Err(error) => Err(error.context("read inventory cache for graph projection")),
+            };
+            match projection {
+                Ok(stats) => tracing::info!(
+                    status = %report.status,
+                    run_id = %report.run_id,
+                    warnings = report.warnings.len(),
+                    graph_entities = stats.entity_count,
+                    graph_relationships = stats.relationship_count,
+                    graph_evidence = stats.evidence_count,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    "inventory_refresh: cache refresh and graph projection complete"
+                ),
+                Err(error) => tracing::warn!(
+                    %error,
                     status = %report.status,
                     run_id = %report.run_id,
                     warnings = report.warnings.len(),
                     elapsed_ms = started.elapsed().as_millis(),
-                    "inventory_refresh: cache refresh complete"
-                ),
-                Err(error) => tracing::warn!(
-                    %error,
-                    elapsed_ms = started.elapsed().as_millis(),
-                    "inventory_refresh: cache refresh failed"
+                    "inventory_refresh: cache refresh complete but graph projection failed"
                 ),
             }
         }
-    }))
+        Err(error) => tracing::warn!(
+            %error,
+            elapsed_ms = started.elapsed().as_millis(),
+            "inventory_refresh: cache refresh failed"
+        ),
+    }
+}
+
+fn start_config_watcher(
+    config: &crate::inventory::InventoryConfig,
+    trigger: mpsc::Sender<()>,
+) -> Option<RecommendedWatcher> {
+    if !inventory_watch_enabled() {
+        tracing::info!("inventory_refresh: local config watcher disabled");
+        return None;
+    }
+    let targets = watched_config_targets(config);
+    if targets.is_empty() {
+        tracing::debug!("inventory_refresh: no local config paths to watch");
+        return None;
+    }
+    let watch_dirs = watch_directories(&targets);
+    let callback_targets = targets.clone();
+    let mut watcher = match RecommendedWatcher::new(
+        move |event| {
+            if should_refresh_for_event(&event, &callback_targets) {
+                let _ = trigger.try_send(());
+            }
+        },
+        NotifyConfig::default(),
+    ) {
+        Ok(watcher) => watcher,
+        Err(error) => {
+            tracing::warn!(%error, "inventory_refresh: failed to create config watcher");
+            return None;
+        }
+    };
+    let mut watched = 0usize;
+    for dir in watch_dirs {
+        match watcher.watch(&dir, RecursiveMode::NonRecursive) {
+            Ok(()) => watched += 1,
+            Err(error) => tracing::debug!(
+                %error,
+                path = %dir.display(),
+                "inventory_refresh: failed to watch config path"
+            ),
+        }
+    }
+    if watched == 0 {
+        return None;
+    }
+    tracing::info!(watched, "inventory_refresh: local config watcher active");
+    Some(watcher)
+}
+
+async fn debounce_watch_events(rx: &mut mpsc::Receiver<()>) {
+    tokio::time::sleep(tokio::time::Duration::from_secs(
+        INVENTORY_WATCH_DEBOUNCE_SECS,
+    ))
+    .await;
+    while rx.try_recv().is_ok() {}
+}
+
+fn spawn_remote_docker_event_tasks(
+    config: &crate::inventory::InventoryConfig,
+    trigger: mpsc::Sender<()>,
+    token: CancellationToken,
+) -> Vec<JoinHandle<()>> {
+    if !remote_docker_events_enabled() {
+        tracing::info!("inventory_refresh: remote Docker event streams disabled");
+        return Vec::new();
+    }
+    let hosts =
+        crate::inventory::ssh::configured_hosts(config.ssh_config.as_deref(), &config.ssh_hosts);
+    hosts
+        .into_iter()
+        .map(|host| {
+            let ssh_config = config.ssh_config.clone();
+            let trigger = trigger.clone();
+            let token = token.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        biased;
+                        _ = token.cancelled() => break,
+                        result = run_remote_docker_events_once(&host, ssh_config.as_deref(), trigger.clone(), token.clone()) => {
+                            if let Err(error) = result {
+                                tracing::debug!(%error, host = %host, "inventory_refresh: remote Docker events unavailable");
+                            }
+                        }
+                    }
+                    tokio::select! {
+                        biased;
+                        _ = token.cancelled() => break,
+                        _ = tokio::time::sleep(Duration::from_secs(REMOTE_DOCKER_EVENT_RECONNECT_SECS)) => {}
+                    }
+                }
+            })
+        })
+        .collect()
+}
+
+async fn run_remote_docker_events_once(
+    host: &str,
+    ssh_config: Option<&Path>,
+    trigger: mpsc::Sender<()>,
+    token: CancellationToken,
+) -> anyhow::Result<()> {
+    let args = remote_docker_events_ssh_args(ssh_config, host);
+    let mut child = Command::new("ssh")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("ssh stdout unavailable"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("ssh stderr unavailable"))?;
+    let stderr_task = tokio::spawn(async move {
+        let mut reader = BufReader::new(stderr);
+        let mut sink = Vec::new();
+        let _ = reader.read_to_end(&mut sink).await;
+    });
+    let mut lines = BufReader::new(stdout).lines();
+    loop {
+        tokio::select! {
+            biased;
+            _ = token.cancelled() => {
+                let _ = child.kill().await;
+                stderr_task.abort();
+                break;
+            }
+            line = lines.next_line() => match line? {
+                Some(line) if !line.trim().is_empty() => {
+                    let _ = trigger.try_send(());
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+    }
+    let status = child.wait().await?;
+    let _ = stderr_task.await;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("ssh docker events exited with {status}"))
+    }
 }
 
 fn inventory_refresh_interval_secs() -> u64 {
@@ -70,6 +261,101 @@ fn inventory_refresh_interval_secs() -> u64 {
 
 fn parse_inventory_refresh_interval_secs(value: &str) -> Option<u64> {
     value.trim().parse::<u64>().ok()
+}
+
+fn inventory_watch_enabled() -> bool {
+    std::env::var("CORTEX_INVENTORY_WATCH_ENABLED")
+        .ok()
+        .as_deref()
+        .map(|value| {
+            !matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "no"
+            )
+        })
+        .unwrap_or(true)
+}
+
+fn remote_docker_events_enabled() -> bool {
+    std::env::var("CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS")
+        .ok()
+        .as_deref()
+        .map(|value| {
+            !matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "no"
+            )
+        })
+        .unwrap_or(true)
+}
+
+fn remote_docker_events_ssh_args(ssh_config: Option<&Path>, host: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    if let Some(config) = ssh_config {
+        args.push("-F".to_string());
+        args.push(config.display().to_string());
+    }
+    args.extend([
+        "-o".to_string(),
+        "BatchMode=yes".to_string(),
+        "-o".to_string(),
+        "StrictHostKeyChecking=accept-new".to_string(),
+        "-o".to_string(),
+        "ConnectTimeout=4".to_string(),
+        "-o".to_string(),
+        "ServerAliveInterval=15".to_string(),
+        "-o".to_string(),
+        "ServerAliveCountMax=2".to_string(),
+        "--".to_string(),
+        host.to_string(),
+        "docker events --filter type=container --format '{{json .}}'".to_string(),
+    ]);
+    args
+}
+
+fn watched_config_targets(config: &crate::inventory::InventoryConfig) -> Vec<PathBuf> {
+    let mut paths = config.compose_paths.clone();
+    paths.extend(config.proxy_paths.clone());
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn watch_directories(targets: &[PathBuf]) -> Vec<PathBuf> {
+    let mut dirs = targets
+        .iter()
+        .filter_map(|path| {
+            if path.is_dir() {
+                Some(path.clone())
+            } else {
+                path.parent().map(Path::to_path_buf)
+            }
+        })
+        .collect::<Vec<_>>();
+    dirs.sort();
+    dirs.dedup();
+    dirs
+}
+
+fn should_refresh_for_event(event: &notify::Result<Event>, targets: &[PathBuf]) -> bool {
+    let Ok(event) = event else {
+        return false;
+    };
+    if !matches!(
+        event.kind,
+        EventKind::Any | EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    ) {
+        return false;
+    }
+    event.paths.iter().any(|changed| {
+        targets
+            .iter()
+            .any(|target| path_matches_target(changed, target))
+    })
+}
+
+fn path_matches_target(changed: &Path, target: &Path) -> bool {
+    changed == target || target.is_dir() && changed.starts_with(target)
 }
 
 #[cfg(test)]

--- a/src/runtime/inventory_refresh.rs
+++ b/src/runtime/inventory_refresh.rs
@@ -3,12 +3,13 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use notify::{
     Config as NotifyConfig, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+use tokio::io::{self, AsyncBufReadExt, BufReader};
 use tokio::process::Command;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Semaphore};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -22,7 +23,11 @@ const INVENTORY_REFRESH_INTERVAL_SECS: u64 = 300;
 const INVENTORY_WATCH_DEBOUNCE_SECS: u64 = 3;
 const REMOTE_DOCKER_EVENT_RECONNECT_SECS: u64 = 10;
 
-pub fn spawn(token: CancellationToken, pool: Arc<DbPool>) -> Option<JoinHandle<()>> {
+pub fn spawn(
+    token: CancellationToken,
+    pool: Arc<DbPool>,
+    maintenance_limiter: Arc<Semaphore>,
+) -> Option<JoinHandle<()>> {
     let interval_secs = inventory_refresh_interval_secs();
     if interval_secs == 0 {
         tracing::info!("inventory_refresh: disabled");
@@ -60,20 +65,31 @@ pub fn spawn(token: CancellationToken, pool: Arc<DbPool>) -> Option<JoinHandle<(
                     _ = interval.tick() => {}
                 }
             }
-            refresh_and_project(&pool).await;
+            refresh_and_project(&pool, &maintenance_limiter).await;
         }
     }))
 }
 
-async fn refresh_and_project(pool: &DbPool) {
+async fn refresh_and_project(pool: &DbPool, maintenance_limiter: &Arc<Semaphore>) {
     let started = Instant::now();
     let config = crate::inventory::InventoryConfig::from_env();
     match crate::inventory::refresh_inventory(config.clone()).await {
         Ok(report) => {
-            let projection = match crate::inventory::read_inventory_cache(&config) {
-                Ok(inventory) => crate::db::graph_inventory::project_inventory(pool, &inventory),
-                Err(error) => Err(error.context("read inventory cache for graph projection")),
+            let Ok(_permit) = Arc::clone(maintenance_limiter).acquire_owned().await else {
+                tracing::error!("inventory_refresh: maintenance limiter closed");
+                return;
             };
+            let pool = pool.clone();
+            let projection_pool = pool.clone();
+            let projection = tokio::task::spawn_blocking(move || {
+                let inventory = crate::inventory::read_inventory_cache(&config)
+                    .context("read inventory cache for graph projection")?;
+                crate::db::graph_inventory::project_inventory(&pool, &inventory)
+            })
+            .await
+            .unwrap_or_else(|error| {
+                Err(anyhow::Error::new(error).context("join graph projection task"))
+            });
             match projection {
                 Ok(stats) => tracing::info!(
                     status = %report.status,
@@ -85,14 +101,20 @@ async fn refresh_and_project(pool: &DbPool) {
                     elapsed_ms = started.elapsed().as_millis(),
                     "inventory_refresh: cache refresh and graph projection complete"
                 ),
-                Err(error) => tracing::warn!(
-                    %error,
-                    status = %report.status,
-                    run_id = %report.run_id,
-                    warnings = report.warnings.len(),
-                    elapsed_ms = started.elapsed().as_millis(),
-                    "inventory_refresh: cache refresh complete but graph projection failed"
-                ),
+                Err(error) => {
+                    let _ = crate::db::graph_inventory::mark_inventory_projection_failed(
+                        &projection_pool,
+                        &error.to_string(),
+                    );
+                    tracing::warn!(
+                        %error,
+                        status = %report.status,
+                        run_id = %report.run_id,
+                        warnings = report.warnings.len(),
+                        elapsed_ms = started.elapsed().as_millis(),
+                        "inventory_refresh: cache refresh complete but graph projection failed"
+                    );
+                }
             }
         }
         Err(error) => tracing::warn!(
@@ -221,8 +243,7 @@ async fn run_remote_docker_events_once(
         .ok_or_else(|| anyhow::anyhow!("ssh stderr unavailable"))?;
     let stderr_task = tokio::spawn(async move {
         let mut reader = BufReader::new(stderr);
-        let mut sink = Vec::new();
-        let _ = reader.read_to_end(&mut sink).await;
+        let _ = io::copy(&mut reader, &mut io::sink()).await;
     });
     let mut lines = BufReader::new(stdout).lines();
     loop {
@@ -286,7 +307,7 @@ fn remote_docker_events_enabled() -> bool {
                 "0" | "false" | "no"
             )
         })
-        .unwrap_or(true)
+        .unwrap_or(false)
 }
 
 fn remote_docker_events_ssh_args(ssh_config: Option<&Path>, host: &str) -> Vec<String> {

--- a/src/runtime/inventory_refresh_tests.rs
+++ b/src/runtime/inventory_refresh_tests.rs
@@ -6,3 +6,74 @@ fn inventory_refresh_interval_parser_accepts_zero_disable() {
     assert_eq!(parse_inventory_refresh_interval_secs("300"), Some(300));
     assert_eq!(parse_inventory_refresh_interval_secs(" nope "), None);
 }
+
+#[test]
+fn watched_config_targets_include_compose_and_proxy_paths_once() {
+    let mut config = crate::inventory::InventoryConfig::from_env();
+    config.compose_paths = vec![
+        "/opt/edge/compose.yaml".into(),
+        "/opt/edge/compose.yaml".into(),
+    ];
+    config.proxy_paths = vec!["/opt/swag/nginx/site.conf".into()];
+
+    let targets = watched_config_targets(&config);
+
+    assert_eq!(targets.len(), 2);
+    assert!(targets.contains(&"/opt/edge/compose.yaml".into()));
+    assert!(targets.contains(&"/opt/swag/nginx/site.conf".into()));
+}
+
+#[test]
+fn watch_directories_watch_parent_for_files() {
+    let targets = vec![
+        "/opt/edge/compose.yaml".into(),
+        "/opt/swag/nginx/site.conf".into(),
+    ];
+
+    let dirs = watch_directories(&targets);
+
+    assert_eq!(
+        dirs,
+        vec![
+            std::path::PathBuf::from("/opt/edge"),
+            std::path::PathBuf::from("/opt/swag/nginx")
+        ]
+    );
+}
+
+#[test]
+fn should_refresh_for_relevant_config_events_only() {
+    let targets = vec!["/opt/edge/compose.yaml".into()];
+    let changed = notify::Event::new(notify::EventKind::Modify(notify::event::ModifyKind::Data(
+        notify::event::DataChange::Content,
+    )))
+    .add_path("/opt/edge/compose.yaml".into());
+    let access = notify::Event::new(notify::EventKind::Access(notify::event::AccessKind::Open(
+        notify::event::AccessMode::Read,
+    )))
+    .add_path("/opt/edge/compose.yaml".into());
+    let unrelated = notify::Event::new(notify::EventKind::Modify(notify::event::ModifyKind::Data(
+        notify::event::DataChange::Content,
+    )))
+    .add_path("/opt/edge/notes.txt".into());
+
+    assert!(should_refresh_for_event(&Ok(changed), &targets));
+    assert!(!should_refresh_for_event(&Ok(access), &targets));
+    assert!(!should_refresh_for_event(&Ok(unrelated), &targets));
+}
+
+#[test]
+fn remote_docker_events_ssh_args_include_safe_options_and_remote_command() {
+    let args =
+        remote_docker_events_ssh_args(Some(std::path::Path::new("/tmp/ssh_config")), "squirts");
+
+    assert_eq!(args[0], "-F");
+    assert!(args.contains(&"/tmp/ssh_config".to_string()));
+    assert!(args.contains(&"BatchMode=yes".to_string()));
+    assert!(args.contains(&"--".to_string()));
+    assert_eq!(args[args.len() - 2], "squirts");
+    assert_eq!(
+        args[args.len() - 1],
+        "docker events --filter type=container --format '{{json .}}'"
+    );
+}

--- a/src/runtime/inventory_refresh_tests.rs
+++ b/src/runtime/inventory_refresh_tests.rs
@@ -1,10 +1,32 @@
 use super::*;
+use std::sync::{Mutex, OnceLock};
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 #[test]
 fn inventory_refresh_interval_parser_accepts_zero_disable() {
     assert_eq!(parse_inventory_refresh_interval_secs("0"), Some(0));
     assert_eq!(parse_inventory_refresh_interval_secs("300"), Some(300));
     assert_eq!(parse_inventory_refresh_interval_secs(" nope "), None);
+}
+
+#[test]
+fn remote_docker_events_default_to_disabled() {
+    let _guard = env_lock().lock().unwrap();
+    unsafe {
+        std::env::remove_var("CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS");
+    }
+    assert!(!remote_docker_events_enabled());
+    unsafe {
+        std::env::set_var("CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS", "true");
+    }
+    assert!(remote_docker_events_enabled());
+    unsafe {
+        std::env::remove_var("CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- expands graph vocabulary for homelab inventory entities and relationships
- projects normalized homelab inventory into graph entities, relationships, aliases, and evidence
- adds realtime-ish inventory updates with local config watchers and remote Docker event streams over SSH
- documents ~/.cortex inventory cache, refresh toggles, optional API collectors, and map/graph behavior

## Verification
- cargo test project_inventory_adds_topology_entities_relationships_and_evidence
- cargo test graph_schema_enforces_vocabulary_and_dedup_keys
- cargo test inventory_refresh
- cargo fmt --check
- bash scripts/check-version-sync.sh
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- inventory refresh --json
- CORTEX_DB_PATH=/tmp/cortex-inventory-graph-verify.db cargo run -- graph rebuild --json
- mcporter call against temp loopback MCP server: action=map

## Notes
- version bumped to 1.13.0
- follow-up bead syslog-mcp-j9a7 tracks splitting oversized pre-existing graph/schema DB modules while preserving this vocabulary and evidence UX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Projects the homelab inventory cache into the investigation graph with a richer topology model, scoped evidence, and near‑real‑time updates. Preserves graph rebuild health by degrading gracefully on inventory issues and keeping remote Docker events opt‑in.

- **New Features**
  - New graph entities: compose_project, reverse_proxy, domain, network, storage, config_artifact; and relationships: defines_service, routes_to, exposes_domain, attached_to, mounts, backed_by, has_artifact.
  - Server projects inventory into the graph on a 5‑minute cadence, reacts to local Compose/proxy changes, and runs after `graph rebuild`; remote Docker `events` over SSH are opt‑in via `CORTEX_INVENTORY_REMOTE_DOCKER_EVENTS=true`.

- **Bug Fixes**
  - Graph rebuild no longer aborts on inventory cache failures; it reports degraded projection health, clears only stale degradation on success, and distinguishes cache misses from unreadable files.
  - Hardened projection to avoid overwriting log‑derived ownership; scoped Compose project and Docker network keys by host; removed raw paths from labels/aliases/source IDs/evidence; serialized background runs via the maintenance limiter; remote Docker event streams default to disabled.

<sup>Written for commit bcb010387fa3ab00fd42479968ea0ee03ff7424c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homelab inventory caching and automatic projection into the investigation graph.
  * Server-side inventory refresh on a 5-minute baseline, reacting to local config changes and optional remote Docker event streams.
  * Expanded graph vocabulary to represent compose projects, reverse proxies, domains, networks, storage, and config artifacts.
  * Optional media/service collector integrations (Unraid, Unifi, Sonarr, Radarr, Prowlarr, Sabnzbd, qBittorrent, Plex, Tautulli, Overseerr).

* **Bug Fixes**
  * Hardened inventory projection behavior and scoping to reduce ambiguous linkages; remote Docker events remain opt-in.

* **Documentation**
  * Added and clarified environment-variable configuration and refresh/watch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->