### PR TITLE
feat: build interactive cortex MCP Apps query widget (syslog-mcp-yi66.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-06-15
+
+### Added
+
+- Build out the MCP Apps query widget (`ui://cortex/query-widget`) into a self-contained, dependency-free interactive UI. It exposes an FTS5 query input plus hostname/severity/limit filters, calls the `cortex` tool with `action=search` over an MCP Apps host bridge (`window.openai.callTool` when present, otherwise an mcp-ui `postMessage` adapter), and renders results in a compact Aurora-dark table with idle/loading/empty/error/bridge-unavailable states. Replaces the previous placeholder form.
+
+### Security
+
+- Render all log fields in the query widget via `textContent`, preventing HTML/script injection from untrusted log message contents.
+
 ## [1.20.1] - 2026-06-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.3] - 2026-06-15
+
+### Security
+
+- Add a defense-in-depth Content-Security-Policy to the query widget (`img-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'`) capping egress/injection vectors it never uses. `script-src`/`connect-src` are intentionally left open so an MCP Apps host can inject its bridge; document the widget's origin-bound message handling and the `ui://` `targetOrigin: "*"` constraint in `docs/mcp/MCPUI.md`.
+- Stop interpolating server-controlled values into `python3 -c` programs in `scripts/smoke-test.sh`: `assert_gte` now reads the compared value via stdin, and `json_get` documents its literal-accessor-only contract.
+
+### Changed
+
+- Factor the repeated PUBLIC_URL `McpConfig` literals in the rmcp server tests into a `public_url_config()` helper, and fix a stray tab in `scripts/smoke-test.sh`.
+
 ## [1.21.2] - 2026-06-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.1] - 2026-06-15
+
+### Added
+
+- Document the MCP Apps query widget as progressive enhancement (README + `docs/SETUP.md`): canonical URI `ui://cortex/query-widget`, `text/html;profile=mcp-app` MIME, host-agnostic JSON-RPC verification snippets, and an explicit note that non-UI hosts keep receiving normal text/JSON tool results.
+- Add host-agnostic widget wire-contract smoke coverage to `scripts/smoke-test.sh`: `resources/list` exposure, `resources/read` MIME + anchors, `tools/list` `_meta.ui.resourceUri`, and `tools/call action=search` returning both `structuredContent` and text. No browser, Node, or named UI host required.
+
 ## [1.21.0] - 2026-06-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.2] - 2026-06-15
+
+### Changed
+
+- Consolidate duplicated rmcp server test helpers: `test_state`/`mounted_state` now delegate to a single `make_state(auth_policy)` builder, and the byte-identical `rmcp_router_no_auth_middleware` is folded into `rmcp_router`. Test-only; no behavior change.
+
 ## [1.21.1] - 2026-06-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.21.0"
+version = "1.21.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.21.2"
+version = "1.21.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.21.1"
+version = "1.21.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.20.1"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.21.0"
+version = "1.21.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.20.1"
+version = "1.21.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.21.2"
+version = "1.21.3"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.21.1"
+version = "1.21.2"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -138,6 +138,48 @@ workflows: `infra.incident-triage`, `infra.host-health`,
 For the prompt catalog and argument reference, see
 [`docs/mcp/PROMPTS.md`](docs/mcp/PROMPTS.md).
 
+## MCP Apps query widget
+
+cortex ships one interactive UI surface as **progressive enhancement**: a simple
+log-search widget for MCP hosts that support [MCP Apps](https://modelcontextprotocol.io/extensions/apps/overview)
+/ MCP-UI (`_meta.ui.resourceUri`). It is a single self-contained HTML resource —
+no browser build step, no external dependencies, no new server routes.
+
+- **Resource URI:** `ui://cortex/query-widget`
+- **MIME type:** `text/html;profile=mcp-app`
+- The `cortex` tool advertises it via `_meta.ui.resourceUri`; the widget calls the
+  same `cortex` tool with `action=search` over the host bridge and renders the
+  rows in a compact table.
+- It is a **simple search UI, not a dashboard** — query (FTS5) plus hostname,
+  severity, and limit filters.
+
+**Non-UI hosts are unaffected.** Plain MCP clients keep reading the normal
+text/JSON tool results; only hosts that detect `_meta.ui.resourceUri` fetch and
+render the `ui://` resource.
+
+Confirm the wire contract with raw JSON-RPC (no UI host required):
+
+```bash
+# Widget resource is listed
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}'
+
+# Widget HTML is served with the MCP Apps MIME type
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"ui://cortex/query-widget"}}'
+
+# Search returns both structuredContent (for UI rows) and text (for plain clients)
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"cortex","arguments":{"action":"search","query":"error","limit":5}}}'
+```
+
+If `CORTEX_TOKEN` is set, add `-H "Authorization: Bearer $CORTEX_TOKEN"`.
+`scripts/smoke-test.sh` runs these same checks automatically. For the wire-format
+details see [`docs/mcp/MCPUI.md`](docs/mcp/MCPUI.md).
+
 ### `cortex search`
 
 Full-text search across all syslog messages with optional filters. Uses SQLite FTS5 with porter stemming.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.2}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.3}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.1}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.2}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.0}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.1}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.20.1}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.0}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -134,6 +134,20 @@ curl -s -X POST http://localhost:3100/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"cortex","arguments":{"action":"tail","n":5}}}' | jq .
 ```
 
+Optionally confirm the MCP Apps query widget resource is served (host-agnostic —
+no UI client required):
+
+```bash
+curl -s -X POST http://localhost:3100/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"ui://cortex/query-widget"}}' | jq -r '.result.contents[0].mimeType'
+# Expected: text/html;profile=mcp-app
+```
+
+See the [MCP Apps query widget](../README.md#mcp-apps-query-widget) section for
+what the widget does and how non-UI hosts are unaffected.
+
 ## 8. Install as Claude Code plugin
 
 ```bash

--- a/docs/mcp/MCPUI.md
+++ b/docs/mcp/MCPUI.md
@@ -4,7 +4,14 @@ Protocol-level UI hints for MCP servers to improve client-side rendering of tool
 
 ## Current state
 
-cortex does not currently include MCP UI annotations in its tool schemas. Tool inputs use standard JSON Schema properties without `x-ui-*` extensions.
+cortex ships one MCP Apps surface: an interactive query widget.
+
+- **Resource:** `ui://cortex/query-widget`, served through `resources/list` and `resources/read` with MIME `text/html;profile=mcp-app` (see `src/mcp/rmcp_server.rs`).
+- **Tool link:** the `cortex` tool carries `_meta.ui.resourceUri` pointing at that resource with `visibility: ["model", "app"]`.
+- **Structured results:** `tools/call` returns both readable JSON text content and `structuredContent` so UI hosts can render rows without re-parsing text.
+- **Widget UI:** `src/mcp/ui/query_widget.html` is a self-contained, dependency-free page (FTS5 query + hostname/severity/limit filters) that calls the `cortex` tool with `action=search` over an MCP Apps host bridge — `window.openai.callTool` when the host injects it, otherwise an mcp-ui `postMessage` adapter (`type:"tool"` → `ui-message-response`). It degrades to a visible "bridge unavailable" state when no host bridge responds, and renders all log fields via `textContent` to avoid HTML injection.
+
+Tool inputs otherwise use standard JSON Schema properties without `x-ui-*` extensions.
 
 ## Schema annotations available
 

--- a/docs/mcp/MCPUI.md
+++ b/docs/mcp/MCPUI.md
@@ -11,6 +11,12 @@ cortex ships one MCP Apps surface: an interactive query widget.
 - **Structured results:** `tools/call` returns both readable JSON text content and `structuredContent` so UI hosts can render rows without re-parsing text.
 - **Widget UI:** `src/mcp/ui/query_widget.html` is a self-contained, dependency-free page (FTS5 query + hostname/severity/limit filters) that calls the `cortex` tool with `action=search` over an MCP Apps host bridge — `window.openai.callTool` when the host injects it, otherwise an mcp-ui `postMessage` adapter (`type:"tool"` → `ui-message-response`). It degrades to a visible "bridge unavailable" state when no host bridge responds, and renders all log fields via `textContent` to avoid HTML injection.
 
+### Security model of the widget bridge
+
+- **Inbound messages are origin-bound.** The `postMessage` handler accepts a response only when `event.source === window.parent` and the `messageId` matches the in-flight request exactly (it fails closed — a host that cannot echo the id times out rather than risking a stale/spoofed response). Reflected host error strings are length-capped and written via `textContent`.
+- **Outbound `postMessage` uses `targetOrigin: "*"`.** This is an inherent limitation of serving the widget from the `ui://` scheme: the framed widget cannot know its parent's real origin, so it cannot pin one. The outbound payload carries only the tool name and search parameters (no tokens or secrets), so the exposure is minimal. A host that serves the widget from a real HTTPS origin can pin that origin instead.
+- **A defense-in-depth CSP** (`img-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'`) blocks egress/injection vectors the widget never uses. `script-src`/`connect-src` are intentionally left open so a host can inject its bridge; tightening them requires live-host verification (see bead `syslog-mcp-7kqp2`).
+
 Tool inputs otherwise use standard JSON Schema properties without `x-ui-*` extensions.
 
 ## Schema annotations available

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -306,6 +306,71 @@ except Exception as e:
 ")
 assert_eq "prompt output schema resource is available" "$PROMPT_SCHEMA_VALID" "ok"
 
+# MCP Apps query widget wire contract — host-agnostic. No browser, Node, or named
+# UI host required; this verifies only the MCP JSON-RPC surface that any capable
+# host (e.g. one honoring _meta.ui.resourceUri) would consume. Non-UI clients
+# keep using normal text/JSON tool results and are unaffected by these fields.
+RES_LIST=$(mcp_jsonrpc '{"jsonrpc":"2.0","id":110,"method":"resources/list","params":{}}' || true)
+RES_LIST_VALID=$(printf '%s\n' "$RES_LIST" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    uris = {r['uri'] for r in d['result']['resources']}
+    assert 'ui://cortex/query-widget' in uris, uris
+    assert 'cortex://schema/mcp-tool' in uris, uris
+    print('ok')
+except Exception as e:
+    print(f'error: {e}')
+")
+assert_eq "resources/list exposes the query widget resource" "$RES_LIST_VALID" "ok"
+
+WIDGET_READ=$(mcp_jsonrpc '{"jsonrpc":"2.0","id":111,"method":"resources/read","params":{"uri":"ui://cortex/query-widget"}}' || true)
+WIDGET_READ_VALID=$(printf '%s\n' "$WIDGET_READ" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    c = d['result']['contents'][0]
+    assert c['uri'] == 'ui://cortex/query-widget', c.get('uri')
+    assert c['mimeType'] == 'text/html;profile=mcp-app', c.get('mimeType')
+    html = c['text']
+    for anchor in ['data-syslog-query-widget', 'value=\"search\"', 'name=\"query\"',
+                   'ui-message-response', 'event.source', 'Host bridge unavailable']:
+        assert anchor in html, anchor
+    print('ok')
+except Exception as e:
+    print(f'error: {e}')
+")
+assert_eq "resources/read returns query widget HTML with MCP Apps MIME + anchors" "$WIDGET_READ_VALID" "ok"
+
+TOOLS_META=$(mcp_jsonrpc '{"jsonrpc":"2.0","id":112,"method":"tools/list","params":{}}' || true)
+TOOLS_META_VALID=$(printf '%s\n' "$TOOLS_META" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    tool = next(t for t in d['result']['tools'] if t['name'] == 'cortex')
+    ui = tool['_meta']['ui']
+    assert ui['resourceUri'] == 'ui://cortex/query-widget', ui.get('resourceUri')
+    print('ok')
+except Exception as e:
+    print(f'error: {e}')
+")
+assert_eq "tools/list cortex tool advertises _meta.ui.resourceUri" "$TOOLS_META_VALID" "ok"
+
+WIDGET_SEARCH=$(mcp_jsonrpc '{"jsonrpc":"2.0","id":113,"method":"tools/call","params":{"name":"cortex","arguments":{"action":"search","query":"smoke","limit":1}}}' || true)
+WIDGET_SEARCH_VALID=$(printf '%s\n' "$WIDGET_SEARCH" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    r = d['result']
+    # UI hosts render structuredContent; non-UI hosts read content[0].text.
+    assert 'logs' in r['structuredContent'], 'no structuredContent.logs'
+    assert r['content'][0]['text'], 'no text content'
+    print('ok')
+except Exception as e:
+    print(f'error: {e}')
+")
+assert_eq "tools/call action=search returns structuredContent and text" "$WIDGET_SEARCH_VALID" "ok"
+
 # ─── Phase 2: Seed test data ─────────────────────────────────────────────────
 echo ""
 echo -e "${COLOR_BOLD}[2/4] Seeding test data${COLOR_RESET}"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -121,6 +121,9 @@ mcp_jsonrpc() {
 }
 
 json_get() {
+    # NOTE: $field is interpolated into the Python program, so callers MUST pass
+    # only a literal accessor (e.g. ['status']) — never a server-controlled value.
+    # The JSON payload itself is safe: it is piped via stdin, not interpolated.
     local json="$1" field="$2"
     printf '%s\n' "$json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d$field)" 2>/dev/null
 }
@@ -136,7 +139,16 @@ assert_eq() {
 
 assert_gte() {
     local label="$1" actual="$2" min="$3"
-    if python3 -c "exit(0 if int('$actual') >= $min else 1)" 2>/dev/null; then
+    # Read $actual via stdin rather than interpolating it into the -c program —
+    # it can originate from server JSON, and int() of an interpolated string is a
+    # footgun. ($min is always an integer literal from in-script callers.)
+    if printf '%s' "$actual" | python3 -c "
+import sys
+try:
+    sys.exit(0 if int(sys.stdin.read().strip()) >= $min else 1)
+except ValueError:
+    sys.exit(1)
+" 2>/dev/null; then
         pass "$label"
     else
         fail "$label (expected >= $min, got '$actual')"
@@ -1066,7 +1078,7 @@ if [[ -n "${CORTEX_SMOKE_GRAPH_EVIDENCE_ID:-}" ]]; then
     GRAPH_PROOF_END=$(python3 -c "import time; print(int(time.time() * 1000))")
     assert_no_error "graph evidence: no error" "$GRAPH_EVIDENCE"
     GRAPH_EVIDENCE_BYTES=$(printf '%s' "$GRAPH_EVIDENCE" | wc -c | tr -d ' ')
-	    GRAPH_EVIDENCE_LATENCY_MS=$((GRAPH_PROOF_END - GRAPH_PROOF_START))
+    GRAPH_EVIDENCE_LATENCY_MS=$((GRAPH_PROOF_END - GRAPH_PROOF_START))
     GRAPH_EVIDENCE_VALID=$(printf '%s\n' "$GRAPH_EVIDENCE" | python3 -c "
 import json, re, sys
 d = json.load(sys.stdin)

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.20.1",
+  "version": "1.21.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.20.1",
+      "identifier": "ghcr.io/jmagar/cortex:v1.21.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.21.1",
+  "version": "1.21.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.21.1",
+      "identifier": "ghcr.io/jmagar/cortex:v1.21.2",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.21.0",
+  "version": "1.21.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.21.0",
+      "identifier": "ghcr.io/jmagar/cortex:v1.21.1",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.21.2",
+  "version": "1.21.3",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.21.2",
+      "identifier": "ghcr.io/jmagar/cortex:v1.21.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -23,9 +23,12 @@ use super::{
     required_scope_for,
 };
 
-fn test_state() -> (AppState, Arc<DbPool>, tempfile::TempDir) {
+/// Build an AppState with the given auth policy. The two production-relevant
+/// policies in these tests (`LoopbackDev`, `Mounted`) share an otherwise
+/// identical config, so they differ only in the policy passed here.
+fn make_state(auth_policy: AuthPolicy) -> (AppState, Arc<DbPool>, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
-    let storage = StorageConfig::for_test(dir.path().join("rmcp-server-test.db"));
+    let storage = StorageConfig::for_test(dir.path().join("rmcp-test.db"));
     let pool = Arc::new(db::init_pool(&storage).unwrap());
     let state = AppState {
         service: CortexService::new(Arc::clone(&pool), storage.clone()),
@@ -43,37 +46,19 @@ fn test_state() -> (AppState, Arc<DbPool>, tempfile::TempDir) {
         },
         notifications_config: crate::config::NotificationsConfig::default(),
         otlp_counters: Arc::new(crate::otlp::OtlpCounters::default()),
-        auth_policy: crate::mcp::AuthPolicy::LoopbackDev,
+        auth_policy,
         observability: Arc::new(crate::observability::RuntimeObservability::default()),
     };
     (state, pool, dir)
 }
 
+fn test_state() -> (AppState, Arc<DbPool>, tempfile::TempDir) {
+    make_state(AuthPolicy::LoopbackDev)
+}
+
 /// Build a Mounted-policy AppState (no OAuth; static-bearer only path).
 fn mounted_state() -> (AppState, Arc<DbPool>, tempfile::TempDir) {
-    let dir = tempfile::tempdir().unwrap();
-    let storage = StorageConfig::for_test(dir.path().join("rmcp-mounted-test.db"));
-    let pool = Arc::new(db::init_pool(&storage).unwrap());
-    let state = AppState {
-        service: CortexService::new(Arc::clone(&pool), storage.clone()),
-        config: McpConfig {
-            host: "127.0.0.1".into(),
-            port: 3100,
-            server_name: "cortex".into(),
-            no_auth: false,
-            trusted_gateway_no_auth: false,
-            api_token: crate::config::Secret(None),
-            allowed_hosts: Vec::new(),
-            allowed_origins: Vec::new(),
-            auth: Default::default(),
-            static_token_is_admin: false,
-        },
-        notifications_config: crate::config::NotificationsConfig::default(),
-        otlp_counters: Arc::new(crate::otlp::OtlpCounters::default()),
-        auth_policy: AuthPolicy::Mounted { auth_state: None },
-        observability: Arc::new(crate::observability::RuntimeObservability::default()),
-    };
-    (state, pool, dir)
+    make_state(AuthPolicy::Mounted { auth_state: None })
 }
 
 /// Build a test router with an axum middleware that injects `auth_ctx` into
@@ -92,13 +77,6 @@ fn rmcp_router_with_auth(state: AppState, auth_ctx: AuthContext) -> Router {
                 }
             },
         ))
-}
-
-/// Build a test router WITHOUT any auth middleware (simulates broken
-/// middleware ordering — AuthContext never inserted).
-fn rmcp_router_no_auth_middleware(state: AppState) -> Router {
-    let config = streamable_http_config(&state.config);
-    Router::new().nest_service("/mcp", streamable_http_service(state, config))
 }
 
 fn auth_ctx(subject: &str, scopes: Vec<&str>, email: Option<&str>) -> AuthContext {
@@ -819,7 +797,7 @@ fn public_url_standard_https_port_host_variants() {
 async fn loopback_dev_policy_permits_all_actions_without_auth_context() {
     let (state, _pool, _dir) = test_state();
     // No auth middleware — AuthContext is NOT in extensions.
-    let router = rmcp_router_no_auth_middleware(state);
+    let router = rmcp_router(state);
 
     // tools/list should succeed without AuthContext under LoopbackDev.
     let (status, response) = post_rmcp(
@@ -1181,7 +1159,7 @@ async fn mounted_policy_with_empty_scopes_permits_help_action() {
 async fn mounted_policy_missing_auth_context_denies_all_including_help_and_tools_list() {
     let (state, _pool, _dir) = mounted_state();
     // No auth middleware — AuthContext absent from extensions.
-    let router = rmcp_router_no_auth_middleware(state);
+    let router = rmcp_router(state);
 
     // tools/list must be denied when AuthContext absent under Mounted policy.
     let (status, response) = post_rmcp(

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -1477,6 +1477,7 @@ async fn mounted_policy_with_auth_context_permits_query_widget_resource() {
         "data-rows",               // results table body
         "Host bridge unavailable", // graceful bridge-unavailable state
         "ui-message-response",     // mcp-ui postMessage bridge protocol
+        "event.source",            // origin-bound message guard (anti-spoof)
     ] {
         assert!(
             widget_html.contains(anchor),

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -658,10 +658,11 @@ async fn rmcp_correlate_events_preserves_truncation_and_host_grouping() {
 
 // ── PUBLIC_URL host/origin allowlist extension ───────────────────────────────
 
-/// `CORTEX_PUBLIC_URL` bare host is added to `allowed_hosts`.
-#[test]
-fn public_url_host_added_to_allowed_hosts() {
-    let config = McpConfig {
+/// Build a default `McpConfig` (host `0.0.0.0`) whose only non-default field is
+/// `auth.public_url`. Shared by the PUBLIC_URL allowlist tests below, which
+/// differ only in the URL they assert against.
+fn public_url_config(public_url: &str) -> McpConfig {
+    McpConfig {
         host: "0.0.0.0".into(),
         port: 3100,
         server_name: "cortex".into(),
@@ -671,11 +672,17 @@ fn public_url_host_added_to_allowed_hosts() {
         allowed_hosts: Vec::new(),
         allowed_origins: Vec::new(),
         auth: crate::config::AuthConfig {
-            public_url: Some("https://syslog.example.com".into()),
+            public_url: Some(public_url.into()),
             ..Default::default()
         },
         static_token_is_admin: false,
-    };
+    }
+}
+
+/// `CORTEX_PUBLIC_URL` bare host is added to `allowed_hosts`.
+#[test]
+fn public_url_host_added_to_allowed_hosts() {
+    let config = public_url_config("https://syslog.example.com");
 
     let hosts = allowed_hosts(&config);
     assert!(
@@ -688,21 +695,7 @@ fn public_url_host_added_to_allowed_hosts() {
 /// without the port (browsers omit default ports from the Origin header).
 #[test]
 fn public_url_origin_added_to_allowed_origins() {
-    let config = McpConfig {
-        host: "0.0.0.0".into(),
-        port: 3100,
-        server_name: "cortex".into(),
-        no_auth: false,
-        trusted_gateway_no_auth: false,
-        api_token: crate::config::Secret(None),
-        allowed_hosts: Vec::new(),
-        allowed_origins: Vec::new(),
-        auth: crate::config::AuthConfig {
-            public_url: Some("https://syslog.example.com".into()),
-            ..Default::default()
-        },
-        static_token_is_admin: false,
-    };
+    let config = public_url_config("https://syslog.example.com");
 
     let origins = allowed_origins(&config);
     // https on port 443 (default) — browser omits port from Origin header.
@@ -715,21 +708,7 @@ fn public_url_origin_added_to_allowed_origins() {
 /// Non-standard port: host and origin variants both include the explicit port.
 #[test]
 fn public_url_non_standard_port_included_in_host_and_origin() {
-    let config = McpConfig {
-        host: "0.0.0.0".into(),
-        port: 3100,
-        server_name: "cortex".into(),
-        no_auth: false,
-        trusted_gateway_no_auth: false,
-        api_token: crate::config::Secret(None),
-        allowed_hosts: Vec::new(),
-        allowed_origins: Vec::new(),
-        auth: crate::config::AuthConfig {
-            public_url: Some("https://syslog.example.com:8443".into()),
-            ..Default::default()
-        },
-        static_token_is_admin: false,
-    };
+    let config = public_url_config("https://syslog.example.com:8443");
 
     let hosts = allowed_hosts(&config);
     // Non-standard port: both bare host and host:port must be present.
@@ -756,21 +735,7 @@ fn public_url_non_standard_port_included_in_host_and_origin() {
 /// host:443 is also added so rmcp's port-aware comparison passes.
 #[test]
 fn public_url_standard_https_port_host_variants() {
-    let config = McpConfig {
-        host: "0.0.0.0".into(),
-        port: 3100,
-        server_name: "cortex".into(),
-        no_auth: false,
-        trusted_gateway_no_auth: false,
-        api_token: crate::config::Secret(None),
-        allowed_hosts: Vec::new(),
-        allowed_origins: Vec::new(),
-        auth: crate::config::AuthConfig {
-            public_url: Some("https://syslog.example.com".into()),
-            ..Default::default()
-        },
-        static_token_is_admin: false,
-    };
+    let config = public_url_config("https://syslog.example.com");
 
     let hosts = allowed_hosts(&config);
     // Bare host: what browsers send when using the default port.

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -1459,12 +1459,30 @@ async fn mounted_policy_with_auth_context_permits_query_widget_resource() {
         response["result"]["contents"][0]["mimeType"],
         super::MCP_APP_HTML_MIME_TYPE
     );
+    let widget_html = response["result"]["contents"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
     assert!(
-        response["result"]["contents"][0]["text"]
-            .as_str()
-            .is_some_and(|text| text.contains("data-syslog-query-widget")),
+        widget_html.contains("data-syslog-query-widget"),
         "resources/read should return query widget HTML; response: {response}"
     );
+    // Stable anchors the widget UI depends on. These guard the wire format
+    // (per yi66 risk note: verify format, do not assume a host renderer).
+    for anchor in [
+        "value=\"search\"",        // hidden action input -> action=search
+        "name=\"query\"",          // FTS5 query field
+        "name=\"hostname\"",       // hostname filter
+        "name=\"severity\"",       // severity filter
+        "name=\"limit\"",          // limit control
+        "data-rows",               // results table body
+        "Host bridge unavailable", // graceful bridge-unavailable state
+        "ui-message-response",     // mcp-ui postMessage bridge protocol
+    ] {
+        assert!(
+            widget_html.contains(anchor),
+            "query widget HTML missing stable anchor {anchor:?}; response: {response}"
+        );
+    }
 }
 
 /// Scope check fires BEFORE execute_tool — a read denied by scope must not

--- a/src/mcp/ui/query_widget.html
+++ b/src/mcp/ui/query_widget.html
@@ -181,7 +181,8 @@
     "use strict";
 
     var TOOL_NAME = "cortex";
-    var BRIDGE_TIMEOUT_MS = 15000;
+    var BRIDGE_TIMEOUT_MS = 12000;
+    var MAX_ERR_LEN = 200;
 
     var form = document.querySelector("[data-query-form]");
     var statusEl = document.querySelector("[data-status]");
@@ -280,6 +281,24 @@
       return params;
     }
 
+    // Reject a hung promise after `ms` so both bridge paths share one liveness
+    // contract — otherwise a host that never settles wedges the form forever.
+    function withTimeout(promise, ms, onTimeout) {
+      return new Promise(function (resolve, reject) {
+        var settled = false;
+        var timer = setTimeout(function () {
+          if (settled) return;
+          settled = true;
+          if (onTimeout) onTimeout();
+          reject(new Error("no-bridge"));
+        }, ms);
+        Promise.resolve(promise).then(
+          function (v) { if (settled) return; settled = true; clearTimeout(timer); resolve(v); },
+          function (e) { if (settled) return; settled = true; clearTimeout(timer); reject(e); }
+        );
+      });
+    }
+
     // ---- Host bridge ---------------------------------------------------------
     // Primary: OpenAI/MCP Apps injected helper, if the host provides one.
     // Fallback: mcp-ui async postMessage protocol (type:"tool" ->
@@ -288,13 +307,20 @@
     function callTool(params) {
       var host = window.openai;
       if (host && typeof host.callTool === "function") {
+        var call;
         try {
-          return Promise.resolve(host.callTool(TOOL_NAME, params));
+          call = Promise.resolve(host.callTool(TOOL_NAME, params));
         } catch (e) {
           return Promise.reject(e);
         }
+        // The injected helper gives no timeout of its own; bound it ourselves.
+        return withTimeout(call, BRIDGE_TIMEOUT_MS, notifyStalling);
       }
       return postMessageCall(params);
+    }
+
+    function notifyStalling() {
+      setStatus("Host bridge not responding…", "loading");
     }
 
     var msgSeq = 0;
@@ -303,32 +329,59 @@
         return Promise.reject(new Error("no-bridge"));
       }
       return new Promise(function (resolve, reject) {
-        var messageId = "cortex-" + (++msgSeq) + "-" + (Date.now ? Date.now() : "");
-        var timer = setTimeout(function () {
+        var messageId = "cortex-" + (++msgSeq) + "-" + Date.now();
+        var done = false;
+        function cleanup() {
+          clearTimeout(timer);
           window.removeEventListener("message", onMessage);
+        }
+        var timer = setTimeout(function () {
+          if (done) return;
+          done = true;
+          notifyStalling();
+          cleanup();
           reject(new Error("no-bridge"));
         }, BRIDGE_TIMEOUT_MS);
 
         function onMessage(event) {
+          // Only accept responses from our direct parent frame. Without this a
+          // sibling/cross-origin frame could spoof a response (messageId is
+          // predictable), so origin-binding is the real correlation guard.
+          if (event.source !== window.parent) return;
           var data = event.data;
           if (!data || typeof data !== "object") return;
-          if (data.messageId && data.messageId !== messageId) return;
+          // Require a positive messageId match. A host that cannot echo the id
+          // cannot be safely multiplexed — fail closed (timeout) rather than
+          // risk applying a stale response to a later query.
+          if (data.messageId !== messageId) return;
           if (data.type !== "ui-message-response" && data.type !== "tool-response") return;
-          clearTimeout(timer);
-          window.removeEventListener("message", onMessage);
+          if (done) return;
+          done = true;
+          cleanup();
           var payload = data.payload || {};
           if (payload.error) {
-            reject(new Error(typeof payload.error === "string" ? payload.error : "tool call failed"));
+            var msg = typeof payload.error === "string"
+              ? payload.error.slice(0, MAX_ERR_LEN)
+              : "tool call failed";
+            reject(new Error(msg));
           } else {
             resolve(payload.response != null ? payload.response : payload);
           }
         }
 
         window.addEventListener("message", onMessage);
-        window.parent.postMessage(
-          { type: "tool", messageId: messageId, payload: { toolName: TOOL_NAME, params: params } },
-          "*"
-        );
+        try {
+          window.parent.postMessage(
+            { type: "tool", messageId: messageId, payload: { toolName: TOOL_NAME, params: params } },
+            "*"
+          );
+        } catch (e) {
+          if (!done) {
+            done = true;
+            cleanup();
+            reject(e);
+          }
+        }
       });
     }
 
@@ -349,7 +402,8 @@
         if (err && err.message === "no-bridge") {
           setStatus("Host bridge unavailable — open this widget in an MCP Apps host to run searches.", "unavailable");
         } else {
-          setStatus("Search failed: " + (err && err.message ? err.message : "unknown error"), "error");
+          var reason = err && err.message ? String(err.message).slice(0, MAX_ERR_LEN) : "unknown error";
+          setStatus("Search failed: " + reason, "error");
         }
       }).then(function () {
         submitEl.disabled = false;

--- a/src/mcp/ui/query_widget.html
+++ b/src/mcp/ui/query_widget.html
@@ -3,17 +3,359 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Syslog Query</title>
+  <title>Cortex Syslog Query</title>
+  <style>
+    /* Aurora dark-first tokens (inlined — widget must be dependency-free). */
+    :root {
+      --aurora-bg: #07131c;
+      --aurora-surface: #0d1f2b;
+      --aurora-surface-2: #102633;
+      --aurora-border: #1d3d4e;
+      --aurora-primary: #e6f4fb;
+      --aurora-muted: #a7bcc9;
+      --aurora-accent: #29b6f6;
+      --aurora-accent-strong: #67cbfa;
+      --aurora-rose: #f9a8c4;
+      --sev-error: #c78490;
+      --sev-warn: #c6a36b;
+      --sev-info: #72c8f5;
+      --sev-neutral: #91a8b6;
+      --radius: 8px;
+      --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; }
+    body {
+      background: var(--aurora-bg);
+      color: var(--aurora-primary);
+      font-family: Manrope, Inter, system-ui, -apple-system, Segoe UI, sans-serif;
+      font-size: 13px;
+      line-height: 1.45;
+      padding: 12px;
+    }
+    form {
+      display: grid;
+      grid-template-columns: 1fr 96px;
+      gap: 8px 10px;
+      align-items: end;
+    }
+    .field { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+    .field.query { grid-column: 1 / -1; }
+    .field.filters {
+      grid-column: 1 / -1;
+      display: grid;
+      grid-template-columns: 1fr 1fr 96px;
+      gap: 8px;
+      align-items: end;
+    }
+    label { color: var(--aurora-muted); font-size: 11px; font-weight: 600; letter-spacing: .02em; }
+    input, select {
+      background: var(--aurora-surface);
+      color: var(--aurora-primary);
+      border: 1px solid var(--aurora-border);
+      border-radius: var(--radius);
+      padding: 7px 9px;
+      font: inherit;
+      width: 100%;
+    }
+    input:focus, select:focus {
+      outline: none;
+      border-color: var(--aurora-accent);
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--aurora-accent) 35%, transparent);
+    }
+    .hint { color: var(--aurora-muted); font-size: 11px; margin: 2px 0 0; }
+    button {
+      grid-column: 2;
+      background: var(--aurora-accent);
+      color: #04222f;
+      border: none;
+      border-radius: var(--radius);
+      padding: 8px 12px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background .12s ease;
+    }
+    button:hover:not(:disabled) { background: var(--aurora-accent-strong); }
+    button:disabled { opacity: .55; cursor: progress; }
+    output {
+      display: block;
+      margin-top: 12px;
+      color: var(--aurora-muted);
+      min-height: 1.2em;
+    }
+    output[data-state="error"] { color: var(--sev-error); }
+    output[data-state="unavailable"] { color: var(--sev-warn); }
+    .results { margin-top: 10px; border: 1px solid var(--aurora-border); border-radius: var(--radius); overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; font-size: 12px; }
+    thead th {
+      text-align: left;
+      background: var(--aurora-surface-2);
+      color: var(--aurora-muted);
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: .04em;
+      padding: 6px 8px;
+      position: sticky;
+      top: 0;
+    }
+    tbody td { padding: 6px 8px; border-top: 1px solid var(--aurora-border); vertical-align: top; }
+    tbody tr:nth-child(even) { background: color-mix(in srgb, var(--aurora-surface) 55%, transparent); }
+    td.ts, td.id { font-family: var(--mono); color: var(--aurora-muted); white-space: nowrap; }
+    td.host { font-family: var(--mono); color: var(--aurora-rose); white-space: nowrap; }
+    td.app { color: var(--aurora-muted); white-space: nowrap; }
+    td.msg {
+      font-family: var(--mono);
+      max-width: 0;
+      width: 100%;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+    .sev {
+      display: inline-block;
+      padding: 1px 6px;
+      border-radius: 999px;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      border: 1px solid currentColor;
+      white-space: nowrap;
+    }
+    .sev-error { color: var(--sev-error); }
+    .sev-warn { color: var(--sev-warn); }
+    .sev-info { color: var(--sev-info); }
+    .sev-neutral { color: var(--sev-neutral); }
+    .scroll { max-height: 360px; overflow: auto; }
+  </style>
 </head>
 <body data-syslog-query-widget>
-  <form aria-label="Syslog query">
-    <label>
-      Query
-      <input name="query" type="search" autocomplete="off" placeholder="error AND sshd">
-    </label>
+  <form aria-label="Cortex syslog query" data-query-form>
+    <div class="field query">
+      <label for="q">Query</label>
+      <input id="q" name="query" type="search" autocomplete="off" placeholder="error AND sshd">
+      <p class="hint">FTS5 syntax. Hyphen is NOT — wrap hyphenated terms in quotes: <code>"smoke-test"</code>.</p>
+    </div>
+    <div class="field filters">
+      <div class="field">
+        <label for="host">Hostname</label>
+        <input id="host" name="hostname" type="text" autocomplete="off" placeholder="any host">
+      </div>
+      <div class="field">
+        <label for="sev">Severity</label>
+        <select id="sev" name="severity">
+          <option value="">Any</option>
+          <option value="emerg">emerg</option>
+          <option value="alert">alert</option>
+          <option value="crit">crit</option>
+          <option value="err">err</option>
+          <option value="warning">warning</option>
+          <option value="notice">notice</option>
+          <option value="info">info</option>
+          <option value="debug">debug</option>
+        </select>
+      </div>
+      <div class="field">
+        <label for="limit">Limit</label>
+        <input id="limit" name="limit" type="number" min="1" max="1000" value="25">
+      </div>
+    </div>
     <input name="action" type="hidden" value="search">
-    <button type="submit">Search</button>
+    <button type="submit" data-submit>Search</button>
   </form>
-  <output aria-live="polite">Ready to query cortex logs.</output>
+
+  <output aria-live="polite" data-status data-state="idle">Ready to query cortex logs.</output>
+  <div class="results" data-results hidden>
+    <div class="scroll">
+      <table>
+        <thead>
+          <tr>
+            <th>Received</th><th>Host</th><th>Severity</th><th>App</th><th>Message</th><th>ID</th>
+          </tr>
+        </thead>
+        <tbody data-rows></tbody>
+      </table>
+    </div>
+  </div>
+
+  <script>
+  (function () {
+    "use strict";
+
+    var TOOL_NAME = "cortex";
+    var BRIDGE_TIMEOUT_MS = 15000;
+
+    var form = document.querySelector("[data-query-form]");
+    var statusEl = document.querySelector("[data-status]");
+    var resultsEl = document.querySelector("[data-results]");
+    var rowsEl = document.querySelector("[data-rows]");
+    var submitEl = document.querySelector("[data-submit]");
+
+    var SEV_CLASS = {
+      emerg: "sev-error", alert: "sev-error", crit: "sev-error", err: "sev-error",
+      warning: "sev-warn",
+      notice: "sev-info", info: "sev-info",
+      debug: "sev-neutral"
+    };
+
+    function setStatus(text, state) {
+      statusEl.textContent = text;
+      statusEl.setAttribute("data-state", state || "idle");
+    }
+
+    function sevClass(sev) {
+      return SEV_CLASS[String(sev || "").toLowerCase()] || "sev-neutral";
+    }
+
+    // Normalize whatever the host hands back into { count, logs: [] }.
+    // Hosts may return a full CallToolResult, just structuredContent, or the
+    // raw response object. Fall back to parsing JSON text content.
+    function normalize(result) {
+      if (!result || typeof result !== "object") return null;
+      var r = result;
+      if (r.structuredContent && typeof r.structuredContent === "object") {
+        r = r.structuredContent;
+      }
+      if (Array.isArray(r.logs)) return r;
+      if (Array.isArray(result.content)) {
+        for (var i = 0; i < result.content.length; i++) {
+          var c = result.content[i];
+          if (c && c.type === "text" && typeof c.text === "string") {
+            try {
+              var parsed = JSON.parse(c.text);
+              if (parsed && Array.isArray(parsed.logs)) return parsed;
+            } catch (e) { /* not JSON; keep looking */ }
+          }
+        }
+      }
+      return null;
+    }
+
+    function render(data) {
+      rowsEl.textContent = "";
+      var logs = data.logs || [];
+      var count = typeof data.count === "number" ? data.count : logs.length;
+      if (!logs.length) {
+        resultsEl.hidden = true;
+        setStatus("No matching log entries.", "idle");
+        return;
+      }
+      var frag = document.createDocumentFragment();
+      logs.forEach(function (row) {
+        var tr = document.createElement("tr");
+        tr.appendChild(cell("ts", row.received_at || row.timestamp || ""));
+        tr.appendChild(cell("host", row.hostname || ""));
+        var sevTd = document.createElement("td");
+        var badge = document.createElement("span");
+        badge.className = "sev " + sevClass(row.severity);
+        badge.textContent = row.severity || "";
+        sevTd.appendChild(badge);
+        tr.appendChild(sevTd);
+        tr.appendChild(cell("app", row.app_name || ""));
+        tr.appendChild(cell("msg", row.message || ""));
+        tr.appendChild(cell("id", row.id != null ? String(row.id) : ""));
+        frag.appendChild(tr);
+      });
+      rowsEl.appendChild(frag);
+      resultsEl.hidden = false;
+      setStatus(count + (count === 1 ? " entry" : " entries") + " returned.", "idle");
+    }
+
+    function cell(cls, text) {
+      var td = document.createElement("td");
+      td.className = cls;
+      td.textContent = text; // textContent prevents HTML injection from log data
+      return td;
+    }
+
+    function buildParams() {
+      var fd = new FormData(form);
+      var params = { action: "search" };
+      var query = String(fd.get("query") || "").trim();
+      if (query) params.query = query;
+      var hostname = String(fd.get("hostname") || "").trim();
+      if (hostname) params.hostname = hostname;
+      var severity = String(fd.get("severity") || "").trim();
+      if (severity) params.severity = severity;
+      var limit = parseInt(fd.get("limit"), 10);
+      if (!isNaN(limit) && limit > 0) params.limit = limit;
+      return params;
+    }
+
+    // ---- Host bridge ---------------------------------------------------------
+    // Primary: OpenAI/MCP Apps injected helper, if the host provides one.
+    // Fallback: mcp-ui async postMessage protocol (type:"tool" ->
+    // "ui-message-response"). If neither responds, degrade to an unavailable
+    // state instead of failing silently.
+    function callTool(params) {
+      var host = window.openai;
+      if (host && typeof host.callTool === "function") {
+        try {
+          return Promise.resolve(host.callTool(TOOL_NAME, params));
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      }
+      return postMessageCall(params);
+    }
+
+    var msgSeq = 0;
+    function postMessageCall(params) {
+      if (window.parent === window) {
+        return Promise.reject(new Error("no-bridge"));
+      }
+      return new Promise(function (resolve, reject) {
+        var messageId = "cortex-" + (++msgSeq) + "-" + (Date.now ? Date.now() : "");
+        var timer = setTimeout(function () {
+          window.removeEventListener("message", onMessage);
+          reject(new Error("no-bridge"));
+        }, BRIDGE_TIMEOUT_MS);
+
+        function onMessage(event) {
+          var data = event.data;
+          if (!data || typeof data !== "object") return;
+          if (data.messageId && data.messageId !== messageId) return;
+          if (data.type !== "ui-message-response" && data.type !== "tool-response") return;
+          clearTimeout(timer);
+          window.removeEventListener("message", onMessage);
+          var payload = data.payload || {};
+          if (payload.error) {
+            reject(new Error(typeof payload.error === "string" ? payload.error : "tool call failed"));
+          } else {
+            resolve(payload.response != null ? payload.response : payload);
+          }
+        }
+
+        window.addEventListener("message", onMessage);
+        window.parent.postMessage(
+          { type: "tool", messageId: messageId, payload: { toolName: TOOL_NAME, params: params } },
+          "*"
+        );
+      });
+    }
+
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      var params = buildParams();
+      submitEl.disabled = true;
+      resultsEl.hidden = true;
+      setStatus("Searching…", "loading");
+      callTool(params).then(function (result) {
+        var data = normalize(result);
+        if (!data) {
+          setStatus("Search ran but the response could not be read.", "error");
+          return;
+        }
+        render(data);
+      }).catch(function (err) {
+        if (err && err.message === "no-bridge") {
+          setStatus("Host bridge unavailable — open this widget in an MCP Apps host to run searches.", "unavailable");
+        } else {
+          setStatus("Search failed: " + (err && err.message ? err.message : "unknown error"), "error");
+        }
+      }).then(function () {
+        submitEl.disabled = false;
+      });
+    });
+  })();
+  </script>
 </body>
 </html>

--- a/src/mcp/ui/query_widget.html
+++ b/src/mcp/ui/query_widget.html
@@ -3,6 +3,19 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!--
+    Defense-in-depth CSP. The widget renders attacker-influenceable log text (a
+    spoofed CEF hostname is a known trust-boundary gotcha) and only ever writes
+    via textContent, so this caps the blast radius of any future regression by
+    blocking egress/injection vectors the widget never uses: no images (beacon
+    exfil), objects, <base>, or form posts. script-src/connect-src are left
+    unrestricted on purpose — an MCP Apps host may inject its bridge (e.g.
+    window.openai) via an external script or fetch, and locking those down
+    without live-host verification could break the bridge. Tightening them is
+    tracked separately and must be verified against the real host.
+  -->
+  <meta http-equiv="Content-Security-Policy"
+        content="img-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
   <title>Cortex Syslog Query</title>
   <style>
     /* Aurora dark-first tokens (inlined — widget must be dependency-free). */


### PR DESCRIPTION
## Summary

The cortex MCP-UI widget rendered as a bare, unstyled, non-functional form — the prior `query_widget.html` was only a placeholder stub from the server-contract slice (`syslog-mcp-yi66.1`). This builds out the actual widget (`syslog-mcp-yi66.2`).

- Self-contained, dependency-free, Aurora-dark widget: FTS5 query input + hostname/severity/limit filters.
- Submit calls the `cortex` tool with `action=search` over an MCP Apps host bridge — `window.openai.callTool` when injected, else an mcp-ui `postMessage` adapter (`type:"tool"` → `ui-message-response`).
- Renders a compact results table (received_at/timestamp, host, severity badge, app, message, id) with idle/loading/empty/error/bridge-unavailable states and clean long-message wrapping.
- All log fields rendered via `textContent` — no HTML injection from untrusted log data.
- Server contract (MIME `text/html;profile=mcp-app`, `_meta.ui.resourceUri`, `ui://cortex/query-widget`) is unchanged — it was an intentional Locked decision, not a bug.

## Review hardening (folded in)

Multi-agent review (security / frontend-races / simplicity) + goal-verifier ran; findings fixed inline:
- **P1** — origin-bound the inbound `postMessage` handler (`event.source === window.parent`) and required a positive `messageId` match — predictable ids + a global listener allowed sibling-frame response spoofing and stale-response cross-talk.
- **P2** — `try/catch` + single `done` guard around `postMessage` so a throw no longer leaks the listener/timer or hangs the promise.
- **P3** — shared `withTimeout()` bounds the `window.openai.callTool` path too (hung host no longer wedges the form); reflected host error strings capped at 200 chars.

## Bead
syslog-mcp-yi66.2: Build the initial log query widget HTML

## Testing
- Extended `resources/read` test with 9 stable wire-format anchors (incl. `event.source` origin guard). Full `cargo test` green via pre-push hook; clippy/fmt clean.
- Live-host end-to-end smoke is the sibling bead `syslog-mcp-yi66.3`.

## Follow-ups
- `syslog-mcp-6jbt7` (P3, pre-existing): consolidate duplicated rmcp test-state helpers.

Version: 1.20.1 → 1.21.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the interactive MCP Apps query widget for `ui://cortex/query-widget`, documents it as a progressive enhancement with host-agnostic smoke tests, and hardens the host bridge with a defense-in-depth CSP. Also consolidates test helpers and deduplicates PUBLIC_URL config. Version: 1.21.3.

- **New Features**
  - Self-contained Aurora-dark widget with FTS5 query plus hostname/severity/limit filters.
  - Calls `window.openai.callTool` when available; otherwise uses a `postMessage` adapter (`type:"tool"` → `ui-message-response`) with a bounded timeout.
  - Compact results table with idle/loading/empty/error/bridge-unavailable states; docs and smoke tests validate `resources/list`, `resources/read` MIME + anchors, `_meta.ui.resourceUri`, and `tools/call action=search` returning both `structuredContent` and text.

- **Bug Fixes**
  - Host bridge hardened: origin-bind `postMessage` (`event.source === window.parent`) with matching `messageId`, shared timeout with “not responding” status, try/catch + single completion guard, and host error strings capped at 200 chars.
  - Add a defense-in-depth CSP to the widget (`img-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'`); docs note origin-bound handling and the `ui://` `targetOrigin:"*"` constraint.
  - Smoke tests stop interpolating server values into `python -c` (`assert_gte` reads via stdin; `json_get` documents literal-accessor contract).
  - Test refactors: dedupe PUBLIC_URL `McpConfig` literals via `public_url_config()` and fold the no-auth router into `rmcp_router` (no behavior change).

<sup>Written for commit c16a57b9f115aaa8b7e5250beeb26633c8ce0d7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive MCP Apps query widget for syslog searches (available to MCP-UI capable hosts)
  * Query widget provides real-time filtering with hostname, severity, and limit controls

* **Documentation**
  * Enhanced setup guides with query widget verification steps and wire-protocol examples

* **Chores**
  * Version bumped to 1.21.2
  * Updated Docker image and server configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->