### PR TITLE
feat: add topology findings map mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-06-07
+
+### Added
+
+- Added `map` `mode=findings` for bounded topology risk and hygiene findings:
+  `potential_public_route`, `risky_mounts`, and `collector_health`.
+- Added relationship-type graph finding helpers and an index for bounded
+  route/mount proof queries without broad graph scans.
+- Documented findings semantics and redaction boundaries for route, mount, and
+  collector-health evidence.
+
 ## [1.14.2] - 2026-06-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.14.2"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.14.2"
+version = "1.15.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -106,7 +106,16 @@ evidence samples, map follow-up queries, and graph proof queries:
 {"action":"map","mode":"host_services","host":"squirts"}
 {"action":"map","mode":"domain_routes","domain":"adguard.tootie.tv"}
 {"action":"map","mode":"service_dependencies","host":"squirts","service":"swag"}
+{"action":"map","mode":"findings","finding_types":["potential_public_route","risky_mounts","collector_health"]}
 ```
+
+`mode=findings` returns bounded topology risk and hygiene findings derived from
+the graph plus normalized inventory/cache state. Findings include severity,
+confidence, reason code, affected entities, safe evidence IDs/excerpts, and
+remediation hints. They deliberately avoid raw config contents, raw artifact or
+cache paths, credential-bearing upstream URLs, and raw collector warning text;
+`potential_public_route` means configured reverse-proxy routing, not proof of
+unauthenticated public internet exposure.
 
 When the server is running, inventory refresh also projects topology evidence
 into the investigation graph. The baseline refresh interval is 5 minutes, with

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -196,7 +196,7 @@ topology questions backed by the graph projection:
 
 Non-snapshot responses include `graph_answer.answer_status`, bounded `rows`,
 safe evidence samples, map-native `next_queries`, and graph `proof_queries`.
-`mode=findings` instead fills `graph_answer.findings` with Phase 1 topology
+`mode=findings` instead fills `graph_answer.findings` with supported topology
 findings: `potential_public_route`, `risky_mounts`, and `collector_health`.
 These findings use relationship-specific graph proof for configured routes and
 mounts, normalized inventory for mount source/target/read-only detail, and

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -191,10 +191,18 @@ topology questions backed by the graph projection:
 {"action":"map","mode":"host_services","host":"squirts"}
 {"action":"map","mode":"domain_routes","domain":"adguard.tootie.tv"}
 {"action":"map","mode":"service_dependencies","host":"squirts","service":"swag"}
+{"action":"map","mode":"findings","finding_limit":25}
 ```
 
 Non-snapshot responses include `graph_answer.answer_status`, bounded `rows`,
 safe evidence samples, map-native `next_queries`, and graph `proof_queries`.
+`mode=findings` instead fills `graph_answer.findings` with Phase 1 topology
+findings: `potential_public_route`, `risky_mounts`, and `collector_health`.
+These findings use relationship-specific graph proof for configured routes and
+mounts, normalized inventory for mount source/target/read-only detail, and
+cache/collector state for degraded-confidence context. Evidence is intentionally
+safe: no raw config bodies, raw cache paths, credential-bearing upstream URLs,
+raw collector warnings, raw frames, or `metadata_json` are returned.
 
 ## Plugin surfaces
 

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -108,9 +108,16 @@ Required argument: `action = "map"`
 Optional arguments: `host_limit` (default 100, max 500), `section_limit`
 (default 100, max 250), and `include_sections` to restrict top-level sections.
 Use `mode = "host_services"` with `host`, `mode = "domain_routes"` with
-`domain`, or `mode = "service_dependencies"` with `service` or `host` +
-`service` to get a `graph_answer` envelope with answer status, topology rows,
-safe evidence, map follow-ups, and graph proof queries.
+`domain`, `mode = "service_dependencies"` with `service` or `host` +
+`service`, or `mode = "findings"` to get a `graph_answer` envelope with answer
+status, topology rows or findings, safe evidence, map follow-ups, and graph
+proof queries.
+
+`mode = "findings"` supports `finding_limit`, `evidence_per_finding`, and
+`finding_types` (`potential_public_route`, `risky_mounts`, `collector_health`).
+Route findings prove configured reverse-proxy routes only; they do not claim
+unauthenticated internet exposure without separate listener/perimeter evidence.
+Risk and hygiene evidence is bounded and redacted.
 
 ## cortex host_state
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -168,7 +168,7 @@ except Exception:
     sys.exit(1)
 " 2>/dev/null; then
         pass "$label"
-    elif printf '%s\n' "$output" | grep -Eq "^\[mcporter\] MCP error -32602:|requires scope: cortex:__deny__"; then
+    elif printf '%s\n' "$output" | grep -Eq "^\[mcporter\] MCP error -32602:|requires scope: cortex:__deny__|Tool execution failed for action 'correlate'"; then
         pass "$label"
     else
         fail "$label (expected tool isError=true or MCP invalid-params error)"
@@ -418,7 +418,9 @@ assert_eq "map: response structure valid" "$MAP_VALID" "ok"
 # ── sessions ──────────────────────────────────────────────────────────────────
 echo ""
 echo "Action: sessions"
-SESSIONS=$(mcp_call sessions "limit=10" 2>&1)
+# Use a time-windowed query so smoke data seeded directly into SQLite is read
+# live instead of through a periodically refreshed session rollup.
+SESSIONS=$(mcp_call sessions "limit=10" "from=1970-01-01T00:00:00Z" 2>&1)
 assert_no_error "sessions: no error" "$SESSIONS"
 
 SESSIONS_VALID=$(printf '%s\n' "$SESSIONS" | python3 -c "

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -168,7 +168,7 @@ except Exception:
     sys.exit(1)
 " 2>/dev/null; then
         pass "$label"
-    elif printf '%s\n' "$output" | grep -Eq "^\[mcporter\] MCP error -32602:|requires scope: cortex:__deny__|Tool execution failed for action 'correlate'"; then
+    elif printf '%s\n' "$output" | grep -Eq "^\[mcporter\] MCP error -32602:|requires scope: cortex:__deny__|unsupported action|unknown action|notanaction"; then
         pass "$label"
     else
         fail "$label (expected tool isError=true or MCP invalid-params error)"
@@ -414,6 +414,29 @@ assert isinstance(d.get('cortex_overlay'), dict), 'cortex_overlay missing'
 print('ok')
 " 2>/dev/null || echo "error")
 assert_eq "map: response structure valid" "$MAP_VALID" "ok"
+
+MAP_FINDINGS=$(mcp_call map "mode=findings" "finding_limit=5" "evidence_per_finding=1" "finding_types=collector_health" 2>&1)
+assert_no_error "map findings: no error" "$MAP_FINDINGS"
+
+MAP_FINDINGS_VALID=$(printf '%s\n' "$MAP_FINDINGS" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+answer = d.get('graph_answer') or {}
+assert answer.get('mode') == 'findings', 'mode mismatch'
+assert answer.get('answer_status') in ('ok', 'degraded'), 'invalid answer_status'
+assert isinstance(answer.get('findings'), list), 'findings not a list'
+metadata = answer.get('metadata') or {}
+truncation = answer.get('truncation') or {}
+assert metadata.get('limit') == 5, 'finding_limit not reflected'
+assert metadata.get('evidence_sample_limit') == 1, 'evidence_per_finding not reflected'
+assert truncation.get('limit') == 5, 'truncation limit mismatch'
+for finding in answer.get('findings', []):
+    assert finding.get('finding_type') == 'collector_health', 'finding_types subset not honored'
+    assert 'evidence_total' in finding, 'evidence_total missing'
+    assert 'evidence_truncated' in finding, 'evidence_truncated missing'
+print('ok')
+" 2>/dev/null || echo "error")
+assert_eq "map findings: response contract valid" "$MAP_FINDINGS_VALID" "ok"
 
 # ── sessions ──────────────────────────────────────────────────────────────────
 echo ""

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.14.2",
+  "version": "1.15.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.14.2",
+      "identifier": "ghcr.io/jmagar/cortex:v1.15.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,7 @@ pub use correlate::severity_at_or_above;
 pub use error::{ServiceError, ServiceResult};
 pub use incident_findings::{ContributingFactor, FailureMode, IncidentFindings, PreventionHint};
 pub use models::{
+    topology_findings,
     AbuseIncident,
     AbuseMatch,
     AbuseSearchRequest,

--- a/src/app/models/log_query.rs
+++ b/src/app/models/log_query.rs
@@ -5,6 +5,40 @@ use crate::inventory::schema::{
 };
 use std::collections::BTreeMap;
 
+pub mod topology_findings {
+    pub const TYPE_POTENTIAL_PUBLIC_ROUTE: &str = "potential_public_route";
+    pub const TYPE_RISKY_MOUNTS: &str = "risky_mounts";
+    pub const TYPE_COLLECTOR_HEALTH: &str = "collector_health";
+    pub const TYPES: [&str; 3] = [
+        TYPE_POTENTIAL_PUBLIC_ROUTE,
+        TYPE_RISKY_MOUNTS,
+        TYPE_COLLECTOR_HEALTH,
+    ];
+
+    pub const SEVERITY_CRITICAL: &str = "critical";
+    pub const SEVERITY_HIGH: &str = "high";
+    pub const SEVERITY_MEDIUM: &str = "medium";
+    pub const SEVERITY_LOW: &str = "low";
+    pub const SEVERITY_INFO: &str = "info";
+
+    pub mod reason {
+        pub const REVERSE_PROXY_ROUTE_CONFIGURED: &str = "reverse_proxy_route_configured";
+        pub const REVERSE_PROXY_DOMAIN_WITHOUT_TARGET_PROOF: &str =
+            "reverse_proxy_domain_without_target_proof";
+        pub const DOCKER_SOCKET_MOUNT: &str = "docker_socket_mount";
+        pub const HOST_ROOT_MOUNT: &str = "host_root_mount";
+        pub const APPDATA_ROOT_MOUNT: &str = "appdata_root_mount";
+        pub const MOUNT_MISSING_SOURCE_DETAIL: &str = "mount_missing_source_detail";
+        pub const GRAPH_PROJECTION_NOT_READY: &str = "graph_projection_not_ready";
+        pub const INVENTORY_CACHE_MISSING: &str = "inventory_cache_missing";
+        pub const INVENTORY_CACHE_STALE: &str = "inventory_cache_stale";
+        pub const INVENTORY_CACHE_UNREADABLE: &str = "inventory_cache_unreadable";
+        pub const COLLECTION_STATE_UNAVAILABLE: &str = "collection_state_unavailable";
+        pub const COLLECTOR_DEGRADED: &str = "collector_degraded";
+        pub const COLLECTOR_PARTIAL: &str = "collector_partial";
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SearchLogsRequest {
@@ -166,8 +200,8 @@ pub struct HomelabMapRequest {
     pub finding_limit: Option<u32>,
     /// Evidence samples per finding for mode=findings. Default 2, max 5.
     pub evidence_per_finding: Option<u32>,
-    /// Optional finding types for mode=findings. Defaults to all Phase 1
-    /// findings: potential_public_route, risky_mounts, collector_health.
+    /// Optional finding types for mode=findings. Defaults to all supported
+    /// finding types: potential_public_route, risky_mounts, collector_health.
     pub finding_types: Option<Vec<String>>,
 }
 
@@ -272,6 +306,13 @@ pub struct TopologyFinding {
     pub reason_code: String,
     pub affected_entities: Vec<TopologyFindingEntity>,
     pub evidence: Vec<TopologyFindingEvidence>,
+    /// Total safe evidence items available before per-finding and payload
+    /// budget limits were applied.
+    pub evidence_total: usize,
+    /// True when safe evidence was omitted from this finding.
+    pub evidence_truncated: bool,
+    /// Number of safe evidence items omitted from this finding.
+    pub evidence_omitted: usize,
     pub remediation: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub degraded_reason: Option<String>,

--- a/src/app/models/log_query.rs
+++ b/src/app/models/log_query.rs
@@ -3,6 +3,7 @@ use crate::inventory::schema::{
     ArtifactRef, CollectionError, ComposeProject, InventoryFreshness, InventoryService,
     MediaService, NetworkSegment, ProjectRepo, ReverseProxyRoute, StorageSummary,
 };
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -161,6 +162,13 @@ pub struct HomelabMapRequest {
     pub evidence_sample_limit: Option<u32>,
     /// Approximate graph payload budget in bytes. Default 32768, max 65536.
     pub payload_budget: Option<u32>,
+    /// Finding cap for mode=findings. Default 25, max 100.
+    pub finding_limit: Option<u32>,
+    /// Evidence samples per finding for mode=findings. Default 2, max 5.
+    pub evidence_per_finding: Option<u32>,
+    /// Optional finding types for mode=findings. Defaults to all Phase 1
+    /// findings: potential_public_route, risky_mounts, collector_health.
+    pub finding_types: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -200,6 +208,8 @@ pub struct HomelabMapGraphAnswer {
     pub degraded_reason: Option<String>,
     pub next_queries: Vec<HomelabMapNextQuery>,
     pub proof_queries: Vec<HomelabMapProofQuery>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub findings: Vec<TopologyFinding>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -252,6 +262,39 @@ pub struct HomelabMapProofQuery {
     pub entity_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub evidence_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologyFinding {
+    pub finding_type: String,
+    pub severity: String,
+    pub confidence: f64,
+    pub reason_code: String,
+    pub affected_entities: Vec<TopologyFindingEntity>,
+    pub evidence: Vec<TopologyFindingEvidence>,
+    pub remediation: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub degraded_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence_context: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologyFindingEntity {
+    pub entity_type: String,
+    pub key: String,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub details: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologyFindingEvidence {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_id: Option<i64>,
+    pub source_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub safe_excerpt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -39,8 +39,8 @@ use super::models::{
     ProjectContextResponse, RequestActor, SearchLogsRequest, SearchLogsResponse,
     SearchSessionsRequest, SearchSessionsResponse, ServiceJournalEntry, ServiceLogsRequest,
     ServiceLogsResponse, SilentHostsRequest, SilentHostsResponse, SimilarIncidentsRequest,
-    SimilarIncidentsResponse, TailLogsRequest, TimelineRequest, TimelineResponse,
-    UsageBlocksRequest, UsageBlocksResponse,
+    SimilarIncidentsResponse, TailLogsRequest, TimelineRequest, TimelineResponse, TopologyFinding,
+    TopologyFindingEntity, TopologyFindingEvidence, UsageBlocksRequest, UsageBlocksResponse,
 };
 use super::os_adapter::{OsAdapter, SystemOsAdapter};
 use super::time::{parse_optional_timestamp, parse_required_timestamp, rfc3339_z};
@@ -70,6 +70,7 @@ mod logs;
 mod maintenance;
 mod map;
 mod map_answers;
+mod map_findings;
 mod rag;
 
 pub use compose::run_compose_status;

--- a/src/app/services/map.rs
+++ b/src/app/services/map.rs
@@ -253,7 +253,7 @@ impl CortexService {
 fn is_graph_answer_mode(mode: Option<&str>) -> bool {
     matches!(
         mode.map(str::trim),
-        Some("host_services" | "domain_routes" | "service_dependencies")
+        Some("host_services" | "domain_routes" | "service_dependencies" | "findings")
     )
 }
 

--- a/src/app/services/map_answers.rs
+++ b/src/app/services/map_answers.rs
@@ -30,9 +30,12 @@ impl CortexService {
                 "service".to_string(),
                 service_dependency_key(req.host.as_deref(), req.service.as_deref())?,
             ),
+            "findings" => {
+                return self.homelab_map_findings_answer(req).await.map(Some);
+            }
             _ => {
                 return Err(ServiceError::InvalidInput(format!(
-                    "unsupported map mode `{mode}`; expected snapshot, host_services, domain_routes, or service_dependencies"
+                    "unsupported map mode `{mode}`; expected snapshot, host_services, domain_routes, service_dependencies, or findings"
                 )));
             }
         };
@@ -152,6 +155,7 @@ fn map_graph_answer(
         }),
         next_queries,
         proof_queries,
+        findings: Vec::new(),
     }
 }
 

--- a/src/app/services/map_findings.rs
+++ b/src/app/services/map_findings.rs
@@ -1,0 +1,708 @@
+use super::graph_safety::*;
+use super::*;
+use crate::inventory::schema::{CollectionError, HomelabInventory, InventoryService, MountRef};
+use crate::inventory::{
+    inventory_status, read_inventory_cache, InventoryCacheStatus, InventoryConfig,
+};
+use std::collections::{BTreeMap, HashSet};
+
+const FINDING_POTENTIAL_PUBLIC_ROUTE: &str = "potential_public_route";
+const FINDING_RISKY_MOUNTS: &str = "risky_mounts";
+const FINDING_COLLECTOR_HEALTH: &str = "collector_health";
+
+#[derive(Debug, Clone)]
+struct MapFindingContext {
+    inventory: Option<HomelabInventory>,
+    cache_status: InventoryCacheStatus,
+}
+
+impl CortexService {
+    pub(super) async fn homelab_map_findings_answer(
+        &self,
+        req: &HomelabMapRequest,
+    ) -> ServiceResult<HomelabMapGraphAnswer> {
+        let finding_limit = req.finding_limit.unwrap_or(25).clamp(1, 100);
+        let evidence_limit = req.evidence_per_finding.unwrap_or(2).clamp(1, 5) as usize;
+        let requested = RequestedFindingTypes::new(req.finding_types.as_deref())?;
+        let context = read_map_finding_context().await?;
+
+        let db_limit = finding_limit.saturating_mul(4).clamp(1, 400);
+        let (public_routes, mount_relationships, graph_status) = self
+            .run_db("homelab_map_findings", move |pool| {
+                Ok((
+                    db::list_public_route_findings(pool, db_limit)?,
+                    db::list_mount_relationship_findings(pool, db_limit)?,
+                    db::graph::graph_projection_status(pool)?,
+                ))
+            })
+            .await?;
+
+        let mut findings = Vec::new();
+        if requested.includes(FINDING_POTENTIAL_PUBLIC_ROUTE) {
+            findings.extend(public_route_findings(
+                public_routes,
+                evidence_limit,
+                &context,
+                &graph_status,
+            ));
+        }
+        if requested.includes(FINDING_RISKY_MOUNTS) {
+            findings.extend(risky_mount_findings(
+                mount_relationships,
+                evidence_limit,
+                &context,
+                &graph_status,
+            ));
+        }
+        if requested.includes(FINDING_COLLECTOR_HEALTH) {
+            findings.extend(collector_health_findings(&context, evidence_limit));
+        }
+        findings.sort_by_key(finding_sort_key);
+        let truncated = findings.len() > finding_limit as usize;
+        findings.truncate(finding_limit as usize);
+
+        let metadata = GraphResponseMetadata {
+            projection_status: graph_status.projection_status,
+            last_completed_at: graph_status.last_completed_at,
+            source_watermark: graph_status.source_watermark,
+            is_degraded: graph_status.is_degraded || context.cache_status.is_stale,
+            last_error: graph_status.last_error.map(redact_graph_text),
+            limit: finding_limit,
+            depth: 1,
+            truncated,
+            truncated_reason: truncated.then(|| "finding_limit".to_string()),
+            evidence_sample_limit: req.evidence_per_finding.unwrap_or(2).clamp(1, 5),
+            payload_budget: req.payload_budget.unwrap_or(32_768).clamp(4_096, 65_536),
+        };
+
+        let degraded_reason = metadata.is_degraded.then(|| {
+            if context.cache_status.status == "missing" {
+                "inventory_cache_missing".to_string()
+            } else if context.cache_status.is_stale {
+                "inventory_cache_stale".to_string()
+            } else {
+                "graph_degraded".to_string()
+            }
+        });
+        Ok(HomelabMapGraphAnswer {
+            mode: "findings".to_string(),
+            answer_status: "ok".to_string(),
+            target: HomelabMapGraphTarget {
+                entity_type: "topology".to_string(),
+                key: "findings".to_string(),
+            },
+            rows: Vec::new(),
+            candidates: Vec::new(),
+            evidence: Vec::new(),
+            metadata,
+            truncation: HomelabMapAnswerTruncation {
+                truncated,
+                reason: truncated.then(|| "finding_limit".to_string()),
+                limit: finding_limit,
+                evidence_sample_limit: req.evidence_per_finding.unwrap_or(2).clamp(1, 5),
+                payload_budget: req.payload_budget.unwrap_or(32_768).clamp(4_096, 65_536),
+            },
+            degraded_reason,
+            next_queries: finding_next_queries(&findings),
+            proof_queries: finding_proof_queries(&findings),
+            findings,
+        })
+    }
+}
+
+async fn read_map_finding_context() -> ServiceResult<MapFindingContext> {
+    let config = InventoryConfig::from_env();
+    tokio::task::spawn_blocking(move || {
+        let cache_status = inventory_status(&config);
+        let inventory = read_inventory_cache(&config).ok();
+        MapFindingContext {
+            inventory,
+            cache_status,
+        }
+    })
+    .await
+    .map_err(|e| ServiceError::Internal(anyhow::anyhow!("inventory findings read panicked: {e}")))
+}
+
+fn public_route_findings(
+    rows: Vec<db::PublicRouteFindingRow>,
+    evidence_limit: usize,
+    context: &MapFindingContext,
+    graph_status: &db::graph::GraphProjectionStatus,
+) -> Vec<TopologyFinding> {
+    let degraded = route_confidence_context(context, graph_status);
+    rows.into_iter()
+        .map(|row| {
+            let mut affected = vec![
+                entity("domain", &row.domain_key, &row.domain_label),
+                entity("reverse_proxy", &row.proxy_key, &row.proxy_label),
+            ];
+            if let (Some(key), Some(label)) = (&row.service_key, &row.service_label) {
+                affected.push(entity("service", key, label));
+            }
+            let has_route_target = row.service_key.is_some();
+            let confidence = route_confidence(&row, degraded.is_some());
+            TopologyFinding {
+                finding_type: FINDING_POTENTIAL_PUBLIC_ROUTE.to_string(),
+                severity: if has_route_target { "medium" } else { "low" }.to_string(),
+                confidence,
+                reason_code: if has_route_target {
+                    "reverse_proxy_route_configured"
+                } else {
+                    "reverse_proxy_domain_without_target_proof"
+                }
+                .to_string(),
+                affected_entities: affected,
+                evidence: public_route_evidence(&row, evidence_limit),
+                remediation: "Review whether the routed domain should remain reachable through the reverse proxy, and verify proxy authentication/TLS policy separately from topology data.".to_string(),
+                degraded_reason: degraded.clone(),
+                confidence_context: degraded.clone().map(|reason| {
+                    format!("Confidence reduced because {reason}; this finding proves configured routing, not unauthenticated internet exposure.")
+                }).or_else(|| Some("Reverse-proxy graph proof indicates a configured route; listener and perimeter exposure require separate validation.".to_string())),
+            }
+        })
+        .collect()
+}
+
+fn risky_mount_findings(
+    rows: Vec<db::MountRelationshipFindingRow>,
+    evidence_limit: usize,
+    context: &MapFindingContext,
+    graph_status: &db::graph::GraphProjectionStatus,
+) -> Vec<TopologyFinding> {
+    let services = context
+        .inventory
+        .as_ref()
+        .map(service_mount_index)
+        .unwrap_or_default();
+    rows.into_iter()
+        .flat_map(|row| {
+            services
+                .get(&row.service_key)
+                .into_iter()
+                .flat_map(move |mounts| {
+                    mounts
+                        .iter()
+                        .filter(|(_, mount)| mount_target_matches(&row, mount))
+                        .filter_map(|(service, mount)| {
+                            classify_mount(mount).map(|risk| {
+                                risky_mount_finding(
+                                    &row,
+                                    service,
+                                    mount,
+                                    risk,
+                                    graph_status,
+                                    evidence_limit,
+                                )
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn risky_mount_finding(
+    row: &db::MountRelationshipFindingRow,
+    service: &InventoryService,
+    mount: &MountRef,
+    risk: MountRisk,
+    graph_status: &db::graph::GraphProjectionStatus,
+    evidence_limit: usize,
+) -> TopologyFinding {
+    let mut service_entity = entity("service", &row.service_key, &row.service_label);
+    service_entity
+        .details
+        .insert("kind".to_string(), service.kind.clone());
+    if let Some(host) = &service.host {
+        service_entity
+            .details
+            .insert("host".to_string(), host.clone());
+    }
+    let mut mount_entity = entity("storage", &row.storage_key, &row.storage_label);
+    mount_entity.details.insert(
+        "mount_source_kind".to_string(),
+        risk.source_kind.to_string(),
+    );
+    mount_entity
+        .details
+        .insert("mount_target".to_string(), safe_mount_target(&mount.target));
+    mount_entity
+        .details
+        .insert("read_only".to_string(), mount.read_only.to_string());
+    TopologyFinding {
+        finding_type: FINDING_RISKY_MOUNTS.to_string(),
+        severity: risk.severity.to_string(),
+        confidence: mount_confidence(row.confidence, mount.read_only, graph_status.is_degraded),
+        reason_code: risk.reason_code.to_string(),
+        affected_entities: vec![service_entity, mount_entity],
+        evidence: graph_row_evidence(row.evidence_id, row.safe_excerpt.clone(), evidence_limit),
+        remediation: risk.remediation.to_string(),
+        degraded_reason: graph_status
+            .is_degraded
+            .then(|| "graph_projection_degraded".to_string()),
+        confidence_context: Some("Mount source details come from normalized inventory; graph mount relationships provide positive service-to-storage proof.".to_string()),
+    }
+}
+
+fn collector_health_findings(
+    context: &MapFindingContext,
+    evidence_limit: usize,
+) -> Vec<TopologyFinding> {
+    let mut findings = Vec::new();
+    if context.cache_status.status == "missing" || context.inventory.is_none() {
+        findings.push(collector_health_finding(
+            "inventory_cache_missing",
+            "warning",
+            0.95,
+            "inventory_cache",
+            "Inventory cache is unavailable, so absence of topology findings is unknown.",
+            evidence_limit,
+        ));
+    } else if context.cache_status.is_stale {
+        findings.push(collector_health_finding(
+            "inventory_cache_stale",
+            "info",
+            0.90,
+            "inventory_cache",
+            "Inventory cache is stale; findings are based on the last available normalized snapshot.",
+            evidence_limit,
+        ));
+    }
+
+    if let Some(state) = &context.cache_status.collection_state {
+        for collector in &state.collectors {
+            if collector.status == "ok" && collector.warnings.is_empty() {
+                continue;
+            }
+            let severity = if is_core_collector(&collector.name) {
+                "warning"
+            } else {
+                "info"
+            };
+            findings.push(collector_health_finding(
+                "collector_degraded",
+                severity,
+                if is_core_collector(&collector.name) { 0.85 } else { 0.70 },
+                &collector.name,
+                "Collector did not complete cleanly; related topology conclusions have reduced confidence.",
+                evidence_limit,
+            ));
+        }
+    }
+
+    if let Some(inventory) = &context.inventory {
+        for error in &inventory.collection_errors {
+            findings.push(collection_error_finding(error, evidence_limit));
+        }
+    }
+    findings
+}
+
+fn collector_health_finding(
+    reason_code: &str,
+    severity: &str,
+    confidence: f64,
+    collector: &str,
+    context: &str,
+    evidence_limit: usize,
+) -> TopologyFinding {
+    let mut details = BTreeMap::new();
+    details.insert("collector".to_string(), sanitize_token(collector));
+    TopologyFinding {
+        finding_type: FINDING_COLLECTOR_HEALTH.to_string(),
+        severity: severity.to_string(),
+        confidence,
+        reason_code: reason_code.to_string(),
+        affected_entities: vec![TopologyFindingEntity {
+            entity_type: "collector".to_string(),
+            key: sanitize_token(collector),
+            label: sanitize_token(collector),
+            details,
+        }],
+        evidence: bounded_evidence(
+            vec![TopologyFindingEvidence {
+                evidence_id: None,
+                source_kind: "collection_state".to_string(),
+                safe_excerpt: Some(context.to_string()),
+            }],
+            evidence_limit,
+        ),
+        remediation: "Refresh inventory collection and inspect collector-specific logs before treating missing topology as absence.".to_string(),
+        degraded_reason: Some(reason_code.to_string()),
+        confidence_context: Some(context.to_string()),
+    }
+}
+
+fn collection_error_finding(error: &CollectionError, evidence_limit: usize) -> TopologyFinding {
+    let severity = if is_core_collector(&error.collector) {
+        "warning"
+    } else {
+        "info"
+    };
+    let mut details = BTreeMap::new();
+    details.insert("collector".to_string(), sanitize_token(&error.collector));
+    details.insert("phase".to_string(), sanitize_token(&error.phase));
+    details.insert("truncated".to_string(), error.truncated.to_string());
+    TopologyFinding {
+        finding_type: FINDING_COLLECTOR_HEALTH.to_string(),
+        severity: severity.to_string(),
+        confidence: if is_core_collector(&error.collector) { 0.85 } else { 0.65 },
+        reason_code: "collector_partial".to_string(),
+        affected_entities: vec![TopologyFindingEntity {
+            entity_type: "collector".to_string(),
+            key: sanitize_token(&error.collector),
+            label: sanitize_token(&error.collector),
+            details,
+        }],
+        evidence: bounded_evidence(
+            vec![TopologyFindingEvidence {
+                evidence_id: None,
+                source_kind: "collection_error".to_string(),
+                safe_excerpt: Some(format!(
+                    "{} collector reported a {} during {}",
+                    sanitize_token(&error.collector),
+                    sanitize_token(&error.severity),
+                    sanitize_token(&error.phase)
+                )),
+            }],
+            evidence_limit,
+        ),
+        remediation: "Refresh or repair the collector, then rebuild the graph projection before relying on absence-oriented topology conclusions.".to_string(),
+        degraded_reason: Some("collector_partial".to_string()),
+        confidence_context: Some("Raw warning text is intentionally withheld; collector class and phase are enough to scope follow-up.".to_string()),
+    }
+}
+
+fn service_mount_index(
+    inventory: &HomelabInventory,
+) -> BTreeMap<String, Vec<(&InventoryService, &MountRef)>> {
+    let mut services = BTreeMap::new();
+    for service in &inventory.services {
+        let Some(host) = service.host.as_deref() else {
+            continue;
+        };
+        let key = canonical_service_key(host, &service.name);
+        services.insert(
+            key,
+            service
+                .mounts
+                .iter()
+                .map(|mount| (service, mount))
+                .collect::<Vec<_>>(),
+        );
+    }
+    services
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MountRisk {
+    severity: &'static str,
+    reason_code: &'static str,
+    source_kind: &'static str,
+    remediation: &'static str,
+}
+
+fn classify_mount(mount: &MountRef) -> Option<MountRisk> {
+    let source = mount.source.as_deref().unwrap_or_default();
+    let target = mount.target.as_str();
+    if source == "/var/run/docker.sock" || target == "/var/run/docker.sock" {
+        return Some(MountRisk {
+            severity: if mount.read_only { "medium" } else { "high" },
+            reason_code: "docker_socket_mount",
+            source_kind: "docker_socket",
+            remediation: "Review whether this service needs Docker daemon access; prefer a narrow proxy or read-only control path when possible.",
+        });
+    }
+    if source == "/" {
+        return Some(MountRisk {
+            severity: if mount.read_only { "medium" } else { "high" },
+            reason_code: "host_root_mount",
+            source_kind: "host_root",
+            remediation: "Replace host-root binds with the smallest required host path and keep the mount read-only when writes are not required.",
+        });
+    }
+    if source.contains("/appdata")
+        || target.contains("/appdata")
+        || source.starts_with("/mnt/user/appdata")
+    {
+        return Some(MountRisk {
+            severity: if mount.read_only { "low" } else { "medium" },
+            reason_code: "appdata_root_mount",
+            source_kind: "appdata_root",
+            remediation: "Scope appdata binds to the service-specific directory and keep secrets outside broadly shared mounts.",
+        });
+    }
+    if mount.source.is_none() {
+        return Some(MountRisk {
+            severity: "low",
+            reason_code: "mount_missing_source_detail",
+            source_kind: "unknown_source",
+            remediation: "Refresh Docker or compose inventory so mount source details can be classified before making risk decisions.",
+        });
+    }
+    None
+}
+
+fn mount_target_matches(row: &db::MountRelationshipFindingRow, mount: &MountRef) -> bool {
+    row.storage_label == mount.target
+        || row
+            .storage_key
+            .ends_with(&canonical_component(&mount.target))
+}
+
+fn route_confidence(row: &db::PublicRouteFindingRow, degraded: bool) -> f64 {
+    let mut confidence = row
+        .routes_confidence
+        .map(|route| row.exposes_confidence.min(route))
+        .unwrap_or(row.exposes_confidence * 0.75);
+    if degraded {
+        confidence *= 0.8;
+    }
+    confidence.clamp(0.0, 1.0)
+}
+
+fn mount_confidence(confidence: f64, read_only: bool, graph_degraded: bool) -> f64 {
+    let mut value = confidence.max(0.70);
+    if read_only {
+        value *= 0.9;
+    }
+    if graph_degraded {
+        value *= 0.8;
+    }
+    value.clamp(0.0, 1.0)
+}
+
+fn route_confidence_context(
+    context: &MapFindingContext,
+    graph_status: &db::graph::GraphProjectionStatus,
+) -> Option<String> {
+    if graph_status.is_degraded {
+        Some("graph_projection_degraded".to_string())
+    } else if context.cache_status.is_stale {
+        Some("inventory_cache_stale".to_string())
+    } else if context.inventory.as_ref().is_some_and(|inventory| {
+        inventory
+            .collection_errors
+            .iter()
+            .any(|e| is_core_collector(&e.collector))
+    }) {
+        Some("core_collector_partial".to_string())
+    } else {
+        None
+    }
+}
+
+fn public_route_evidence(
+    row: &db::PublicRouteFindingRow,
+    evidence_limit: usize,
+) -> Vec<TopologyFindingEvidence> {
+    bounded_evidence(
+        vec![
+            TopologyFindingEvidence {
+                evidence_id: row.exposes_evidence_id,
+                source_kind: "app_inventory".to_string(),
+                safe_excerpt: row.exposes_excerpt.clone().map(redact_graph_text),
+            },
+            TopologyFindingEvidence {
+                evidence_id: row.routes_evidence_id,
+                source_kind: "app_inventory".to_string(),
+                safe_excerpt: row.routes_excerpt.clone().map(redact_graph_text),
+            },
+        ],
+        evidence_limit,
+    )
+}
+
+fn graph_row_evidence(
+    evidence_id: Option<i64>,
+    safe_excerpt: Option<String>,
+    evidence_limit: usize,
+) -> Vec<TopologyFindingEvidence> {
+    bounded_evidence(
+        vec![TopologyFindingEvidence {
+            evidence_id,
+            source_kind: "app_inventory".to_string(),
+            safe_excerpt: safe_excerpt.map(redact_graph_text),
+        }],
+        evidence_limit,
+    )
+}
+
+fn bounded_evidence(
+    evidence: Vec<TopologyFindingEvidence>,
+    limit: usize,
+) -> Vec<TopologyFindingEvidence> {
+    evidence
+        .into_iter()
+        .filter(|item| item.evidence_id.is_some() || item.safe_excerpt.is_some())
+        .take(limit)
+        .collect()
+}
+
+fn entity(entity_type: &str, key: &str, label: &str) -> TopologyFindingEntity {
+    TopologyFindingEntity {
+        entity_type: entity_type.to_string(),
+        key: key.to_string(),
+        label: label.to_string(),
+        details: BTreeMap::new(),
+    }
+}
+
+fn finding_next_queries(findings: &[TopologyFinding]) -> Vec<HomelabMapNextQuery> {
+    let mut seen = HashSet::new();
+    findings
+        .iter()
+        .flat_map(|finding| &finding.affected_entities)
+        .filter_map(|entity| match entity.entity_type.as_str() {
+            "domain" => Some(HomelabMapNextQuery {
+                action: "map".to_string(),
+                mode: "domain_routes".to_string(),
+                reason: "Inspect route proof for this finding domain".to_string(),
+                host: None,
+                domain: Some(entity.key.clone()),
+                service: None,
+            }),
+            "service" => Some(HomelabMapNextQuery {
+                action: "map".to_string(),
+                mode: "service_dependencies".to_string(),
+                reason: "Inspect service dependencies for this finding service".to_string(),
+                host: None,
+                domain: None,
+                service: Some(entity.key.clone()),
+            }),
+            _ => None,
+        })
+        .filter(|query| {
+            seen.insert(format!(
+                "{}:{:?}:{:?}",
+                query.mode, query.domain, query.service
+            ))
+        })
+        .take(10)
+        .collect()
+}
+
+fn finding_proof_queries(findings: &[TopologyFinding]) -> Vec<HomelabMapProofQuery> {
+    let mut seen = HashSet::new();
+    findings
+        .iter()
+        .flat_map(|finding| &finding.evidence)
+        .filter_map(|evidence| evidence.evidence_id)
+        .filter(|id| seen.insert(*id))
+        .take(10)
+        .map(|id| HomelabMapProofQuery {
+            action: "graph".to_string(),
+            mode: "evidence".to_string(),
+            label: "Inspect finding evidence".to_string(),
+            entity_id: None,
+            evidence_id: Some(id),
+        })
+        .collect()
+}
+
+fn finding_sort_key(finding: &TopologyFinding) -> (u8, std::cmp::Reverse<i64>, String) {
+    (
+        severity_rank(&finding.severity),
+        std::cmp::Reverse((finding.confidence * 1000.0) as i64),
+        finding.finding_type.clone(),
+    )
+}
+
+fn severity_rank(severity: &str) -> u8 {
+    match severity {
+        "critical" => 0,
+        "high" => 1,
+        "medium" | "warning" => 2,
+        "low" => 3,
+        "info" => 4,
+        _ => 5,
+    }
+}
+
+fn canonical_service_key(host: &str, name: &str) -> String {
+    format!(
+        "{}:{}",
+        canonical_component(host),
+        canonical_component(name)
+    )
+}
+
+fn canonical_component(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
+fn safe_mount_target(target: &str) -> String {
+    match target {
+        "/var/run/docker.sock" => "/var/run/docker.sock".to_string(),
+        "/" => "/".to_string(),
+        value if value.contains("/appdata") => "appdata_path".to_string(),
+        value if value.starts_with('/') => value.to_string(),
+        _ => "relative_mount_target".to_string(),
+    }
+}
+
+fn sanitize_token(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('_')
+        .to_string()
+}
+
+fn is_core_collector(name: &str) -> bool {
+    matches!(
+        name,
+        "raw_configs" | "docker" | "remote_docker" | "reverse_proxy" | "compose"
+    )
+}
+
+struct RequestedFindingTypes {
+    values: HashSet<String>,
+}
+
+impl RequestedFindingTypes {
+    fn new(values: Option<&[String]>) -> ServiceResult<Self> {
+        let values = values
+            .map(|values| {
+                values
+                    .iter()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|values| !values.is_empty())
+            .unwrap_or_else(|| {
+                vec![
+                    FINDING_POTENTIAL_PUBLIC_ROUTE.to_string(),
+                    FINDING_RISKY_MOUNTS.to_string(),
+                    FINDING_COLLECTOR_HEALTH.to_string(),
+                ]
+            });
+        for value in &values {
+            if !matches!(
+                value.as_str(),
+                FINDING_POTENTIAL_PUBLIC_ROUTE | FINDING_RISKY_MOUNTS | FINDING_COLLECTOR_HEALTH
+            ) {
+                return Err(ServiceError::InvalidInput(format!(
+                    "unsupported finding type `{value}`; expected potential_public_route, risky_mounts, or collector_health"
+                )));
+            }
+        }
+        Ok(Self {
+            values: values.into_iter().collect(),
+        })
+    }
+
+    fn includes(&self, value: &str) -> bool {
+        self.values.contains(value)
+    }
+}

--- a/src/app/services/map_findings.rs
+++ b/src/app/services/map_findings.rs
@@ -1,19 +1,50 @@
 use super::graph_safety::*;
 use super::*;
+use crate::app::topology_findings as finding_const;
+use crate::app::topology_findings::reason as reason_const;
 use crate::inventory::schema::{CollectionError, HomelabInventory, InventoryService, MountRef};
 use crate::inventory::{
-    inventory_status, read_inventory_cache, InventoryCacheStatus, InventoryConfig,
+    inventory_status, is_not_found_error, read_inventory_cache, InventoryCacheStatus,
+    InventoryConfig,
 };
 use std::collections::{BTreeMap, HashSet};
-
-const FINDING_POTENTIAL_PUBLIC_ROUTE: &str = "potential_public_route";
-const FINDING_RISKY_MOUNTS: &str = "risky_mounts";
-const FINDING_COLLECTOR_HEALTH: &str = "collector_health";
 
 #[derive(Debug, Clone)]
 struct MapFindingContext {
     inventory: Option<HomelabInventory>,
+    inventory_read_issue: Option<InventoryReadIssue>,
     cache_status: InventoryCacheStatus,
+}
+
+#[derive(Debug, Clone)]
+enum InventoryReadIssue {
+    NotFound,
+    Unreadable,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FindingLimits {
+    finding_limit: u32,
+    evidence_limit: usize,
+    payload_budget: u32,
+}
+
+impl FindingLimits {
+    fn from_request(req: &HomelabMapRequest) -> Self {
+        Self {
+            finding_limit: req.finding_limit.unwrap_or(25).clamp(1, 100),
+            evidence_limit: req.evidence_per_finding.unwrap_or(2).clamp(1, 5) as usize,
+            payload_budget: req.payload_budget.unwrap_or(32_768).clamp(4_096, 65_536),
+        }
+    }
+
+    fn db_limit(self) -> u32 {
+        self.finding_limit.saturating_mul(4).clamp(1, 400)
+    }
+
+    fn evidence_sample_limit(self) -> u32 {
+        self.evidence_limit as u32
+    }
 }
 
 impl CortexService {
@@ -21,12 +52,11 @@ impl CortexService {
         &self,
         req: &HomelabMapRequest,
     ) -> ServiceResult<HomelabMapGraphAnswer> {
-        let finding_limit = req.finding_limit.unwrap_or(25).clamp(1, 100);
-        let evidence_limit = req.evidence_per_finding.unwrap_or(2).clamp(1, 5) as usize;
+        let limits = FindingLimits::from_request(req);
         let requested = RequestedFindingTypes::new(req.finding_types.as_deref())?;
         let context = read_map_finding_context().await?;
 
-        let db_limit = finding_limit.saturating_mul(4).clamp(1, 400);
+        let db_limit = limits.db_limit();
         let (public_routes, mount_relationships, graph_status) = self
             .run_db("homelab_map_findings", move |pool| {
                 Ok((
@@ -38,55 +68,89 @@ impl CortexService {
             .await?;
 
         let mut findings = Vec::new();
-        if requested.includes(FINDING_POTENTIAL_PUBLIC_ROUTE) {
+        if let Some(finding) = graph_projection_health_finding(&graph_status, limits.evidence_limit)
+        {
+            findings.push(finding);
+        }
+        if requested.includes(finding_const::TYPE_POTENTIAL_PUBLIC_ROUTE) {
             findings.extend(public_route_findings(
                 public_routes,
-                evidence_limit,
+                limits.evidence_limit,
                 &context,
                 &graph_status,
             ));
         }
-        if requested.includes(FINDING_RISKY_MOUNTS) {
+        if requested.includes(finding_const::TYPE_RISKY_MOUNTS) {
             findings.extend(risky_mount_findings(
                 mount_relationships,
-                evidence_limit,
+                limits.evidence_limit,
                 &context,
                 &graph_status,
             ));
         }
-        if requested.includes(FINDING_COLLECTOR_HEALTH) {
-            findings.extend(collector_health_findings(&context, evidence_limit));
+        if requested.includes(finding_const::TYPE_COLLECTOR_HEALTH) {
+            findings.extend(collector_health_findings(&context, limits.evidence_limit));
         }
         findings.sort_by_key(finding_sort_key);
-        let truncated = findings.len() > finding_limit as usize;
-        findings.truncate(finding_limit as usize);
+        let mut truncated = findings.len() > limits.finding_limit as usize;
+        if truncated {
+            findings.truncate(limits.finding_limit as usize);
+        }
+        let mut truncated_reason = truncated.then(|| "finding_limit".to_string());
+        if apply_findings_payload_budget(&mut findings, limits.payload_budget) {
+            truncated = true;
+            truncated_reason = Some("payload_budget".to_string());
+        }
+
+        let projection_not_ready = graph_projection_not_ready(&graph_status);
+        let context_degraded = projection_not_ready
+            || graph_status.is_degraded
+            || context.cache_status.is_stale
+            || context.inventory_read_issue.is_some()
+            || has_core_collector_degradation(&context);
 
         let metadata = GraphResponseMetadata {
             projection_status: graph_status.projection_status,
             last_completed_at: graph_status.last_completed_at,
             source_watermark: graph_status.source_watermark,
-            is_degraded: graph_status.is_degraded || context.cache_status.is_stale,
+            is_degraded: context_degraded,
             last_error: graph_status.last_error.map(redact_graph_text),
-            limit: finding_limit,
+            limit: limits.finding_limit,
             depth: 1,
             truncated,
-            truncated_reason: truncated.then(|| "finding_limit".to_string()),
-            evidence_sample_limit: req.evidence_per_finding.unwrap_or(2).clamp(1, 5),
-            payload_budget: req.payload_budget.unwrap_or(32_768).clamp(4_096, 65_536),
+            truncated_reason: truncated_reason.clone(),
+            evidence_sample_limit: limits.evidence_sample_limit(),
+            payload_budget: limits.payload_budget,
         };
 
+        let answer_status = if metadata.is_degraded {
+            "degraded"
+        } else {
+            "ok"
+        }
+        .to_string();
         let degraded_reason = metadata.is_degraded.then(|| {
-            if context.cache_status.status == "missing" {
-                "inventory_cache_missing".to_string()
+            if projection_not_ready {
+                reason_const::GRAPH_PROJECTION_NOT_READY.to_string()
+            } else if context.inventory_read_issue.is_some() {
+                match context.inventory_read_issue {
+                    Some(InventoryReadIssue::NotFound) => {
+                        reason_const::INVENTORY_CACHE_MISSING.to_string()
+                    }
+                    Some(InventoryReadIssue::Unreadable) => {
+                        reason_const::INVENTORY_CACHE_UNREADABLE.to_string()
+                    }
+                    None => "inventory_context_unavailable".to_string(),
+                }
             } else if context.cache_status.is_stale {
-                "inventory_cache_stale".to_string()
+                reason_const::INVENTORY_CACHE_STALE.to_string()
             } else {
                 "graph_degraded".to_string()
             }
         });
         Ok(HomelabMapGraphAnswer {
             mode: "findings".to_string(),
-            answer_status: "ok".to_string(),
+            answer_status,
             target: HomelabMapGraphTarget {
                 entity_type: "topology".to_string(),
                 key: "findings".to_string(),
@@ -97,10 +161,10 @@ impl CortexService {
             metadata,
             truncation: HomelabMapAnswerTruncation {
                 truncated,
-                reason: truncated.then(|| "finding_limit".to_string()),
-                limit: finding_limit,
-                evidence_sample_limit: req.evidence_per_finding.unwrap_or(2).clamp(1, 5),
-                payload_budget: req.payload_budget.unwrap_or(32_768).clamp(4_096, 65_536),
+                reason: truncated_reason,
+                limit: limits.finding_limit,
+                evidence_sample_limit: limits.evidence_sample_limit(),
+                payload_budget: limits.payload_budget,
             },
             degraded_reason,
             next_queries: finding_next_queries(&findings),
@@ -114,9 +178,14 @@ async fn read_map_finding_context() -> ServiceResult<MapFindingContext> {
     let config = InventoryConfig::from_env();
     tokio::task::spawn_blocking(move || {
         let cache_status = inventory_status(&config);
-        let inventory = read_inventory_cache(&config).ok();
+        let (inventory, inventory_read_issue) = match read_inventory_cache(&config) {
+            Ok(inventory) => (Some(inventory), None),
+            Err(error) if is_not_found_error(&error) => (None, Some(InventoryReadIssue::NotFound)),
+            Err(_) => (None, Some(InventoryReadIssue::Unreadable)),
+        };
         MapFindingContext {
             inventory,
+            inventory_read_issue,
             cache_status,
         }
     })
@@ -142,18 +211,27 @@ fn public_route_findings(
             }
             let has_route_target = row.service_key.is_some();
             let confidence = route_confidence(&row, degraded.is_some());
+            let evidence = public_route_evidence(&row, evidence_limit);
             TopologyFinding {
-                finding_type: FINDING_POTENTIAL_PUBLIC_ROUTE.to_string(),
-                severity: if has_route_target { "medium" } else { "low" }.to_string(),
+                finding_type: finding_const::TYPE_POTENTIAL_PUBLIC_ROUTE.to_string(),
+                severity: if has_route_target {
+                    finding_const::SEVERITY_MEDIUM
+                } else {
+                    finding_const::SEVERITY_LOW
+                }
+                .to_string(),
                 confidence,
                 reason_code: if has_route_target {
-                    "reverse_proxy_route_configured"
+                    reason_const::REVERSE_PROXY_ROUTE_CONFIGURED
                 } else {
-                    "reverse_proxy_domain_without_target_proof"
+                    reason_const::REVERSE_PROXY_DOMAIN_WITHOUT_TARGET_PROOF
                 }
                 .to_string(),
                 affected_entities: affected,
-                evidence: public_route_evidence(&row, evidence_limit),
+                evidence: evidence.items,
+                evidence_total: evidence.total,
+                evidence_truncated: evidence.truncated,
+                evidence_omitted: evidence.omitted,
                 remediation: "Review whether the routed domain should remain reachable through the reverse proxy, and verify proxy authentication/TLS policy separately from topology data.".to_string(),
                 degraded_reason: degraded.clone(),
                 confidence_context: degraded.clone().map(|reason| {
@@ -175,32 +253,28 @@ fn risky_mount_findings(
         .as_ref()
         .map(service_mount_index)
         .unwrap_or_default();
-    rows.into_iter()
-        .flat_map(|row| {
-            services
-                .get(&row.service_key)
-                .into_iter()
-                .flat_map(move |mounts| {
-                    mounts
-                        .iter()
-                        .filter(|(_, mount)| mount_target_matches(&row, mount))
-                        .filter_map(|(service, mount)| {
-                            classify_mount(mount).map(|risk| {
-                                risky_mount_finding(
-                                    &row,
-                                    service,
-                                    mount,
-                                    risk,
-                                    graph_status,
-                                    evidence_limit,
-                                )
-                            })
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect()
+    let mut findings = Vec::new();
+    for row in rows {
+        let Some(mounts) = services.get(&row.service_key) else {
+            continue;
+        };
+        for (service, mount) in mounts {
+            if !mount_target_matches(&row, mount) {
+                continue;
+            }
+            if let Some(risk) = classify_mount(mount) {
+                findings.push(risky_mount_finding(
+                    &row,
+                    service,
+                    mount,
+                    risk,
+                    graph_status,
+                    evidence_limit,
+                ));
+            }
+        }
+    }
+    findings
 }
 
 fn risky_mount_finding(
@@ -231,13 +305,17 @@ fn risky_mount_finding(
     mount_entity
         .details
         .insert("read_only".to_string(), mount.read_only.to_string());
+    let evidence = graph_row_evidence(row.evidence_id, row.safe_excerpt.clone(), evidence_limit);
     TopologyFinding {
-        finding_type: FINDING_RISKY_MOUNTS.to_string(),
+        finding_type: finding_const::TYPE_RISKY_MOUNTS.to_string(),
         severity: risk.severity.to_string(),
         confidence: mount_confidence(row.confidence, mount.read_only, graph_status.is_degraded),
         reason_code: risk.reason_code.to_string(),
         affected_entities: vec![service_entity, mount_entity],
-        evidence: graph_row_evidence(row.evidence_id, row.safe_excerpt.clone(), evidence_limit),
+        evidence: evidence.items,
+        evidence_total: evidence.total,
+        evidence_truncated: evidence.truncated,
+        evidence_omitted: evidence.omitted,
         remediation: risk.remediation.to_string(),
         degraded_reason: graph_status
             .is_degraded
@@ -251,22 +329,53 @@ fn collector_health_findings(
     evidence_limit: usize,
 ) -> Vec<TopologyFinding> {
     let mut findings = Vec::new();
-    if context.cache_status.status == "missing" || context.inventory.is_none() {
+    match context.inventory_read_issue {
+        Some(InventoryReadIssue::NotFound) => {
+            findings.push(collector_health_finding(
+                reason_const::INVENTORY_CACHE_MISSING,
+                finding_const::SEVERITY_MEDIUM,
+                0.95,
+                "inventory_cache",
+                "Inventory cache is unavailable, so absence of topology findings is unknown.",
+                evidence_limit,
+            ));
+        }
+        Some(InventoryReadIssue::Unreadable) => {
+            findings.push(collector_health_finding(
+                reason_const::INVENTORY_CACHE_UNREADABLE,
+                finding_const::SEVERITY_HIGH,
+                0.95,
+                "inventory_cache",
+                "Inventory cache could not be read safely; absence-oriented topology findings are incomplete.",
+                evidence_limit,
+            ));
+        }
+        None => {}
+    }
+
+    if context.cache_status.is_stale {
         findings.push(collector_health_finding(
-            "inventory_cache_missing",
-            "warning",
-            0.95,
-            "inventory_cache",
-            "Inventory cache is unavailable, so absence of topology findings is unknown.",
-            evidence_limit,
-        ));
-    } else if context.cache_status.is_stale {
-        findings.push(collector_health_finding(
-            "inventory_cache_stale",
-            "info",
+            reason_const::INVENTORY_CACHE_STALE,
+            finding_const::SEVERITY_INFO,
             0.90,
             "inventory_cache",
             "Inventory cache is stale; findings are based on the last available normalized snapshot.",
+            evidence_limit,
+        ));
+    }
+
+    for warning in &context.cache_status.warnings {
+        let reason_code = if warning.starts_with("collection-state unavailable") {
+            reason_const::COLLECTION_STATE_UNAVAILABLE
+        } else {
+            reason_const::INVENTORY_CACHE_UNREADABLE
+        };
+        findings.push(collector_health_finding(
+            reason_code,
+            finding_const::SEVERITY_MEDIUM,
+            0.90,
+            "collection_state",
+            "Inventory cache status reported a read warning; raw warning text is withheld.",
             evidence_limit,
         ));
     }
@@ -276,15 +385,11 @@ fn collector_health_findings(
             if collector.status == "ok" && collector.warnings.is_empty() {
                 continue;
             }
-            let severity = if is_core_collector(&collector.name) {
-                "warning"
-            } else {
-                "info"
-            };
+            let profile = collector_profile(&collector.name);
             findings.push(collector_health_finding(
-                "collector_degraded",
-                severity,
-                if is_core_collector(&collector.name) { 0.85 } else { 0.70 },
+                reason_const::COLLECTOR_DEGRADED,
+                profile.degraded_severity,
+                profile.degraded_confidence,
                 &collector.name,
                 "Collector did not complete cleanly; related topology conclusions have reduced confidence.",
                 evidence_limit,
@@ -308,27 +413,24 @@ fn collector_health_finding(
     context: &str,
     evidence_limit: usize,
 ) -> TopologyFinding {
-    let mut details = BTreeMap::new();
-    details.insert("collector".to_string(), sanitize_token(collector));
+    let evidence = bounded_evidence(
+        vec![TopologyFindingEvidence {
+            evidence_id: None,
+            source_kind: "collection_state".to_string(),
+            safe_excerpt: Some(context.to_string()),
+        }],
+        evidence_limit,
+    );
     TopologyFinding {
-        finding_type: FINDING_COLLECTOR_HEALTH.to_string(),
+        finding_type: finding_const::TYPE_COLLECTOR_HEALTH.to_string(),
         severity: severity.to_string(),
         confidence,
         reason_code: reason_code.to_string(),
-        affected_entities: vec![TopologyFindingEntity {
-            entity_type: "collector".to_string(),
-            key: sanitize_token(collector),
-            label: sanitize_token(collector),
-            details,
-        }],
-        evidence: bounded_evidence(
-            vec![TopologyFindingEvidence {
-                evidence_id: None,
-                source_kind: "collection_state".to_string(),
-                safe_excerpt: Some(context.to_string()),
-            }],
-            evidence_limit,
-        ),
+        affected_entities: vec![collector_entity(collector)],
+        evidence: evidence.items,
+        evidence_total: evidence.total,
+        evidence_truncated: evidence.truncated,
+        evidence_omitted: evidence.omitted,
         remediation: "Refresh inventory collection and inspect collector-specific logs before treating missing topology as absence.".to_string(),
         degraded_reason: Some(reason_code.to_string()),
         confidence_context: Some(context.to_string()),
@@ -336,41 +438,39 @@ fn collector_health_finding(
 }
 
 fn collection_error_finding(error: &CollectionError, evidence_limit: usize) -> TopologyFinding {
-    let severity = if is_core_collector(&error.collector) {
-        "warning"
-    } else {
-        "info"
-    };
-    let mut details = BTreeMap::new();
-    details.insert("collector".to_string(), sanitize_token(&error.collector));
-    details.insert("phase".to_string(), sanitize_token(&error.phase));
-    details.insert("truncated".to_string(), error.truncated.to_string());
-    TopologyFinding {
-        finding_type: FINDING_COLLECTOR_HEALTH.to_string(),
-        severity: severity.to_string(),
-        confidence: if is_core_collector(&error.collector) { 0.85 } else { 0.65 },
-        reason_code: "collector_partial".to_string(),
-        affected_entities: vec![TopologyFindingEntity {
-            entity_type: "collector".to_string(),
-            key: sanitize_token(&error.collector),
-            label: sanitize_token(&error.collector),
-            details,
+    let profile = collector_profile(&error.collector);
+    let mut entity = collector_entity(&error.collector);
+    entity
+        .details
+        .insert("phase".to_string(), sanitize_token(&error.phase));
+    entity
+        .details
+        .insert("truncated".to_string(), error.truncated.to_string());
+    let evidence = bounded_evidence(
+        vec![TopologyFindingEvidence {
+            evidence_id: None,
+            source_kind: "collection_error".to_string(),
+            safe_excerpt: Some(format!(
+                "{} collector reported a {} during {}",
+                sanitize_token(&error.collector),
+                sanitize_token(&error.severity),
+                sanitize_token(&error.phase)
+            )),
         }],
-        evidence: bounded_evidence(
-            vec![TopologyFindingEvidence {
-                evidence_id: None,
-                source_kind: "collection_error".to_string(),
-                safe_excerpt: Some(format!(
-                    "{} collector reported a {} during {}",
-                    sanitize_token(&error.collector),
-                    sanitize_token(&error.severity),
-                    sanitize_token(&error.phase)
-                )),
-            }],
-            evidence_limit,
-        ),
+        evidence_limit,
+    );
+    TopologyFinding {
+        finding_type: finding_const::TYPE_COLLECTOR_HEALTH.to_string(),
+        severity: profile.partial_severity.to_string(),
+        confidence: profile.partial_confidence,
+        reason_code: reason_const::COLLECTOR_PARTIAL.to_string(),
+        affected_entities: vec![entity],
+        evidence: evidence.items,
+        evidence_total: evidence.total,
+        evidence_truncated: evidence.truncated,
+        evidence_omitted: evidence.omitted,
         remediation: "Refresh or repair the collector, then rebuild the graph projection before relying on absence-oriented topology conclusions.".to_string(),
-        degraded_reason: Some("collector_partial".to_string()),
+        degraded_reason: Some(reason_const::COLLECTOR_PARTIAL.to_string()),
         confidence_context: Some("Raw warning text is intentionally withheld; collector class and phase are enough to scope follow-up.".to_string()),
     }
 }
@@ -409,16 +509,24 @@ fn classify_mount(mount: &MountRef) -> Option<MountRisk> {
     let target = mount.target.as_str();
     if source == "/var/run/docker.sock" || target == "/var/run/docker.sock" {
         return Some(MountRisk {
-            severity: if mount.read_only { "medium" } else { "high" },
-            reason_code: "docker_socket_mount",
+            severity: if mount.read_only {
+                finding_const::SEVERITY_MEDIUM
+            } else {
+                finding_const::SEVERITY_HIGH
+            },
+            reason_code: reason_const::DOCKER_SOCKET_MOUNT,
             source_kind: "docker_socket",
             remediation: "Review whether this service needs Docker daemon access; prefer a narrow proxy or read-only control path when possible.",
         });
     }
     if source == "/" {
         return Some(MountRisk {
-            severity: if mount.read_only { "medium" } else { "high" },
-            reason_code: "host_root_mount",
+            severity: if mount.read_only {
+                finding_const::SEVERITY_MEDIUM
+            } else {
+                finding_const::SEVERITY_HIGH
+            },
+            reason_code: reason_const::HOST_ROOT_MOUNT,
             source_kind: "host_root",
             remediation: "Replace host-root binds with the smallest required host path and keep the mount read-only when writes are not required.",
         });
@@ -428,16 +536,20 @@ fn classify_mount(mount: &MountRef) -> Option<MountRisk> {
         || source.starts_with("/mnt/user/appdata")
     {
         return Some(MountRisk {
-            severity: if mount.read_only { "low" } else { "medium" },
-            reason_code: "appdata_root_mount",
+            severity: if mount.read_only {
+                finding_const::SEVERITY_LOW
+            } else {
+                finding_const::SEVERITY_MEDIUM
+            },
+            reason_code: reason_const::APPDATA_ROOT_MOUNT,
             source_kind: "appdata_root",
             remediation: "Scope appdata binds to the service-specific directory and keep secrets outside broadly shared mounts.",
         });
     }
     if mount.source.is_none() {
         return Some(MountRisk {
-            severity: "low",
-            reason_code: "mount_missing_source_detail",
+            severity: finding_const::SEVERITY_LOW,
+            reason_code: reason_const::MOUNT_MISSING_SOURCE_DETAIL,
             source_kind: "unknown_source",
             remediation: "Refresh Docker or compose inventory so mount source details can be classified before making risk decisions.",
         });
@@ -478,16 +590,15 @@ fn route_confidence_context(
     context: &MapFindingContext,
     graph_status: &db::graph::GraphProjectionStatus,
 ) -> Option<String> {
-    if graph_status.is_degraded {
+    if graph_projection_not_ready(graph_status) {
+        Some(reason_const::GRAPH_PROJECTION_NOT_READY.to_string())
+    } else if graph_status.is_degraded {
         Some("graph_projection_degraded".to_string())
     } else if context.cache_status.is_stale {
-        Some("inventory_cache_stale".to_string())
-    } else if context.inventory.as_ref().is_some_and(|inventory| {
-        inventory
-            .collection_errors
-            .iter()
-            .any(|e| is_core_collector(&e.collector))
-    }) {
+        Some(reason_const::INVENTORY_CACHE_STALE.to_string())
+    } else if context.inventory_read_issue.is_some() {
+        Some("inventory_context_unavailable".to_string())
+    } else if has_core_collector_degradation(context) {
         Some("core_collector_partial".to_string())
     } else {
         None
@@ -497,7 +608,7 @@ fn route_confidence_context(
 fn public_route_evidence(
     row: &db::PublicRouteFindingRow,
     evidence_limit: usize,
-) -> Vec<TopologyFindingEvidence> {
+) -> BoundedEvidence {
     bounded_evidence(
         vec![
             TopologyFindingEvidence {
@@ -519,7 +630,7 @@ fn graph_row_evidence(
     evidence_id: Option<i64>,
     safe_excerpt: Option<String>,
     evidence_limit: usize,
-) -> Vec<TopologyFindingEvidence> {
+) -> BoundedEvidence {
     bounded_evidence(
         vec![TopologyFindingEvidence {
             evidence_id,
@@ -530,15 +641,99 @@ fn graph_row_evidence(
     )
 }
 
-fn bounded_evidence(
-    evidence: Vec<TopologyFindingEvidence>,
-    limit: usize,
-) -> Vec<TopologyFindingEvidence> {
-    evidence
+fn bounded_evidence(evidence: Vec<TopologyFindingEvidence>, limit: usize) -> BoundedEvidence {
+    let candidates = evidence
         .into_iter()
         .filter(|item| item.evidence_id.is_some() || item.safe_excerpt.is_some())
-        .take(limit)
-        .collect()
+        .collect::<Vec<_>>();
+    let total = candidates.len();
+    let items = candidates.into_iter().take(limit).collect::<Vec<_>>();
+    let omitted = total.saturating_sub(items.len());
+    BoundedEvidence {
+        items,
+        total,
+        truncated: omitted > 0,
+        omitted,
+    }
+}
+
+#[derive(Debug)]
+struct BoundedEvidence {
+    items: Vec<TopologyFindingEvidence>,
+    total: usize,
+    truncated: bool,
+    omitted: usize,
+}
+
+fn graph_projection_not_ready(graph_status: &db::graph::GraphProjectionStatus) -> bool {
+    graph_status.projection_status != "ready" || graph_status.last_completed_at.is_none()
+}
+
+fn graph_projection_health_finding(
+    graph_status: &db::graph::GraphProjectionStatus,
+    evidence_limit: usize,
+) -> Option<TopologyFinding> {
+    if !graph_projection_not_ready(graph_status) {
+        return None;
+    }
+    Some(collector_health_finding(
+        reason_const::GRAPH_PROJECTION_NOT_READY,
+        finding_const::SEVERITY_MEDIUM,
+        0.98,
+        "graph_projection",
+        "Graph projection is not ready, so absence of topology findings is incomplete.",
+        evidence_limit,
+    ))
+}
+
+fn has_core_collector_degradation(context: &MapFindingContext) -> bool {
+    let state_degraded = context
+        .cache_status
+        .collection_state
+        .as_ref()
+        .is_some_and(|state| {
+            state.collectors.iter().any(|collector| {
+                is_core_collector(&collector.name)
+                    && (collector.status != "ok" || !collector.warnings.is_empty())
+            })
+        });
+    let errors_degraded = context.inventory.as_ref().is_some_and(|inventory| {
+        inventory
+            .collection_errors
+            .iter()
+            .any(|error| is_core_collector(&error.collector))
+    });
+    state_degraded || errors_degraded
+}
+
+fn apply_findings_payload_budget(findings: &mut Vec<TopologyFinding>, payload_budget: u32) -> bool {
+    let budget = payload_budget as usize;
+    let mut truncated = false;
+    while findings_payload_size(findings) > budget {
+        if let Some(finding) = findings
+            .iter_mut()
+            .rev()
+            .find(|finding| !finding.evidence.is_empty())
+        {
+            finding.evidence.clear();
+            finding.evidence_truncated = finding.evidence_total > 0;
+            finding.evidence_omitted = finding.evidence_total;
+            truncated = true;
+            continue;
+        }
+        if findings.pop().is_some() {
+            truncated = true;
+        } else {
+            break;
+        }
+    }
+    truncated
+}
+
+fn findings_payload_size(findings: &[TopologyFinding]) -> usize {
+    serde_json::to_vec(findings)
+        .map(|bytes| bytes.len())
+        .unwrap_or(usize::MAX)
 }
 
 fn entity(entity_type: &str, key: &str, label: &str) -> TopologyFindingEntity {
@@ -612,11 +807,11 @@ fn finding_sort_key(finding: &TopologyFinding) -> (u8, std::cmp::Reverse<i64>, S
 
 fn severity_rank(severity: &str) -> u8 {
     match severity {
-        "critical" => 0,
-        "high" => 1,
-        "medium" | "warning" => 2,
-        "low" => 3,
-        "info" => 4,
+        finding_const::SEVERITY_CRITICAL => 0,
+        finding_const::SEVERITY_HIGH => 1,
+        finding_const::SEVERITY_MEDIUM => 2,
+        finding_const::SEVERITY_LOW => 3,
+        finding_const::SEVERITY_INFO => 4,
         _ => 5,
     }
 }
@@ -665,6 +860,43 @@ fn is_core_collector(name: &str) -> bool {
     )
 }
 
+#[derive(Debug, Clone, Copy)]
+struct CollectorProfile {
+    degraded_severity: &'static str,
+    partial_severity: &'static str,
+    degraded_confidence: f64,
+    partial_confidence: f64,
+}
+
+fn collector_profile(name: &str) -> CollectorProfile {
+    if is_core_collector(name) {
+        CollectorProfile {
+            degraded_severity: finding_const::SEVERITY_MEDIUM,
+            partial_severity: finding_const::SEVERITY_MEDIUM,
+            degraded_confidence: 0.85,
+            partial_confidence: 0.85,
+        }
+    } else {
+        CollectorProfile {
+            degraded_severity: finding_const::SEVERITY_INFO,
+            partial_severity: finding_const::SEVERITY_INFO,
+            degraded_confidence: 0.70,
+            partial_confidence: 0.65,
+        }
+    }
+}
+
+fn collector_entity(collector: &str) -> TopologyFindingEntity {
+    let mut details = BTreeMap::new();
+    details.insert("collector".to_string(), sanitize_token(collector));
+    TopologyFindingEntity {
+        entity_type: "collector".to_string(),
+        key: sanitize_token(collector),
+        label: sanitize_token(collector),
+        details,
+    }
+}
+
 struct RequestedFindingTypes {
     values: HashSet<String>,
 }
@@ -681,17 +913,13 @@ impl RequestedFindingTypes {
             })
             .filter(|values| !values.is_empty())
             .unwrap_or_else(|| {
-                vec![
-                    FINDING_POTENTIAL_PUBLIC_ROUTE.to_string(),
-                    FINDING_RISKY_MOUNTS.to_string(),
-                    FINDING_COLLECTOR_HEALTH.to_string(),
-                ]
+                finding_const::TYPES
+                    .iter()
+                    .map(|value| (*value).to_string())
+                    .collect()
             });
         for value in &values {
-            if !matches!(
-                value.as_str(),
-                FINDING_POTENTIAL_PUBLIC_ROUTE | FINDING_RISKY_MOUNTS | FINDING_COLLECTOR_HEALTH
-            ) {
+            if !finding_const::TYPES.contains(&value.as_str()) {
                 return Err(ServiceError::InvalidInput(format!(
                     "unsupported finding type `{value}`; expected potential_public_route, risky_mounts, or collector_health"
                 )));
@@ -704,5 +932,72 @@ impl RequestedFindingTypes {
 
     fn includes(&self, value: &str) -> bool {
         self.values.contains(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mount(source: Option<&str>, target: &str, read_only: bool) -> MountRef {
+        MountRef {
+            source: source.map(str::to_string),
+            target: target.to_string(),
+            read_only,
+        }
+    }
+
+    #[test]
+    fn classify_mount_covers_risky_source_branches() {
+        let docker_rw = classify_mount(&mount(
+            Some("/var/run/docker.sock"),
+            "/var/run/docker.sock",
+            false,
+        ))
+        .unwrap();
+        assert_eq!(docker_rw.reason_code, reason_const::DOCKER_SOCKET_MOUNT);
+        assert_eq!(docker_rw.severity, finding_const::SEVERITY_HIGH);
+
+        let docker_ro = classify_mount(&mount(
+            Some("/var/run/docker.sock"),
+            "/var/run/docker.sock",
+            true,
+        ))
+        .unwrap();
+        assert_eq!(docker_ro.severity, finding_const::SEVERITY_MEDIUM);
+
+        let root_rw = classify_mount(&mount(Some("/"), "/host", false)).unwrap();
+        assert_eq!(root_rw.reason_code, reason_const::HOST_ROOT_MOUNT);
+        assert_eq!(root_rw.severity, finding_const::SEVERITY_HIGH);
+
+        let root_ro = classify_mount(&mount(Some("/"), "/host", true)).unwrap();
+        assert_eq!(root_ro.severity, finding_const::SEVERITY_MEDIUM);
+
+        let appdata_rw =
+            classify_mount(&mount(Some("/mnt/user/appdata"), "/config", false)).unwrap();
+        assert_eq!(appdata_rw.reason_code, reason_const::APPDATA_ROOT_MOUNT);
+        assert_eq!(appdata_rw.severity, finding_const::SEVERITY_MEDIUM);
+
+        let appdata_ro =
+            classify_mount(&mount(Some("/mnt/user/appdata"), "/config", true)).unwrap();
+        assert_eq!(appdata_ro.severity, finding_const::SEVERITY_LOW);
+
+        let missing = classify_mount(&mount(None, "/config", false)).unwrap();
+        assert_eq!(
+            missing.reason_code,
+            reason_const::MOUNT_MISSING_SOURCE_DETAIL
+        );
+        assert_eq!(missing.severity, finding_const::SEVERITY_LOW);
+    }
+
+    #[test]
+    fn safe_mount_target_renders_sensitive_targets_safely() {
+        assert_eq!(
+            safe_mount_target("/var/run/docker.sock"),
+            "/var/run/docker.sock"
+        );
+        assert_eq!(safe_mount_target("/"), "/");
+        assert_eq!(safe_mount_target("/mnt/user/appdata/app"), "appdata_path");
+        assert_eq!(safe_mount_target("relative"), "relative_mount_target");
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,6 +3,7 @@
 mod analytics;
 pub(crate) mod error_signatures;
 pub mod graph;
+pub mod graph_findings;
 pub mod graph_inventory;
 mod heartbeat;
 mod ingest;
@@ -26,6 +27,10 @@ pub use graph::{
     is_known_entity_type, is_known_evidence_source_kind, is_known_reason_code,
     is_known_relationship_type, is_known_trust_level, ENTITY_TYPES, EVIDENCE_SOURCE_KINDS,
     PROJECTION_STATUSES, REASON_CODES, RELATIONSHIP_TYPES, TRUST_LEVELS,
+};
+pub use graph_findings::{
+    list_mount_relationship_findings, list_public_route_findings, MountRelationshipFindingRow,
+    PublicRouteFindingRow,
 };
 pub use heartbeat::{
     heartbeat_host_state, heartbeat_latest_all, heartbeat_metric_snapshot_batch,

--- a/src/db/graph_findings.rs
+++ b/src/db/graph_findings.rs
@@ -1,0 +1,186 @@
+#[cfg(test)]
+#[path = "graph_findings_tests.rs"]
+mod tests;
+
+use anyhow::Result;
+use rusqlite::params;
+
+use crate::db::graph;
+use crate::db::DbPool;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PublicRouteFindingRow {
+    pub domain_key: String,
+    pub domain_label: String,
+    pub proxy_key: String,
+    pub proxy_label: String,
+    pub service_key: Option<String>,
+    pub service_label: Option<String>,
+    pub exposes_confidence: f64,
+    pub routes_confidence: Option<f64>,
+    pub exposes_evidence_id: Option<i64>,
+    pub exposes_excerpt: Option<String>,
+    pub routes_evidence_id: Option<i64>,
+    pub routes_excerpt: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MountRelationshipFindingRow {
+    pub service_key: String,
+    pub service_label: String,
+    pub storage_key: String,
+    pub storage_label: String,
+    pub confidence: f64,
+    pub evidence_id: Option<i64>,
+    pub safe_excerpt: Option<String>,
+}
+
+pub fn list_public_route_findings(pool: &DbPool, limit: u32) -> Result<Vec<PublicRouteFindingRow>> {
+    let conn = pool.get()?;
+    let mut stmt = conn.prepare(
+        "SELECT
+             domain.canonical_key,
+             domain.display_label,
+             proxy.canonical_key,
+             proxy.display_label,
+             service.canonical_key,
+             service.display_label,
+             exposes.confidence,
+             routes.confidence,
+             exposes_ev.id,
+             exposes_ev.safe_excerpt,
+             routes_ev.id,
+             routes_ev.safe_excerpt
+         FROM graph_relationships exposes INDEXED BY idx_graph_relationships_type_seen
+         JOIN graph_entities proxy ON proxy.id = exposes.src_entity_id
+         JOIN graph_entities domain ON domain.id = exposes.dst_entity_id
+         LEFT JOIN graph_relationship_evidence exposes_ev
+           ON exposes_ev.id = (
+               SELECT id
+                 FROM graph_relationship_evidence
+                WHERE relationship_id = exposes.id
+                ORDER BY observed_at DESC, id DESC
+                LIMIT 1
+           )
+         LEFT JOIN graph_relationships routes
+           ON routes.src_entity_id = proxy.id
+          AND routes.relationship_type = ?2
+         LEFT JOIN graph_entities service ON service.id = routes.dst_entity_id
+         LEFT JOIN graph_relationship_evidence routes_ev
+           ON routes_ev.id = (
+               SELECT id
+                 FROM graph_relationship_evidence
+                WHERE relationship_id = routes.id
+                ORDER BY observed_at DESC, id DESC
+                LIMIT 1
+           )
+        WHERE exposes.relationship_type = ?1
+          AND proxy.entity_type = ?3
+          AND domain.entity_type = ?4
+        ORDER BY exposes.confidence DESC, exposes.last_seen_at DESC, exposes.id DESC
+        LIMIT ?5",
+    )?;
+    let rows = stmt
+        .query_map(
+            params![
+                graph::REL_EXPOSES_DOMAIN,
+                graph::REL_ROUTES_TO,
+                graph::ENTITY_TYPE_REVERSE_PROXY,
+                graph::ENTITY_TYPE_DOMAIN,
+                i64::from(limit),
+            ],
+            |row| {
+                Ok(PublicRouteFindingRow {
+                    domain_key: row.get(0)?,
+                    domain_label: row.get(1)?,
+                    proxy_key: row.get(2)?,
+                    proxy_label: row.get(3)?,
+                    service_key: row.get(4)?,
+                    service_label: row.get(5)?,
+                    exposes_confidence: row.get(6)?,
+                    routes_confidence: row.get(7)?,
+                    exposes_evidence_id: row.get(8)?,
+                    exposes_excerpt: row.get(9)?,
+                    routes_evidence_id: row.get(10)?,
+                    routes_excerpt: row.get(11)?,
+                })
+            },
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+pub fn list_mount_relationship_findings(
+    pool: &DbPool,
+    limit: u32,
+) -> Result<Vec<MountRelationshipFindingRow>> {
+    let conn = pool.get()?;
+    let mut stmt = conn.prepare(
+        "SELECT
+             service.canonical_key,
+             service.display_label,
+             storage.canonical_key,
+             storage.display_label,
+             mounts.confidence,
+             evidence.id,
+             evidence.safe_excerpt
+         FROM graph_relationships mounts INDEXED BY idx_graph_relationships_type_seen
+         JOIN graph_entities service ON service.id = mounts.src_entity_id
+         JOIN graph_entities storage ON storage.id = mounts.dst_entity_id
+         LEFT JOIN graph_relationship_evidence evidence
+           ON evidence.id = (
+               SELECT id
+                 FROM graph_relationship_evidence
+                WHERE relationship_id = mounts.id
+                ORDER BY observed_at DESC, id DESC
+                LIMIT 1
+           )
+        WHERE mounts.relationship_type = ?1
+          AND service.entity_type = ?2
+          AND storage.entity_type = ?3
+        ORDER BY mounts.confidence DESC, mounts.last_seen_at DESC, mounts.id DESC
+        LIMIT ?4",
+    )?;
+    let rows = stmt
+        .query_map(
+            params![
+                graph::REL_MOUNTS,
+                graph::ENTITY_TYPE_SERVICE,
+                graph::ENTITY_TYPE_STORAGE,
+                i64::from(limit),
+            ],
+            |row| {
+                Ok(MountRelationshipFindingRow {
+                    service_key: row.get(0)?,
+                    service_label: row.get(1)?,
+                    storage_key: row.get(2)?,
+                    storage_label: row.get(3)?,
+                    confidence: row.get(4)?,
+                    evidence_id: row.get(5)?,
+                    safe_excerpt: row.get(6)?,
+                })
+            },
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+#[cfg(test)]
+pub(crate) fn relationship_type_query_plan(
+    pool: &DbPool,
+    relationship_type: &str,
+) -> Result<Vec<String>> {
+    let conn = pool.get()?;
+    let mut stmt = conn.prepare(
+        "EXPLAIN QUERY PLAN
+         SELECT id
+           FROM graph_relationships INDEXED BY idx_graph_relationships_type_seen
+          WHERE relationship_type = ?1
+          ORDER BY last_seen_at DESC
+          LIMIT 10",
+    )?;
+    let rows = stmt
+        .query_map([relationship_type], |row| row.get::<_, String>(3))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}

--- a/src/db/graph_findings_tests.rs
+++ b/src/db/graph_findings_tests.rs
@@ -68,6 +68,36 @@ fn seed_inventory(pool: &DbPool, services: usize) {
     crate::db::graph_inventory::project_inventory(pool, &inventory).unwrap();
 }
 
+fn seed_inventory_without_route_target(pool: &DbPool) {
+    let mut inventory = HomelabInventory::empty(
+        "graph-findings-no-target-test".to_string(),
+        "2026-01-01T00:00:00Z".to_string(),
+    );
+    inventory.nodes.push(InventoryNode {
+        id: "node:squirts".to_string(),
+        hostname: "squirts".to_string(),
+        trust_level: TrustLevel::Observed,
+        provenance: provenance("ssh:squirts"),
+        roles: Vec::new(),
+        ips: Vec::new(),
+        os: None,
+        cpu: None,
+        memory: None,
+        listeners: Vec::new(),
+        storage: Vec::new(),
+        extras: Default::default(),
+    });
+    inventory.reverse_proxies.push(ReverseProxyRoute {
+        id: "proxy:orphan.example.test".to_string(),
+        server_names: vec!["orphan.example.test".to_string()],
+        upstreams: vec!["missing-service:80".to_string()],
+        provenance: provenance("swag:squirts:/redacted.conf"),
+    });
+    let _guard = crate::db::graph::GRAPH_TEST_LOCK.lock();
+    crate::db::graph::refresh_graph_projection(pool).unwrap();
+    crate::db::graph_inventory::project_inventory(pool, &inventory).unwrap();
+}
+
 #[test]
 fn public_route_findings_return_route_target_and_evidence() {
     let (pool, _dir) = test_pool();
@@ -81,6 +111,21 @@ fn public_route_findings_return_route_target_and_evidence() {
     assert_eq!(rows[0].service_key.as_deref(), Some("squirts:svc-0"));
     assert!(rows[0].exposes_evidence_id.is_some());
     assert!(rows[0].routes_evidence_id.is_some());
+}
+
+#[test]
+fn public_route_findings_return_domain_without_route_target() {
+    let (pool, _dir) = test_pool();
+    seed_inventory_without_route_target(&pool);
+
+    let rows = list_public_route_findings(&pool, 10).unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].domain_key, "orphan.example.test");
+    assert_eq!(rows[0].proxy_key, "proxy:orphan.example.test");
+    assert!(rows[0].service_key.is_none());
+    assert!(rows[0].routes_evidence_id.is_none());
+    assert!(rows[0].exposes_evidence_id.is_some());
 }
 
 #[test]

--- a/src/db/graph_findings_tests.rs
+++ b/src/db/graph_findings_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use crate::config::StorageConfig;
+use crate::inventory::schema::{
+    HomelabInventory, InventoryNode, InventoryService, MountRef, Provenance, ReverseProxyRoute,
+    TrustLevel,
+};
+
+fn test_pool() -> (DbPool, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let storage = StorageConfig::for_test(dir.path().join("graph-findings.db"));
+    let pool = crate::db::init_pool(&storage).unwrap();
+    (pool, dir)
+}
+
+fn provenance(source: &str) -> Provenance {
+    Provenance::new(source, "app_inventory", "2026-01-01T00:00:00Z".to_string())
+}
+
+fn seed_inventory(pool: &DbPool, services: usize) {
+    let mut inventory = HomelabInventory::empty(
+        "graph-findings-test".to_string(),
+        "2026-01-01T00:00:00Z".to_string(),
+    );
+    inventory.nodes.push(InventoryNode {
+        id: "node:squirts".to_string(),
+        hostname: "squirts".to_string(),
+        trust_level: TrustLevel::Observed,
+        provenance: provenance("ssh:squirts"),
+        roles: Vec::new(),
+        ips: Vec::new(),
+        os: None,
+        cpu: None,
+        memory: None,
+        listeners: Vec::new(),
+        storage: Vec::new(),
+        extras: Default::default(),
+    });
+    for idx in 0..services {
+        let name = format!("svc-{idx}");
+        inventory.services.push(InventoryService {
+            id: format!("container:squirts:{name}"),
+            name: name.clone(),
+            kind: "container".to_string(),
+            trust_level: TrustLevel::Observed,
+            provenance: provenance("docker:squirts"),
+            host: Some("squirts".to_string()),
+            image: None,
+            status: Some("running".to_string()),
+            domains: Vec::new(),
+            ports: Vec::new(),
+            mounts: vec![MountRef {
+                source: Some("/var/run/docker.sock".to_string()),
+                target: "/var/run/docker.sock".to_string(),
+                read_only: false,
+            }],
+            env_keys: Vec::new(),
+            labels: Default::default(),
+        });
+    }
+    inventory.reverse_proxies.push(ReverseProxyRoute {
+        id: "proxy:one.example.test".to_string(),
+        server_names: vec!["one.example.test".to_string()],
+        upstreams: vec!["svc-0:80".to_string()],
+        provenance: provenance("swag:squirts:/redacted.conf"),
+    });
+    let _guard = crate::db::graph::GRAPH_TEST_LOCK.lock();
+    crate::db::graph::refresh_graph_projection(pool).unwrap();
+    crate::db::graph_inventory::project_inventory(pool, &inventory).unwrap();
+}
+
+#[test]
+fn public_route_findings_return_route_target_and_evidence() {
+    let (pool, _dir) = test_pool();
+    seed_inventory(&pool, 2);
+
+    let rows = list_public_route_findings(&pool, 10).unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].domain_key, "one.example.test");
+    assert_eq!(rows[0].proxy_key, "proxy:one.example.test");
+    assert_eq!(rows[0].service_key.as_deref(), Some("squirts:svc-0"));
+    assert!(rows[0].exposes_evidence_id.is_some());
+    assert!(rows[0].routes_evidence_id.is_some());
+}
+
+#[test]
+fn mount_findings_are_bounded_and_use_relationship_type_index() {
+    let (pool, _dir) = test_pool();
+    seed_inventory(&pool, 25);
+
+    let rows = list_mount_relationship_findings(&pool, 5).unwrap();
+    let plan = relationship_type_query_plan(&pool, crate::db::graph::REL_MOUNTS).unwrap();
+
+    assert_eq!(rows.len(), 5);
+    assert!(
+        plan.iter()
+            .any(|row| row.contains("idx_graph_relationships_type_seen")),
+        "expected type-specific graph index in query plan: {plan:?}"
+    );
+    assert!(
+        !plan.iter().any(|row| row == "SCAN graph_relationships"),
+        "findings query must not broad-scan graph relationships: {plan:?}"
+    );
+}

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -24,7 +24,7 @@ pub fn write_lock() -> parking_lot::ReentrantMutexGuard<'static, ()> {
     WRITE_LOCK.lock()
 }
 
-pub const KNOWN_SCHEMA_VERSION: i64 = 30;
+pub const KNOWN_SCHEMA_VERSION: i64 = 31;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SchemaVersionInfo {
@@ -1009,6 +1009,8 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
                  ON graph_relationships(src_entity_id, relationship_type, last_seen_at DESC);
              CREATE INDEX IF NOT EXISTS idx_graph_relationships_dst_type_seen
                  ON graph_relationships(dst_entity_id, relationship_type, last_seen_at DESC);
+             CREATE INDEX IF NOT EXISTS idx_graph_relationships_type_seen
+                 ON graph_relationships(relationship_type, last_seen_at DESC);
 
              CREATE TABLE IF NOT EXISTS graph_relationship_evidence (
                  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1213,6 +1215,8 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
                  ON graph_relationships(src_entity_id, relationship_type, last_seen_at DESC);
              CREATE INDEX idx_graph_relationships_dst_type_seen
                  ON graph_relationships(dst_entity_id, relationship_type, last_seen_at DESC);
+             CREATE INDEX idx_graph_relationships_type_seen
+                 ON graph_relationships(relationship_type, last_seen_at DESC);
 
              CREATE TABLE graph_relationship_evidence_new (
                  id                 INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1276,6 +1280,18 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
              COMMIT;",
         )?;
         tracing::info!("Migration 30: widened graph vocabulary for inventory topology");
+    }
+
+    // Migration 31: relationship-type covering index for bounded topology
+    // findings. Findings ask for all relationships of one graph vocabulary
+    // type, so the src/dst-specific graph indexes are not sufficient.
+    if !migration_applied(&conn, 31)? {
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_graph_relationships_type_seen
+                 ON graph_relationships(relationship_type, last_seen_at DESC);
+             INSERT OR IGNORE INTO schema_migrations (version) VALUES (31);",
+        )?;
+        tracing::info!("Migration 31: added graph relationship type index for topology findings");
     }
 
     // A server crash/restart mid-check leaves an orphaned 'running' maintenance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 
 pub mod ai_watch;
 pub mod api;

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -1,3 +1,4 @@
+use crate::app::topology_findings;
 use crate::db::{PATTERN_SCAN_LIMIT_MAX, SEVERITY_LEVELS};
 use serde_json::{json, Value};
 
@@ -225,7 +226,7 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 },
                 "payload_budget": {
                     "type": "integer",
-                    "description": "For action=graph and action=map graph-backed modes: approximate graph payload budget in bytes, default 32768, clamped 4096..65536."
+                    "description": "For action=graph and action=map graph-backed modes, including mode=findings: approximate graph payload budget in bytes, default 32768, clamped 4096..65536."
                 },
                 "finding_limit": {
                     "type": "integer",
@@ -243,9 +244,9 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": ["potential_public_route", "risky_mounts", "collector_health"]
+                        "enum": topology_findings::TYPES
                     },
-                    "description": "For action=map mode=findings: optional Phase 1 finding types to return."
+                    "description": "For action=map mode=findings: optional supported finding types to return."
                 },
                 "offset": {
                     "type": "integer",

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -57,8 +57,8 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 },
                 "mode": {
                     "type": "string",
-                    "enum": ["entity", "around", "explain", "evidence", "snapshot", "host_services", "domain_routes", "service_dependencies"],
-                    "description": "For action=graph: entity resolves an entity by key or alias; around returns a bounded one-hop neighborhood; explain returns conservative evidence-backed chains; evidence resolves one evidence row by evidence_id. Defaults to around. For action=map: snapshot returns the inventory snapshot; host_services, domain_routes, and service_dependencies add a graph_answer."
+                    "enum": ["entity", "around", "explain", "evidence", "snapshot", "host_services", "domain_routes", "service_dependencies", "findings"],
+                    "description": "For action=graph: entity resolves an entity by key or alias; around returns a bounded one-hop neighborhood; explain returns conservative evidence-backed chains; evidence resolves one evidence row by evidence_id. Defaults to around. For action=map: snapshot returns the inventory snapshot; host_services, domain_routes, service_dependencies, and findings add a graph_answer."
                 },
                 "evidence_id": {
                     "type": "integer",
@@ -226,6 +226,26 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 "payload_budget": {
                     "type": "integer",
                     "description": "For action=graph and action=map graph-backed modes: approximate graph payload budget in bytes, default 32768, clamped 4096..65536."
+                },
+                "finding_limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "For action=map mode=findings: maximum findings returned, default 25, max 100."
+                },
+                "evidence_per_finding": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5,
+                    "description": "For action=map mode=findings: bounded safe evidence samples per finding, default 2, max 5."
+                },
+                "finding_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": ["potential_public_route", "risky_mounts", "collector_health"]
+                    },
+                    "description": "For action=map mode=findings: optional Phase 1 finding types to return."
                 },
                 "offset": {
                     "type": "integer",
@@ -464,7 +484,7 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                     "then": {
                         "properties": {
                             "mode": {
-                                "enum": ["snapshot", "host_services", "domain_routes", "service_dependencies"]
+                                "enum": ["snapshot", "host_services", "domain_routes", "service_dependencies", "findings"]
                             }
                         }
                     }

--- a/src/mcp/schemas_tests.rs
+++ b/src/mcp/schemas_tests.rs
@@ -178,6 +178,34 @@ fn schema_mode_constraints_are_action_specific() {
 }
 
 #[test]
+fn schema_map_findings_exposes_findings_arguments() {
+    let tools = tool_definitions();
+    let props = &tools[0]["inputSchema"]["properties"];
+
+    assert!(props["mode"]["enum"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|mode| mode == "findings"));
+    assert_eq!(props["finding_limit"]["minimum"], 1);
+    assert_eq!(props["finding_limit"]["maximum"], 100);
+    assert_eq!(props["evidence_per_finding"]["minimum"], 1);
+    assert_eq!(props["evidence_per_finding"]["maximum"], 5);
+    assert!(props["payload_budget"]["description"]
+        .as_str()
+        .unwrap()
+        .contains("mode=findings"));
+    assert_eq!(
+        props["finding_types"]["items"]["enum"],
+        serde_json::json!(crate::app::topology_findings::TYPES)
+    );
+    assert!(props["finding_types"]["description"]
+        .as_str()
+        .unwrap()
+        .contains("supported finding types"));
+}
+
+#[test]
 fn schema_timeline_and_patterns_warn_on_full_history_scan() {
     let tools = tool_definitions();
     let props = &tools[0]["inputSchema"]["properties"];

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -665,13 +665,14 @@ Return a bounded homelab infrastructure snapshot from Cortex's current database.
 The map includes known host nodes, verified source identities, top observed
 applications per host, latest heartbeat status when available, and the external
 inventory sources that complement Cortex's DB-backed view.
-When `mode` is `host_services`, `domain_routes`, or `service_dependencies`, the
+When `mode` is `host_services`, `domain_routes`, `service_dependencies`, or `findings`, the
 response also includes `graph_answer` with answer status, topology rows,
-candidates, safe evidence samples, map follow-up queries, and graph proof
-queries.
+candidates, safe evidence samples, map follow-up queries, graph proof queries,
+and for `findings` a bounded `findings` array with topology risk/hygiene
+findings.
 
 **Parameters:**
-- `mode` (string, optional) — `snapshot` (default), `host_services`, `domain_routes`, or `service_dependencies`
+- `mode` (string, optional) — `snapshot` (default), `host_services`, `domain_routes`, `service_dependencies`, or `findings`
 - `host` (string, optional) — target host for `host_services`; also used with bare `service` names for `service_dependencies`
 - `domain` (string, optional) — target domain for `domain_routes`
 - `service` (string, optional) — target service for `service_dependencies`, either `host:name` or a bare name with `host`
@@ -681,6 +682,9 @@ queries.
 - `answer_limit` (integer, optional) — graph relationship cap for graph-backed modes (default 100, max 500)
 - `evidence_sample_limit` (integer, optional) — evidence samples per relationship for graph-backed modes (default 3, max 5)
 - `payload_budget` (integer, optional) — approximate graph payload budget in bytes (default 32768, max 65536)
+- `finding_limit` (integer, optional) — findings returned by `mode=findings` (default 25, max 100)
+- `evidence_per_finding` (integer, optional) — safe evidence samples per finding (default 2, max 5)
+- `finding_types` (array, optional) — subset of `potential_public_route`, `risky_mounts`, `collector_health`
 - `per_host_limit` (integer, optional) — deprecated map v1 compatibility option; ignored by map v2
 
 ---

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -3,9 +3,9 @@ use crate::app::CortexService;
 use crate::config::{McpConfig, StorageConfig};
 use crate::db;
 use crate::inventory::schema::{
-    ArtifactRef, CollectionError, ComposeProject, HomelabInventory, InventoryNode,
-    InventoryService, MountRef, PortMapping, Provenance, RedactionStatus, ReverseProxyRoute,
-    TrustLevel,
+    ArtifactRef, CollectionError, CollectionState, CollectorState, ComposeProject,
+    HomelabInventory, InventoryNode, InventoryService, MountRef, PortMapping, Provenance,
+    RedactionStatus, ReverseProxyRoute, TrustLevel,
 };
 use crate::inventory::storage::InventoryPaths;
 use crate::mcp::AppState;
@@ -164,6 +164,35 @@ fn graph_inventory_fixture() -> HomelabInventory {
     inventory
 }
 
+fn graph_inventory_without_route_target_fixture() -> HomelabInventory {
+    let mut inventory = HomelabInventory::empty(
+        "mcp-map-no-target-test".to_string(),
+        "2026-01-01T00:00:00Z".to_string(),
+    );
+    inventory.nodes.push(InventoryNode {
+        id: "node:squirts".to_string(),
+        hostname: "squirts".to_string(),
+        trust_level: TrustLevel::Observed,
+        provenance: test_provenance("ssh:squirts", "source_inventory"),
+        roles: vec!["edge".to_string()],
+        ips: vec!["10.1.0.8".to_string()],
+        os: Some("Ubuntu".to_string()),
+        cpu: None,
+        memory: None,
+        listeners: Vec::new(),
+        storage: Vec::new(),
+        extras: Default::default(),
+    });
+    inventory.reverse_proxies.push(ReverseProxyRoute {
+        id: "proxy:orphan.tootie.tv".to_string(),
+        server_names: vec!["orphan.tootie.tv".to_string()],
+        upstreams: vec!["missing-service:443".to_string()],
+        provenance: test_provenance("swag:squirts:/config/nginx/orphan.conf", "app_inventory"),
+    });
+    inventory.recompute_summary();
+    inventory
+}
+
 fn project_graph_fixture(pool: &db::DbPool) {
     db::graph::refresh_graph_projection(pool).unwrap();
     let inventory = graph_inventory_fixture();
@@ -179,6 +208,38 @@ fn write_inventory_cache_fixture(root: &std::path::Path, inventory: &HomelabInve
         serde_json::to_vec_pretty(inventory).unwrap(),
     )
     .unwrap();
+}
+
+fn write_collection_state_fixture(root: &std::path::Path, collectors: Vec<CollectorState>) {
+    let paths = InventoryPaths::new(root.to_path_buf());
+    std::fs::create_dir_all(&paths.root).unwrap();
+    let state = CollectionState {
+        schema: "cortex.inventory.collection_state.v1".to_string(),
+        run_id: "test-run".to_string(),
+        started_at: "2026-01-01T00:00:00Z".to_string(),
+        finished_at: "2026-01-01T00:00:01Z".to_string(),
+        status: "partial".to_string(),
+        collectors,
+        artifact_refs: Vec::new(),
+        errors: Vec::new(),
+    };
+    std::fs::write(
+        &paths.collection_state_json,
+        serde_json::to_vec_pretty(&state).unwrap(),
+    )
+    .unwrap();
+}
+
+fn collector_state(name: &str, status: &str, warnings: Vec<&str>) -> CollectorState {
+    CollectorState {
+        name: name.to_string(),
+        status: status.to_string(),
+        started_at: "2026-01-01T00:00:00Z".to_string(),
+        finished_at: "2026-01-01T00:00:01Z".to_string(),
+        elapsed_ms: 10,
+        warnings: warnings.into_iter().map(str::to_string).collect(),
+        artifacts: Vec::new(),
+    }
 }
 
 #[tokio::test]
@@ -604,6 +665,291 @@ async fn map_action_findings_mode_returns_topology_findings_without_raw_leaks() 
     assert!(
         !rendered.contains("/home/jmagar/.cortex/inventory"),
         "{rendered}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn map_action_findings_payload_budget_trims_findings() {
+    let inventory_dir = tempfile::tempdir().unwrap();
+    let _inventory_env = EnvVarGuard::set_path("CORTEX_INVENTORY_DIR", inventory_dir.path());
+    let h = TestHarness::new();
+    let inventory = graph_inventory_fixture();
+    write_inventory_cache_fixture(inventory_dir.path(), &inventory);
+    write_collection_state_fixture(
+        inventory_dir.path(),
+        vec![
+            collector_state("raw_configs", "partial", vec!["raw /secret/token abc"]),
+            collector_state("docker", "partial", vec!["socket warning"]),
+            collector_state("reverse_proxy", "partial", vec!["proxy warning"]),
+            collector_state("compose", "partial", vec!["compose warning"]),
+        ],
+    );
+    {
+        let _guard = db::graph::GRAPH_TEST_LOCK.lock();
+        db::graph::refresh_graph_projection(&h.pool).unwrap();
+        db::graph_inventory::project_inventory(&h.pool, &inventory).unwrap();
+    }
+
+    let value = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_limit": 100,
+            "evidence_per_finding": 5,
+            "payload_budget": 4096
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let answer = &value["graph_answer"];
+    assert_eq!(answer["truncation"]["truncated"], true);
+    assert_eq!(answer["truncation"]["reason"], "payload_budget");
+    assert_eq!(answer["metadata"]["truncated_reason"], "payload_budget");
+    assert!(
+        answer["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| finding["evidence_truncated"] == true),
+        "budget trimming should mark at least one finding evidence-truncated: {answer}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn map_action_findings_type_subset_and_invalid_value_are_enforced() {
+    let inventory_dir = tempfile::tempdir().unwrap();
+    let _inventory_env = EnvVarGuard::set_path("CORTEX_INVENTORY_DIR", inventory_dir.path());
+    let h = TestHarness::new();
+    let inventory = graph_inventory_fixture();
+    write_inventory_cache_fixture(inventory_dir.path(), &inventory);
+    {
+        let _guard = db::graph::GRAPH_TEST_LOCK.lock();
+        db::graph::refresh_graph_projection(&h.pool).unwrap();
+        db::graph_inventory::project_inventory(&h.pool, &inventory).unwrap();
+    }
+
+    let value = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_types": ["collector_health"]
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+    let findings = value["graph_answer"]["findings"].as_array().unwrap();
+    assert!(!findings.is_empty(), "{value}");
+    assert!(
+        findings
+            .iter()
+            .all(|finding| finding["finding_type"] == "collector_health"),
+        "subset should only return collector health findings: {value}"
+    );
+
+    let err = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_types": ["bad"]
+        }),
+        None,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("unsupported finding type"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn map_action_findings_collector_health_cache_branches_are_safe() {
+    let inventory_dir = tempfile::tempdir().unwrap();
+    let _inventory_env = EnvVarGuard::set_path("CORTEX_INVENTORY_DIR", inventory_dir.path());
+    let h = TestHarness::new();
+
+    let missing_value = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_types": ["collector_health"]
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+    let missing_answer = &missing_value["graph_answer"];
+    assert_eq!(missing_answer["answer_status"], "degraded");
+    assert!(
+        missing_answer["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(
+                |finding| finding["reason_code"] == "inventory_cache_missing"
+                    || finding["reason_code"] == "collection_state_unavailable"
+            ),
+        "missing cache should surface collector health findings: {missing_answer}"
+    );
+
+    let inventory = graph_inventory_fixture();
+    write_inventory_cache_fixture(inventory_dir.path(), &inventory);
+    write_collection_state_fixture(
+        inventory_dir.path(),
+        vec![collector_state(
+            "raw_configs",
+            "ok",
+            vec!["raw path /secret/config.conf token abc"],
+        )],
+    );
+    let stale_value = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_types": ["collector_health"]
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+    let stale_answer = &stale_value["graph_answer"];
+    assert!(
+        stale_answer["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| finding["reason_code"] == "inventory_cache_stale"
+                || finding["reason_code"] == "collector_degraded"),
+        "stale cache and collector warnings should surface: {stale_answer}"
+    );
+    let rendered = serde_json::to_string(stale_answer).unwrap();
+    assert!(!rendered.contains("/secret/config.conf"), "{rendered}");
+    assert!(!rendered.contains("abc"), "{rendered}");
+
+    let paths = InventoryPaths::new(inventory_dir.path().to_path_buf());
+    std::fs::write(&paths.normalized_json, b"{not json").unwrap();
+    let corrupt_value = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_types": ["collector_health"]
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+    assert!(
+        corrupt_value["graph_answer"]["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| finding["reason_code"] == "inventory_cache_unreadable"),
+        "corrupt cache should surface unreadable collector health: {corrupt_value}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn map_action_findings_degrades_when_graph_projection_was_never_built() {
+    let inventory_dir = tempfile::tempdir().unwrap();
+    let _inventory_env = EnvVarGuard::set_path("CORTEX_INVENTORY_DIR", inventory_dir.path());
+    let h = TestHarness::new();
+    write_inventory_cache_fixture(inventory_dir.path(), &graph_inventory_fixture());
+
+    let value = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_types": ["potential_public_route"]
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+    let answer = &value["graph_answer"];
+    assert_eq!(answer["answer_status"], "degraded");
+    assert_eq!(answer["degraded_reason"], "graph_projection_not_ready");
+    assert!(
+        answer["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| finding["reason_code"] == "graph_projection_not_ready"),
+        "graph projection health finding should prevent empty-ok: {answer}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn map_action_findings_public_route_without_target_is_low_confidence() {
+    let inventory_dir = tempfile::tempdir().unwrap();
+    let _inventory_env = EnvVarGuard::set_path("CORTEX_INVENTORY_DIR", inventory_dir.path());
+    let h = TestHarness::new();
+    let inventory = graph_inventory_without_route_target_fixture();
+    write_inventory_cache_fixture(inventory_dir.path(), &inventory);
+    write_collection_state_fixture(
+        inventory_dir.path(),
+        vec![collector_state("raw_configs", "partial", vec!["redacted"])],
+    );
+    {
+        let _guard = db::graph::GRAPH_TEST_LOCK.lock();
+        db::graph::refresh_graph_projection(&h.pool).unwrap();
+        db::graph_inventory::project_inventory(&h.pool, &inventory).unwrap();
+    }
+
+    let value = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_types": ["potential_public_route"]
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let answer = &value["graph_answer"];
+    let finding = answer["findings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|finding| finding["reason_code"] == "reverse_proxy_domain_without_target_proof")
+        .unwrap_or_else(|| panic!("expected no-target route finding: {answer}"));
+    assert_eq!(finding["severity"], "low");
+    assert_eq!(finding["finding_type"], "potential_public_route");
+    assert!(finding["confidence_context"]
+        .as_str()
+        .unwrap()
+        .contains("Confidence reduced"));
+    assert!(
+        finding["affected_entities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|entity| entity["entity_type"] != "service"),
+        "no-target finding should not invent a routed service: {finding}"
     );
 }
 

--- a/src/mcp/tools_tests.rs
+++ b/src/mcp/tools_tests.rs
@@ -3,9 +3,11 @@ use crate::app::CortexService;
 use crate::config::{McpConfig, StorageConfig};
 use crate::db;
 use crate::inventory::schema::{
-    ArtifactRef, ComposeProject, HomelabInventory, InventoryNode, InventoryService, PortMapping,
-    Provenance, RedactionStatus, ReverseProxyRoute, TrustLevel,
+    ArtifactRef, CollectionError, ComposeProject, HomelabInventory, InventoryNode,
+    InventoryService, MountRef, PortMapping, Provenance, RedactionStatus, ReverseProxyRoute,
+    TrustLevel,
 };
+use crate::inventory::storage::InventoryPaths;
 use crate::mcp::AppState;
 use serde_json::json;
 use std::sync::Arc;
@@ -82,9 +84,7 @@ fn test_provenance(source: &str, kind: &str) -> Provenance {
     Provenance::new(source, kind, "2026-01-01T00:00:00Z".to_string())
 }
 
-fn project_graph_fixture(pool: &db::DbPool) {
-    db::graph::refresh_graph_projection(pool).unwrap();
-
+fn graph_inventory_fixture() -> HomelabInventory {
     let mut inventory = HomelabInventory::empty(
         "mcp-map-test".to_string(),
         "2026-01-01T00:00:00Z".to_string(),
@@ -119,7 +119,11 @@ fn project_graph_fixture(pool: &db::DbPool) {
             container_port: Some(443),
             protocol: "tcp".to_string(),
         }],
-        mounts: Vec::new(),
+        mounts: vec![MountRef {
+            source: Some("/var/run/docker.sock".to_string()),
+            target: "/var/run/docker.sock".to_string(),
+            read_only: false,
+        }],
         env_keys: vec!["URL".to_string()],
         labels: Default::default(),
     });
@@ -148,8 +152,33 @@ fn project_graph_fixture(pool: &db::DbPool) {
         byte_len: 42,
         truncated: false,
     });
+    inventory.collection_errors.push(CollectionError {
+        collector: "raw_configs".to_string(),
+        phase: "collect".to_string(),
+        severity: "warning".to_string(),
+        message: "raw path /secret/config.conf failed with token abc".to_string(),
+        elapsed_ms: 25,
+        truncated: false,
+    });
+    inventory.recompute_summary();
+    inventory
+}
+
+fn project_graph_fixture(pool: &db::DbPool) {
+    db::graph::refresh_graph_projection(pool).unwrap();
+    let inventory = graph_inventory_fixture();
 
     db::graph_inventory::project_inventory(pool, &inventory).unwrap();
+}
+
+fn write_inventory_cache_fixture(root: &std::path::Path, inventory: &HomelabInventory) {
+    let paths = InventoryPaths::new(root.to_path_buf());
+    std::fs::create_dir_all(&paths.normalized_dir).unwrap();
+    std::fs::write(
+        &paths.normalized_json,
+        serde_json::to_vec_pretty(inventory).unwrap(),
+    )
+    .unwrap();
 }
 
 #[tokio::test]
@@ -492,6 +521,89 @@ async fn map_action_service_dependencies_mode_accepts_bare_service_with_host() {
             .iter()
             .any(|row| row["entity_type"] == "compose_project" && row["key"] == "squirts:edge"),
         "service_dependencies should include compose project evidence: {answer}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn map_action_findings_mode_returns_topology_findings_without_raw_leaks() {
+    let inventory_dir = tempfile::tempdir().unwrap();
+    let _inventory_env = EnvVarGuard::set_path("CORTEX_INVENTORY_DIR", inventory_dir.path());
+    let h = TestHarness::new();
+    let inventory = graph_inventory_fixture();
+    write_inventory_cache_fixture(inventory_dir.path(), &inventory);
+    {
+        let _guard = db::graph::GRAPH_TEST_LOCK.lock();
+        db::graph::refresh_graph_projection(&h.pool).unwrap();
+        db::graph_inventory::project_inventory(&h.pool, &inventory).unwrap();
+    }
+
+    let value = execute_tool(
+        &h.state,
+        "cortex",
+        json!({
+            "action": "map",
+            "mode": "findings",
+            "finding_limit": 10,
+            "evidence_per_finding": 1
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let answer = &value["graph_answer"];
+    assert_eq!(answer["mode"], "findings");
+    assert_eq!(answer["target"]["entity_type"], "topology");
+    assert_eq!(value["summary"]["returned_hosts"], 0);
+    assert!(
+        answer["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(
+                |finding| finding["finding_type"] == "potential_public_route"
+                    && finding["reason_code"] == "reverse_proxy_route_configured"
+                    && finding["affected_entities"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .any(|entity| entity["key"] == "adguard.tootie.tv")
+            ),
+        "findings should include bounded public route proof: {answer}"
+    );
+    assert!(
+        answer["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| finding["finding_type"] == "risky_mounts"
+                && finding["reason_code"] == "docker_socket_mount"
+                && finding["affected_entities"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(
+                        |entity| entity["details"]["mount_source_kind"] == "docker_socket"
+                            && entity["details"]["read_only"] == "false"
+                    )),
+        "findings should include docker socket mount details: {answer}"
+    );
+    assert!(
+        answer["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| finding["finding_type"] == "collector_health"
+                && finding["reason_code"] == "collector_partial"),
+        "findings should include degraded collector context: {answer}"
+    );
+    let rendered = serde_json::to_string(answer).unwrap();
+    assert!(!rendered.contains("/secret/config.conf"), "{rendered}");
+    assert!(!rendered.contains("abc"), "{rendered}");
+    assert!(
+        !rendered.contains("/home/jmagar/.cortex/inventory"),
+        "{rendered}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add `map` `mode=findings` for topology findings: `potential_public_route`, `risky_mounts`, and `collector_health`
- add bounded graph findings queries plus relationship-type index migration; use inventory/cache details for mount and collector evidence
- update schema/help/docs, smoke harness, changelog, and version-bearing files to `1.15.0`

## Verification
- `cargo fmt --check`
- `RUSTC_WRAPPER='' cargo test --config 'build.rustc-wrapper=""'`
- `RUSTC_WRAPPER='' cargo clippy --config 'build.rustc-wrapper=""' -- -D warnings`
- `bash scripts/check-version-sync.sh`
- `.cache/cargo/debug/cortex compose doctor` and `compose status --json` (read-only live runtime: container running/healthy)
- isolated local server on alternate ports: `/health` OK, `map mode=findings` returned `collector_health` with `inventory_cache_missing`, `scripts/smoke-test.sh` passed 87/87 with 1 optional graph-proof skip

Bead: `syslog-mcp-ulmq.2` closed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `map` `mode=findings` to return bounded topology risk and hygiene findings with severity, confidence, redacted evidence, and follow-up queries. Adds payload-budget-aware trimming and degraded context, uses a new graph relationship-type index, and bumps version to 1.15.0.

- **New Features**
  - `map` `mode=findings` with `potential_public_route`, `risky_mounts`, `collector_health`.
  - Options: `finding_limit`, `evidence_per_finding`, `finding_types`; respects `payload_budget` and marks truncation.
  - Findings include affected entities, safe evidence IDs/excerpts, remediation, `next_queries`, and `proof_queries`.
  - Route findings prove configured reverse-proxy routes; they do not assert internet exposure. Redaction enforced for raw configs, cache paths, credentialed URLs, and warnings.
  - MCP schema/docs updated; README and tool docs cover arguments and semantics; smoke tests validate responses.

- **Migration**
  - DB schema v31 adds `idx_graph_relationships_type_seen` for bounded findings without broad scans; runs automatically.
  - No breaking changes to existing `map` modes; new fields under `graph_answer.findings`.
  - Version updated to 1.15.0 in `Cargo.toml`, `Cargo.lock`, `mcpb/manifest.json`, and `server.json`.

<sup>Written for commit f367433b1f6431e7cb91359995ed881384113114. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 1.15.0

* **New Features**
  * Added topology "findings" mode to the homelab map action, returning risk and hygiene findings including potential public routes, risky mounts, and collector health status
  * New query parameters: `finding_limit`, `evidence_per_finding`, and `finding_types` for customized findings discovery

* **Documentation**
  * Updated guides with details on the new findings mode, response structure, and bounded evidence handling

* **Chores**
  * Version bump to 1.15.0
  * Database schema optimization with new index for findings queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->