### PR TITLE
fix(file_tail): guard Unix-only APIs so the Windows release build compiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.6] - 2026-06-15
+
+### Fixed
+
+- Fix the Windows release build, which had been failing since the `file_tail` ingest module landed and was blocking the `publish` job (it `needs` both the Linux and Windows builds). `src/file_tail/path_policy.rs` and `src/file_tail/supervisor.rs` called Unix-only APIs unconditionally — `MetadataExt::dev`/`ino`, `OpenOptionsExt::custom_flags`, and `libc::O_NOFOLLOW` — but `libc`/`rustix` are `[target.'cfg(unix)'.dependencies]`, so the Windows target failed to compile (E0599/E0433). Introduced `src/file_tail/platform.rs`, a small `#[cfg(unix)]`/`#[cfg(windows)]` shim for file identity and no-follow open. Linux behavior is byte-identical (`(st_dev, st_ino)` + `O_NOFOLLOW`); on Windows the no-follow open maps to `FILE_FLAG_OPEN_REPARSE_POINT` and identity-based rotation detection falls back to the content fingerprint + length.
+
 ## [1.21.5] - 2026-06-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.21.5"
+version = "1.21.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.21.5"
+version = "1.21.6"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.5}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.6}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.21.5",
+  "version": "1.21.6",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.21.5",
+  "version": "1.21.6",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.21.5",
+      "identifier": "ghcr.io/jmagar/cortex:v1.21.6",
       "transport": {
         "type": "stdio"
       },

--- a/src/file_tail.rs
+++ b/src/file_tail.rs
@@ -1,5 +1,6 @@
 pub(crate) mod models;
 pub(crate) mod path_policy;
+pub(crate) mod platform;
 pub(crate) mod registry;
 pub(crate) mod supervisor;
 

--- a/src/file_tail/path_policy.rs
+++ b/src/file_tail/path_policy.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
-use std::os::unix::fs::MetadataExt;
+
+use super::platform::metadata_identity;
 
 pub(crate) fn validate_file_tail_path(path: &str) -> Result<()> {
     let raw = Path::new(path);
@@ -53,8 +54,7 @@ pub(crate) fn validate_opened_file_tail_path(
     validate_file_tail_path(path)?;
     let path_metadata = std::fs::symlink_metadata(path)
         .map_err(|err| anyhow::anyhow!("file-tail path is not readable: {path}: {err}"))?;
-    if opened_metadata.dev() != path_metadata.dev() || opened_metadata.ino() != path_metadata.ino()
-    {
+    if metadata_identity(opened_metadata) != metadata_identity(&path_metadata) {
         bail!("file-tail path changed while opening");
     }
     Ok(())

--- a/src/file_tail/platform.rs
+++ b/src/file_tail/platform.rs
@@ -1,0 +1,56 @@
+//! Platform-specific primitives for file-tail ingest.
+//!
+//! The file-tail security and rotation model is Unix-centric: it uses the
+//! `(st_dev, st_ino)` pair to detect log rotation/truncation and opens files
+//! with `O_NOFOLLOW` to defeat symlink-swap TOCTOU attacks. Those concepts have
+//! no direct Windows equivalent, so this module isolates the two
+//! platform-specific operations behind a stable, cross-platform surface.
+//!
+//! On Unix the behavior is exactly as before. On Windows file identity is not
+//! cheaply available for path-based metadata, so [`metadata_identity`] returns
+//! a constant and rotation detection falls back to the content fingerprint and
+//! file length (see `supervisor::reopen_if_rotated_or_truncated`). The
+//! no-follow open maps to `FILE_FLAG_OPEN_REPARSE_POINT`, which mirrors the
+//! intent of `O_NOFOLLOW` (open the reparse point itself rather than its
+//! target).
+
+use std::fs::{File, Metadata, OpenOptions};
+use std::path::Path;
+
+/// File identity used to detect rotation/truncation.
+///
+/// Unix: `(st_dev, st_ino)`. Windows: `(0, 0)` — identity-based rotation
+/// detection is disabled and the caller relies on the content fingerprint and
+/// length instead.
+pub(crate) fn metadata_identity(metadata: &Metadata) -> (u64, u64) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        (metadata.dev(), metadata.ino())
+    }
+    #[cfg(windows)]
+    {
+        let _ = metadata;
+        (0, 0)
+    }
+}
+
+/// Open `path` read-only without following a terminal symlink / reparse point.
+pub(crate) fn open_read_no_follow(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // FILE_FLAG_OPEN_REPARSE_POINT — open the reparse point itself rather
+        // than following it, mirroring O_NOFOLLOW's symlink-swap protection.
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    options.open(path)
+}

--- a/src/file_tail/supervisor.rs
+++ b/src/file_tail/supervisor.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::io::ErrorKind;
-use std::os::unix::fs::MetadataExt;
-use std::os::unix::fs::OpenOptionsExt;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -18,6 +16,7 @@ use crate::ingest_metadata::bounded_metadata_json;
 
 use super::models::{FileTailSource, FileTailStatus};
 use super::path_policy::{validate_file_tail_path, validate_opened_file_tail_path};
+use super::platform::{metadata_identity, open_read_no_follow};
 use super::registry::FileTailRegistry;
 
 const FILE_TAIL_FINGERPRINT_BYTES: usize = 256;
@@ -118,13 +117,9 @@ impl FileTailSupervisor {
         } else {
             0
         };
-        self.registry.update_checkpoint(
-            &source.id,
-            metadata.dev(),
-            metadata.ino(),
-            offset,
-            &now_iso(),
-        )
+        let (dev, ino) = metadata_identity(&metadata);
+        self.registry
+            .update_checkpoint(&source.id, dev, ino, offset, &now_iso())
     }
 
     fn build_task(&self, source: FileTailSource) -> (String, TailTask) {
@@ -382,6 +377,13 @@ pub(crate) struct FileIdentity {
     pub(crate) ino: u64,
 }
 
+impl FileIdentity {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        let (dev, ino) = metadata_identity(metadata);
+        Self { dev, ino }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct OpenedTailFile {
     pub(crate) file: tokio::fs::File,
@@ -402,10 +404,7 @@ pub(crate) async fn open_tail_file(
 ) -> Result<OpenedTailFile> {
     let mut file = open_validated_tail_file(&source.path).await?;
     let metadata = file.metadata().await?;
-    let identity = FileIdentity {
-        dev: metadata.dev(),
-        ino: metadata.ino(),
-    };
+    let identity = FileIdentity::from_metadata(&metadata);
     let fingerprint = file_prefix_fingerprint(&mut file).await?;
     let checkpoint_matches = source.checkpoint_dev == Some(identity.dev)
         && source.checkpoint_ino == Some(identity.ino)
@@ -446,10 +445,7 @@ pub(crate) async fn reopen_if_rotated_or_truncated(
         }
         Err(err) => return Err(err.into()),
     };
-    let current = FileIdentity {
-        dev: metadata.dev(),
-        ino: metadata.ino(),
-    };
+    let current = FileIdentity::from_metadata(&metadata);
     if current != identity || metadata.len() < position {
         return reopen_from_start(source).await.map(Some);
     }
@@ -461,10 +457,7 @@ pub(crate) async fn reopen_if_rotated_or_truncated(
             file.seek(std::io::SeekFrom::Start(0)).await?;
             return Ok(Some(OpenedTailFile {
                 file,
-                identity: FileIdentity {
-                    dev: metadata.dev(),
-                    ino: metadata.ino(),
-                },
+                identity: FileIdentity::from_metadata(&metadata),
                 position: 0,
                 fingerprint: current_fingerprint,
             }));
@@ -481,10 +474,7 @@ async fn path_identity_changed(source: &FileTailSource, identity: FileIdentity) 
         }
         Err(err) => return Err(err.into()),
     };
-    Ok(FileIdentity {
-        dev: metadata.dev(),
-        ino: metadata.ino(),
-    } != identity)
+    Ok(FileIdentity::from_metadata(&metadata) != identity)
 }
 
 async fn reopen_from_start(source: &FileTailSource) -> Result<OpenedTailFile> {
@@ -494,10 +484,7 @@ async fn reopen_from_start(source: &FileTailSource) -> Result<OpenedTailFile> {
     file.seek(std::io::SeekFrom::Start(0)).await?;
     Ok(OpenedTailFile {
         file,
-        identity: FileIdentity {
-            dev: metadata.dev(),
-            ino: metadata.ino(),
-        },
+        identity: FileIdentity::from_metadata(&metadata),
         position: 0,
         fingerprint,
     })
@@ -517,12 +504,7 @@ async fn open_validated_tail_file(path: &str) -> Result<tokio::fs::File> {
     let path = path.to_string();
     let std_file = tokio::task::spawn_blocking({
         let path = path.clone();
-        move || {
-            std::fs::OpenOptions::new()
-                .read(true)
-                .custom_flags(libc::O_NOFOLLOW)
-                .open(&path)
-        }
+        move || open_read_no_follow(std::path::Path::new(&path))
     })
     .await??;
     let metadata = std_file.metadata()?;
@@ -532,10 +514,7 @@ async fn open_validated_tail_file(path: &str) -> Result<tokio::fs::File> {
 
 fn open_validated_tail_file_sync(path: &str) -> Result<std::fs::File> {
     validate_file_tail_path(path)?;
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)?;
+    let file = open_read_no_follow(std::path::Path::new(path))?;
     let metadata = file.metadata()?;
     validate_opened_file_tail_path(path, &metadata)?;
     Ok(file)


### PR DESCRIPTION
## Problem

The `release` workflow builds cortex for **both Linux and Windows**, and the `publish` job `needs: [cortex-linux, cortex-windows]`. The Windows build has been **failing** since the `file_tail` ingest module landed — so the v1.21.3, v1.21.4, and v1.21.5 release runs all went red and never published artifacts.

Root cause: `src/file_tail/path_policy.rs` and `src/file_tail/supervisor.rs` call Unix-only APIs unconditionally:
- `std::os::unix::fs::MetadataExt::dev()` / `ino()`
- `std::os::unix::fs::OpenOptionsExt::custom_flags()`
- `libc::O_NOFOLLOW`

But `libc` and `rustix` are declared under `[target.'cfg(unix)'.dependencies]`, so on `x86_64-pc-windows-msvc` these fail to compile (E0599 / E0433).

## Fix

Add `src/file_tail/platform.rs` — a small `#[cfg(unix)]`/`#[cfg(windows)]` shim (matching the existing pattern in `src/db/maintenance.rs`) for the two platform-specific primitives:

- **File identity** — Unix: `(st_dev, st_ino)`. Windows: `(0, 0)`; identity-based rotation detection falls back to the existing content fingerprint + file length.
- **No-follow open** — Unix: `O_NOFOLLOW`. Windows: `FILE_FLAG_OPEN_REPARSE_POINT` (same symlink-swap intent).

Linux behavior is **byte-identical** to before. The change is fully contained inside the `file_tail` module — no public surface or wiring changes.

## Verification

- ✅ Linux `cargo clippy --all-targets` — clean
- ✅ Linux full test suite (ran in pre-push hook, 188s) — all pass
- ✅ Windows type-check of the new `platform.rs` cfg paths via `rustc --target x86_64-pc-windows-msvc --emit=metadata` (full cross-build blocked locally only by the `aws-lc-sys` C/TLS dep, which the native windows-latest CI runner has)
- Patch version bump 1.21.5 → 1.21.6 across all version-bearing files + CHANGELOG

Closes the red Windows release build; once merged, auto-tag cuts v1.21.6 and the release run should go fully green.

bd: syslog-mcp-rbapl

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows release build by guarding Unix-only APIs in `file_tail` behind platform shims, restoring cross-platform builds and unblocking the publish workflow. Linux behavior is unchanged.

- **Bug Fixes**
  - Added `src/file_tail/platform.rs` with `#[cfg(unix)]`/`#[cfg(windows)]` shims for file identity and no-follow open.
  - Replaced direct `MetadataExt::dev/ino` and `O_NOFOLLOW` usage with `metadata_identity` and `open_read_no_follow`.
  - Windows: use `FILE_FLAG_OPEN_REPARSE_POINT`; rotation falls back to content fingerprint + length.
  - Bumped version to `1.21.6` and updated image/manifests to match.

<sup>Written for commit 10ad7307624527c34a5728ef2c0aa468163c3c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

