### PR TITLE
fix(ci): allowlist doc/test placeholder tokens in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,30 @@
+# gitleaks configuration for cortex.
+#
+# The weekly scheduled CI run (.github/workflows/ci.yml `gitleaks` job) executes
+# a full-history `gitleaks detect`. Unlike the per-push/PR scans, it walks every
+# commit and flags example tokens that live in documentation and test scripts.
+# None are real credentials — they are self-evident placeholders. This config
+# keeps all of gitleaks' built-in rules and allowlists only those exact
+# placeholder values by secret content, so the scan stays green without
+# weakening detection of genuine secrets (a real key on any of these lines would
+# still match).
+#
+# To regenerate the finding list:  gitleaks detect --no-banner --report-format=json --report-path=-
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documentation and test placeholder tokens (not real secrets)"
+regexTarget = "secret"
+regexes = [
+  # docs/contracts/{agent-protocol,forwarder-dropins}.md — base64url placeholder
+  # that decodes to the literal string "secret-token-opaque-base64url-32bytes".
+  '''c2VjcmV0LXRva2VuLW9wYXF1ZS1iYXNlNjR1cmwtMzJieXRlcw''',
+  # README curl examples — uppercase fill-in-the-blank placeholder.
+  '''YOUR_TOKEN''',
+  # tests/test_live.sh + tests/mcporter/test-tools.sh — deliberately invalid
+  # tokens used to assert auth-rejection paths.
+  '''bad-token''',
+  '''intentionally-wrong-token-for-testing''',
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.5] - 2026-06-15
+
+### Fixed
+
+- Add a `.gitleaks.toml` so the weekly scheduled full-history Secret Scan stays green. The scan flagged eight placeholder tokens committed in docs and test scripts (the `secret-token-opaque-base64url-32bytes` base64 example in `docs/contracts/*.md`, plus `YOUR_TOKEN`, `bad-token`, and `intentionally-wrong-token-for-testing` in `README.md` and `tests/`). All built-in gitleaks rules remain active; only these exact placeholder strings are allowlisted by secret content, so a real credential on any of those lines would still be caught.
+
 ## [1.21.4] - 2026-06-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.21.4"
+version = "1.21.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.21.4"
+version = "1.21.5"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.4}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.5}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.21.4",
+  "version": "1.21.5",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.21.4",
+  "version": "1.21.5",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.21.4",
+      "identifier": "ghcr.io/jmagar/cortex:v1.21.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Problem

The weekly **scheduled** CI run (`ci.yml`, cron `43 6 * * 1`) runs a full-history `gitleaks detect`. Unlike per-push/PR scans (which only see new commits), it walks every commit and fails on 8 placeholder tokens that have long lived in docs and test scripts. This is why the [scheduled run on 2026-06-15 failed](https://github.com/jmagar/cortex/actions/runs/27534561013) while PR/push Secret Scans stayed green.

## Findings (all placeholders, zero real secrets)

| Rule | Where | Value |
|------|-------|-------|
| `generic-api-key` | `docs/contracts/agent-protocol.md`, `docs/contracts/forwarder-dropins.md` | `c2VjcmV0...` → decodes to literally `secret-token-opaque-base64url-32bytes` |
| `curl-auth-header` | `README.md` | `YOUR_TOKEN` |
| `curl-auth-header` | `tests/test_live.sh` | `bad-token` |
| `curl-auth-header` | `tests/mcporter/test-tools.sh` | `bad-token-intentionally-invalid` |
| `curl-auth-header` | `tests/test_live.sh` | `intentionally-wrong-token-for-testing` |

## Fix

Add a `.gitleaks.toml` that keeps **every** built-in rule (`extend.useDefault = true`) and allowlists only these exact placeholder strings by secret content (`regexTarget = "secret"`). A real credential appearing on any of those lines would still be caught.

## Verification (local, gitleaks 8.x)

- Full-history `gitleaks detect`: **8 findings → 0** with the config; exact CI command (`--exit-code=2`) exits 0.
- Narrowness proven: a real high-entropy `ghp_…` token is still detected with the cortex config (same as default); the allowlist only suppresses the 4 known placeholder strings.

Patch bump to **1.21.5** (version-bearing files + CHANGELOG).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.gitleaks.toml` to allowlist known doc/test placeholders so the weekly full-history `gitleaks detect` stops failing. Keeps all default rules and bumps version to 1.21.5.

- Bug Fixes
  - Allowlist only these exact placeholders by secret content: base64 example in `docs/contracts/*.md`, `YOUR_TOKEN`, `bad-token`, `intentionally-wrong-token-for-testing`. Real credentials on those lines still trigger.
  - Verified full-history scan drops from 8 findings to 0; per-push scans unchanged.

<sup>Written for commit 24a4e3cd10a91e6308dde50c728386bcf44c43ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

