### PR TITLE
feat(agent): heartbeat-coordinated server→agent auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.22.0] - 2026-06-15
+
+### Added
+
+- **Heartbeat-coordinated agent auto-update** — the server now keeps fleet agent binaries in lockstep with itself, preventing the version drift that silently broke Docker/syslog forwarding (an agent binary predating unified forwarding). The heartbeat `202` ack carries `server_version` plus an optional `agent_update` directive (`{version, path, sha256}`), and a new authenticated `GET /v1/agent/binary?os=&arch=` streams the server's own running binary (phase 1: `linux/x86_64`). When an agent reports a different version, it downloads the binary over the bearer-authenticated channel, verifies the SHA-256, validates that the staged binary runs and self-reports the expected version, keeps a `.bak`, atomically swaps, and re-execs. Bounded auto-rollback restores the `.bak` if the new binary fails to confirm a healthy heartbeat within 3 restarts. Gated by `CORTEX_AGENT_AUTO_UPDATE` (default on); when disabled, version drift is logged only. Phase 2 (a GitHub-release fallback for windows/non-x86_64 agents) is tracked separately.
+
 ## [1.21.5] - 2026-06-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.21.5"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.21.5"
+version = "1.22.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.21.5}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.22.0}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.21.5",
+  "version": "1.22.0",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.21.5",
+  "version": "1.22.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.21.5",
+      "identifier": "ghcr.io/jmagar/cortex:v1.22.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,5 +1,6 @@
 pub mod docker;
 pub mod journald;
+pub mod self_update;
 pub mod syslog_file;
 pub mod syslog_sender;
 

--- a/src/agent/self_update.rs
+++ b/src/agent/self_update.rs
@@ -1,0 +1,301 @@
+//! Agent self-update — keeps the host agent binary in lockstep with the cortex
+//! server it reports to.
+//!
+//! The server advertises its own version + a download directive in the heartbeat
+//! `202` response (see `heartbeat.rs::AgentUpdateDirective`). When the agent's
+//! compiled version differs from the server's, [`maybe_update`] downloads the
+//! server's binary over the same bearer-authenticated channel, verifies its
+//! SHA-256, sanity-checks that it runs and self-reports the expected version,
+//! atomically swaps it into place (keeping a `.bak`), and re-execs.
+//!
+//! Safety model (matches the approved design):
+//! - **integrity**: SHA-256 from the authenticated heartbeat response, verified
+//!   against the downloaded bytes before anything is written over the live path.
+//! - **pre-swap validation**: the freshly downloaded binary must execute
+//!   `--version` and report the advertised version, so a corrupt or incompatible
+//!   download is never installed.
+//! - **bounded rollback**: a marker file records the in-flight update. The new
+//!   process clears it after its first successful heartbeat. If `MAX_ATTEMPTS`
+//!   restarts elapse without that confirmation, [`confirm_or_rollback`] restores
+//!   the `.bak` and re-execs the previous binary.
+//!
+//! Gated by `CORTEX_AGENT_AUTO_UPDATE` (default on) in the caller.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Number of agent restarts allowed without a confirming heartbeat before the
+/// in-flight update is rolled back to the previous `.bak` binary.
+const MAX_ATTEMPTS: u32 = 3;
+
+const MARKER_FILE: &str = ".cortex-update-state.json";
+
+/// Server-issued update directive, deserialized from the heartbeat `202` body.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentUpdateDirective {
+    /// Target version the agent should converge to (the server's own version).
+    pub version: String,
+    /// Path on the server to download the matching binary from, resolved
+    /// relative to the agent's configured heartbeat target.
+    pub path: String,
+    /// Lowercase hex SHA-256 of the target binary.
+    pub sha256: String,
+}
+
+/// Persisted record of an in-flight update, used for bounded auto-rollback.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UpdateMarker {
+    /// Version we attempted to install (matches the running binary on success).
+    target: String,
+    /// Absolute path of the backed-up previous binary to roll back to.
+    bak: PathBuf,
+    /// Restarts observed since the swap without a confirming heartbeat.
+    attempts: u32,
+}
+
+fn marker_path(exe: &Path) -> PathBuf {
+    exe.parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(MARKER_FILE)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// Join a base URL with a server-supplied relative path.
+fn join_url(base: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}
+
+/// True when the directive asks for a version different from the one compiled
+/// into this binary. The server is the source of truth, so any difference
+/// (upgrade or downgrade) converges the agent toward the server.
+pub fn update_needed(directive: &AgentUpdateDirective) -> bool {
+    directive.version != env!("CARGO_PKG_VERSION")
+}
+
+/// Download, verify, install, and re-exec the advertised binary. On success this
+/// function does not return (the process image is replaced). It returns `Ok(())`
+/// only when no update was needed; any failure leaves the live binary untouched.
+pub async fn maybe_update(
+    client: &reqwest::Client,
+    target_base: &str,
+    token: Option<&str>,
+    directive: &AgentUpdateDirective,
+) -> Result<()> {
+    if !update_needed(directive) {
+        return Ok(());
+    }
+
+    let current = env!("CARGO_PKG_VERSION");
+    let exe = std::env::current_exe().context("resolve current_exe")?;
+    let dir = exe
+        .parent()
+        .ok_or_else(|| anyhow!("current_exe has no parent dir"))?
+        .to_path_buf();
+
+    tracing::warn!(
+        from = current,
+        to = %directive.version,
+        "agent behind server; downloading update"
+    );
+
+    // 1. Download over the authenticated channel.
+    let url = join_url(target_base, &directive.path);
+    let mut req = client.get(&url);
+    if let Some(token) = token {
+        req = req.bearer_auth(token);
+    }
+    let bytes = req
+        .send()
+        .await
+        .context("agent binary download failed")?
+        .error_for_status()
+        .context("agent binary download returned error status")?
+        .bytes()
+        .await
+        .context("read agent binary body")?;
+
+    // 2. Verify integrity before touching disk near the live path.
+    let got = sha256_hex(&bytes);
+    if !got.eq_ignore_ascii_case(&directive.sha256) {
+        bail!(
+            "agent binary sha256 mismatch: expected {}, got {got}",
+            directive.sha256
+        );
+    }
+
+    // 3. Stage into the same directory (atomic rename requires same filesystem).
+    let tmp = dir.join(format!(".cortex-update-{}.tmp", directive.version));
+    std::fs::write(&tmp, &bytes).with_context(|| format!("write staged binary {tmp:?}"))?;
+    set_executable(&tmp)?;
+
+    // 4. Pre-swap validation: the new binary must run and self-report the
+    //    advertised version. Guards against corrupt/incompatible downloads.
+    if let Err(error) = validate_binary(&tmp, &directive.version) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(error.context("staged agent binary failed validation; not installed"));
+    }
+
+    // 5. Keep a rollback copy of the current binary, then atomically swap.
+    let bak = dir.join(format!("cortex.bak-{current}"));
+    let _ = std::fs::remove_file(&bak);
+    std::fs::hard_link(&exe, &bak)
+        .or_else(|_| std::fs::copy(&exe, &bak).map(|_| ()))
+        .with_context(|| format!("back up current binary to {bak:?}"))?;
+
+    // Record the in-flight update before the swap so a boot-crash is recoverable.
+    write_marker(
+        &exe,
+        &UpdateMarker {
+            target: directive.version.clone(),
+            bak: bak.clone(),
+            attempts: 0,
+        },
+    )?;
+
+    std::fs::rename(&tmp, &exe).with_context(|| format!("swap new binary into {exe:?}"))?;
+
+    tracing::warn!(
+        from = current,
+        to = %directive.version,
+        "agent binary updated; re-executing"
+    );
+    reexec(&exe)
+}
+
+/// Confirm a just-installed update is healthy, or roll back if it never settled.
+///
+/// Called once at agent startup, before the heartbeat loop. If a marker shows
+/// the running binary matches the intended target, it bumps the restart counter;
+/// once `MAX_ATTEMPTS` restarts pass without [`confirm_update_success`] clearing
+/// the marker (i.e. no successful heartbeat), it restores the `.bak` and re-execs.
+pub fn confirm_or_rollback() -> Result<()> {
+    let exe = std::env::current_exe().context("resolve current_exe")?;
+    let path = marker_path(&exe);
+    let Some(mut marker) = read_marker(&path) else {
+        return Ok(());
+    };
+
+    let current = env!("CARGO_PKG_VERSION");
+    if marker.target != current {
+        // Running binary is not the one the marker tracked (e.g. manual change);
+        // the marker is stale — drop it without acting.
+        let _ = std::fs::remove_file(&path);
+        return Ok(());
+    }
+
+    if marker.attempts >= MAX_ATTEMPTS {
+        tracing::error!(
+            target = %marker.target,
+            attempts = marker.attempts,
+            "agent update never confirmed healthy; rolling back"
+        );
+        if marker.bak.exists() {
+            std::fs::rename(&marker.bak, &exe)
+                .with_context(|| format!("restore rollback binary from {:?}", marker.bak))?;
+            let _ = std::fs::remove_file(&path);
+            return reexec(&exe);
+        }
+        // No backup to restore — give up on rollback but clear the marker so we
+        // stop looping; the operator must intervene.
+        let _ = std::fs::remove_file(&path);
+        bail!(
+            "agent update unhealthy but no rollback binary at {:?}",
+            marker.bak
+        );
+    }
+
+    marker.attempts += 1;
+    write_marker(&exe, &marker)?;
+    Ok(())
+}
+
+/// Clear the in-flight update marker after the agent's first successful
+/// heartbeat, finalizing the update. Also prunes the retained `.bak`.
+pub fn confirm_update_success() {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let path = marker_path(&exe);
+    if let Some(marker) = read_marker(&path) {
+        tracing::info!(version = %marker.target, "agent update confirmed healthy");
+        let _ = std::fs::remove_file(&marker.bak);
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+fn validate_binary(path: &Path, expected_version: &str) -> Result<()> {
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .context("run --version on staged binary")?;
+    if !output.status.success() {
+        bail!("staged binary --version exited with {}", output.status);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !stdout.contains(expected_version) {
+        bail!(
+            "staged binary reported '{}', expected version {expected_version}",
+            stdout.trim()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).context("chmod staged binary")
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn reexec(exe: &Path) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+    let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+    // `exec` only returns on failure.
+    let error = Command::new(exe).args(args).exec();
+    Err(anyhow!("re-exec of {exe:?} failed: {error}"))
+}
+
+#[cfg(not(unix))]
+fn reexec(_exe: &Path) -> Result<()> {
+    bail!("agent re-exec is only supported on unix")
+}
+
+fn write_marker(exe: &Path, marker: &UpdateMarker) -> Result<()> {
+    let path = marker_path(exe);
+    let json = serde_json::to_string(marker).context("serialize update marker")?;
+    std::fs::write(&path, json).with_context(|| format!("write update marker {path:?}"))
+}
+
+fn read_marker(path: &Path) -> Option<UpdateMarker> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+#[cfg(test)]
+#[path = "self_update_tests.rs"]
+mod tests;

--- a/src/agent/self_update_tests.rs
+++ b/src/agent/self_update_tests.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+#[test]
+fn update_needed_false_for_matching_version() {
+    let directive = AgentUpdateDirective {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        path: "/v1/agent/binary?os=linux&arch=x86_64".to_string(),
+        sha256: "deadbeef".to_string(),
+    };
+    assert!(!update_needed(&directive));
+}
+
+#[test]
+fn update_needed_true_for_different_version() {
+    let directive = AgentUpdateDirective {
+        version: "0.0.0-other".to_string(),
+        path: "/v1/agent/binary".to_string(),
+        sha256: "deadbeef".to_string(),
+    };
+    assert!(update_needed(&directive));
+}
+
+#[test]
+fn sha256_hex_matches_known_vector() {
+    // SHA-256 of the empty input.
+    assert_eq!(
+        sha256_hex(b""),
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+    // SHA-256 of "abc".
+    assert_eq!(
+        sha256_hex(b"abc"),
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+#[test]
+fn join_url_normalizes_slashes() {
+    assert_eq!(
+        join_url("http://127.0.0.1:3100", "/v1/agent/binary"),
+        "http://127.0.0.1:3100/v1/agent/binary"
+    );
+    assert_eq!(
+        join_url("http://127.0.0.1:3100/", "v1/agent/binary"),
+        "http://127.0.0.1:3100/v1/agent/binary"
+    );
+    assert_eq!(
+        join_url(
+            "https://cortex.tootie.tv",
+            "/v1/agent/binary?os=linux&arch=x86_64"
+        ),
+        "https://cortex.tootie.tv/v1/agent/binary?os=linux&arch=x86_64"
+    );
+}
+
+#[test]
+fn marker_roundtrips_through_disk() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = dir.path().join("cortex");
+    std::fs::write(&exe, b"fake").unwrap();
+
+    let marker = UpdateMarker {
+        target: "1.2.3".to_string(),
+        bak: dir.path().join("cortex.bak-1.1.0"),
+        attempts: 2,
+    };
+    write_marker(&exe, &marker).unwrap();
+
+    let read = read_marker(&marker_path(&exe)).expect("marker present");
+    assert_eq!(read.target, "1.2.3");
+    assert_eq!(read.attempts, 2);
+    assert_eq!(read.bak, marker.bak);
+}
+
+#[test]
+fn read_marker_absent_returns_none() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(read_marker(&dir.path().join("nope.json")).is_none());
+}
+
+#[cfg(unix)]
+#[test]
+fn validate_binary_accepts_matching_version_and_rejects_mismatch() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempfile::tempdir().unwrap();
+    let fake = dir.path().join("fake-cortex");
+    std::fs::write(&fake, "#!/bin/sh\necho \"cortex 9.9.9\"\n").unwrap();
+    let mut perms = std::fs::metadata(&fake).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake, perms).unwrap();
+
+    assert!(validate_binary(&fake, "9.9.9").is_ok());
+    assert!(validate_binary(&fake, "1.2.3").is_err());
+}

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -10,27 +10,35 @@
 //! static `CORTEX_TOKEN` bearer when configured, with non-loopback
 //! unauthenticated exposure rejected at startup by config validation.
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
 use axum::{
     Router,
-    extract::{ConnectInfo, State},
-    http::{HeaderMap, StatusCode},
+    body::Body,
+    extract::{ConnectInfo, Query, State},
+    http::{HeaderMap, StatusCode, header},
     middleware::{Next, from_fn},
-    response::{IntoResponse, Json},
-    routing::post,
+    response::{IntoResponse, Json, Response},
+    routing::{get, post},
 };
 use bytes::Bytes;
 use lab_auth::middleware::{parse_bearer_token, tokens_equal};
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use sha2::{Digest, Sha256};
 use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::db::DbPool;
 use crate::mcp::AuthPolicy;
+
+/// Server version compiled into this binary; advertised to agents so they can
+/// converge to it via [`AgentReleaseInfo`].
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub const HEARTBEAT_BODY_LIMIT_BYTES: usize = 256 * 1024;
 
@@ -39,6 +47,7 @@ pub struct HeartbeatState {
     pool: Arc<DbPool>,
     api_token: Option<String>,
     auth_policy: AuthPolicy,
+    release: Arc<AgentReleaseInfo>,
 }
 
 impl HeartbeatState {
@@ -47,8 +56,85 @@ impl HeartbeatState {
             pool,
             api_token,
             auth_policy,
+            release: Arc::new(AgentReleaseInfo::from_current_exe()),
         }
     }
+}
+
+/// Identity of the agent binary this server can hand out (its own running
+/// binary). Computed once at construction; the SHA-256 lets agents verify the
+/// download over the authenticated heartbeat channel.
+struct AgentReleaseInfo {
+    version: &'static str,
+    /// Lowercase hex SHA-256 of the server binary, or `None` if it could not be
+    /// read (e.g. in unit tests) — in which case no update is ever advertised.
+    sha256: Option<String>,
+    exe_path: Option<PathBuf>,
+}
+
+impl AgentReleaseInfo {
+    fn from_current_exe() -> Self {
+        let (sha256, exe_path) = match std::env::current_exe()
+            .ok()
+            .and_then(|path| std::fs::read(&path).ok().map(|bytes| (path, bytes)))
+        {
+            Some((path, bytes)) => {
+                let mut hasher = Sha256::new();
+                hasher.update(&bytes);
+                let hexed: String = hasher
+                    .finalize()
+                    .iter()
+                    .map(|b| format!("{b:02x}"))
+                    .collect();
+                (Some(hexed), Some(path))
+            }
+            None => (None, None),
+        };
+        Self {
+            version: SERVER_VERSION,
+            sha256,
+            exe_path,
+        }
+    }
+
+    /// Build an update directive when the reporting agent is on a different
+    /// version and we can serve a matching binary. Phase 1 serves only
+    /// `linux/x86_64` (the binary the server itself runs); other platforms get
+    /// no directive (handled out-of-band until the phase-2 fallback lands).
+    fn directive_for(
+        &self,
+        os: &str,
+        arch: &str,
+        agent_version: &str,
+    ) -> Option<AgentUpdateDirective> {
+        let sha256 = self.sha256.as_ref()?;
+        if agent_version == self.version {
+            return None;
+        }
+        if !platform_self_servable(os, arch) {
+            return None;
+        }
+        Some(AgentUpdateDirective {
+            version: self.version.to_string(),
+            path: format!("/v1/agent/binary?os={os}&arch={arch}"),
+            sha256: sha256.clone(),
+        })
+    }
+}
+
+/// True for the platform whose binary the server can hand out from its own
+/// running image (linux on a 64-bit x86 host).
+fn platform_self_servable(os: &str, arch: &str) -> bool {
+    os.eq_ignore_ascii_case("linux") && matches!(arch, "x86_64" | "amd64")
+}
+
+/// Auto-update directive serialized into the heartbeat `202` ack. The agent
+/// resolves `path` against its own heartbeat target base URL.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentUpdateDirective {
+    pub version: String,
+    pub path: String,
+    pub sha256: String,
 }
 
 pub fn router(state: HeartbeatState) -> Router {
@@ -56,7 +142,58 @@ pub fn router(state: HeartbeatState) -> Router {
         .route("/v1/heartbeats", post(heartbeat_handler))
         .layer(RequestBodyLimitLayer::new(HEARTBEAT_BODY_LIMIT_BYTES))
         .layer(from_fn(json_payload_too_large))
+        .route("/v1/agent/binary", get(agent_binary_handler))
         .with_state(state)
+}
+
+/// `GET /v1/agent/binary?os=&arch=` — streams the server's own binary so agents
+/// can self-update to match. Shares the heartbeat auth model (bearer token, or
+/// loopback under `LoopbackDev`). Only serves the platform the server runs on.
+async fn agent_binary_handler(
+    State(state): State<HeartbeatState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Query(params): Query<HashMap<String, String>>,
+) -> Response {
+    if !is_authorized(&state, &peer, &headers) {
+        return unauthorized();
+    }
+    let os = params.get("os").map(String::as_str).unwrap_or("");
+    let arch = params.get("arch").map(String::as_str).unwrap_or("");
+    if !platform_self_servable(os, arch) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "unsupported_platform", "os": os, "arch": arch})),
+        )
+            .into_response();
+    }
+    let Some(exe_path) = state.release.exe_path.clone() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "binary_unavailable"})),
+        )
+            .into_response();
+    };
+    let sha256 = state.release.sha256.clone().unwrap_or_default();
+    match tokio::fs::read(&exe_path).await {
+        Ok(bytes) => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/octet-stream")
+            .header("x-cortex-version", state.release.version)
+            .header("x-cortex-sha256", sha256)
+            .body(Body::from(bytes))
+            .unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "response build failed").into_response()
+            }),
+        Err(error) => {
+            tracing::error!(error = %error, "failed to read agent binary for download");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": "binary_read_failed"})),
+            )
+                .into_response()
+        }
+    }
 }
 
 async fn json_payload_too_large(
@@ -95,6 +232,12 @@ async fn heartbeat_handler(
         }
     };
 
+    // Capture identity for the auto-update directive before `request` is moved
+    // into the blocking insert task.
+    let agent_os = request.host.os.clone();
+    let agent_arch = request.host.architecture.clone();
+    let agent_version = request.agent.version.clone();
+
     let pool = Arc::clone(&state.pool);
     let source_ip = peer.to_string();
     let exec_start = Instant::now();
@@ -118,7 +261,14 @@ async fn heartbeat_handler(
     }
 
     match result {
-        Ok(response) => (StatusCode::ACCEPTED, Json(response)).into_response(),
+        Ok(mut response) => {
+            response.server_version = Some(state.release.version.to_string());
+            response.agent_update =
+                state
+                    .release
+                    .directive_for(&agent_os, &agent_arch, &agent_version);
+            (StatusCode::ACCEPTED, Json(response)).into_response()
+        }
         Err(error) => {
             tracing::error!(error = %error, "heartbeat ingest failed");
             (
@@ -209,6 +359,8 @@ fn insert_heartbeat(
             accepted: 0,
             heartbeat_id: id,
             received_at,
+            server_version: None,
+            agent_update: None,
         });
     } else {
         tx.last_insert_rowid()
@@ -255,6 +407,8 @@ fn insert_heartbeat(
         accepted: 1,
         heartbeat_id,
         received_at,
+        server_version: None,
+        agent_update: None,
     })
 }
 
@@ -413,6 +567,12 @@ struct HeartbeatIngestResponse {
     accepted: u32,
     heartbeat_id: i64,
     received_at: String,
+    /// Server version, so agents can detect drift even without a directive.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server_version: Option<String>,
+    /// Present only when the agent should self-update to match the server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent_update: Option<AgentUpdateDirective>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/heartbeat_agent.rs
+++ b/src/heartbeat_agent.rs
@@ -1183,6 +1183,19 @@ pub fn backoff_duration(attempt: u32) -> Duration {
 pub async fn run_agent(config: HeartbeatAgentConfig) -> Result<()> {
     let host_id = load_or_create_host_id(&config.host_id_path)?;
 
+    // If we are running immediately after a self-update, confirm it settled or
+    // roll back to the previous binary. May re-exec and not return.
+    if let Err(error) = crate::agent::self_update::confirm_or_rollback() {
+        tracing::error!(error = %error, "agent update rollback check failed");
+    }
+
+    // Server-coordinated auto-update keeps the agent binary in lockstep with the
+    // cortex server it reports to. Opt out with CORTEX_AGENT_AUTO_UPDATE=false.
+    let auto_update = std::env::var("CORTEX_AGENT_AUTO_UPDATE")
+        .map(|v| !(v.eq_ignore_ascii_case("false") || v == "0"))
+        .unwrap_or(true);
+    let mut update_confirmed = false;
+
     // Spawn Docker / journald forwarding streams as a background task.
     if config.docker || config.journald || config.syslog_file.is_some() {
         let syslog_target = config
@@ -1236,7 +1249,36 @@ pub async fn run_agent(config: HeartbeatAgentConfig) -> Result<()> {
         flush_retry_buffer(&client, &mut retry, target, config.token.as_deref()).await;
         payload.agent.retry_backlog = retry.len() as i64;
         match send_payload(&client, target, config.token.as_deref(), &mut payload).await {
-            Ok(()) => attempt = 0,
+            Ok(directive) => {
+                attempt = 0;
+                // First successful heartbeat after a swap finalizes the update.
+                if !update_confirmed {
+                    crate::agent::self_update::confirm_update_success();
+                    update_confirmed = true;
+                }
+                if let Some(directive) = directive {
+                    if auto_update {
+                        if let Err(error) = crate::agent::self_update::maybe_update(
+                            &client,
+                            target,
+                            config.token.as_deref(),
+                            &directive,
+                        )
+                        .await
+                        {
+                            tracing::warn!(
+                                error = %error,
+                                "agent self-update failed; staying on current binary"
+                            );
+                        }
+                    } else if crate::agent::self_update::update_needed(&directive) {
+                        tracing::info!(
+                            target_version = %directive.version,
+                            "agent update available (CORTEX_AGENT_AUTO_UPDATE disabled)"
+                        );
+                    }
+                }
+            }
             Err(error) => {
                 tracing::warn!(error = %error, "heartbeat push failed; queued for retry");
                 retry.push(payload);
@@ -1277,12 +1319,22 @@ async fn flush_retry_buffer(
     }
 }
 
+/// Minimal view of the heartbeat `202` ack body. Only the optional auto-update
+/// directive is consumed; all other fields are ignored.
+#[derive(Debug, Deserialize)]
+struct HeartbeatAck {
+    #[serde(default)]
+    agent_update: Option<crate::agent::self_update::AgentUpdateDirective>,
+}
+
+/// Returns the server's auto-update directive when one is advertised in the
+/// heartbeat ack, otherwise `None`.
 async fn send_payload(
     client: &reqwest::Client,
     target: &str,
     token: Option<&str>,
     payload: &mut HeartbeatPayload,
-) -> Result<()> {
+) -> Result<Option<crate::agent::self_update::AgentUpdateDirective>> {
     let url = heartbeat_url(target)?;
     let started = Instant::now();
     let mut request = client.post(url).json(payload);
@@ -1292,7 +1344,11 @@ async fn send_payload(
     let response = request.send().await.context("heartbeat POST failed")?;
     payload.agent.push_latency_ms = Some(started.elapsed().as_millis() as i64);
     if response.status().as_u16() == 202 {
-        return Ok(());
+        let body = response.text().await.unwrap_or_default();
+        let directive = serde_json::from_str::<HeartbeatAck>(&body)
+            .ok()
+            .and_then(|ack| ack.agent_update);
+        return Ok(directive);
     }
     let status = response.status();
     let body = response.text().await.unwrap_or_default();

--- a/src/heartbeat_tests.rs
+++ b/src/heartbeat_tests.rs
@@ -352,3 +352,105 @@ async fn zero_memory_total_stores_null_used_percent() {
         "used_percent should be NULL when mem_total_bytes is 0"
     );
 }
+
+// --- Agent auto-update (server side) ---
+
+async fn get_request(app: Router, uri: &str, token: Option<&str>) -> StatusCode {
+    let mut builder = Request::builder().method("GET").uri(uri);
+    if let Some(token) = token {
+        builder = builder.header("authorization", format!("Bearer {token}"));
+    }
+    app.oneshot(builder.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+        .status()
+}
+
+#[test]
+fn platform_self_servable_only_linux_x86_64() {
+    assert!(platform_self_servable("linux", "x86_64"));
+    assert!(platform_self_servable("linux", "amd64"));
+    assert!(platform_self_servable("Linux", "x86_64"));
+    assert!(!platform_self_servable("windows", "x86_64"));
+    assert!(!platform_self_servable("linux", "aarch64"));
+}
+
+#[test]
+fn directive_for_decisions() {
+    let release = AgentReleaseInfo {
+        version: SERVER_VERSION,
+        sha256: Some("abc123".to_string()),
+        exe_path: None,
+    };
+    // Stale linux agent → directive toward the server version.
+    let d = release
+        .directive_for("linux", "x86_64", "0.0.0")
+        .expect("stale linux agent gets a directive");
+    assert_eq!(d.version, SERVER_VERSION);
+    assert_eq!(d.sha256, "abc123");
+    assert!(d.path.contains("os=linux"));
+    assert!(d.path.contains("arch=x86_64"));
+    // Matching version → no directive.
+    assert!(
+        release
+            .directive_for("linux", "x86_64", SERVER_VERSION)
+            .is_none()
+    );
+    // Unsupported platform → no directive.
+    assert!(
+        release
+            .directive_for("windows", "x86_64", "0.0.0")
+            .is_none()
+    );
+
+    // No sha (binary unreadable) → never advertise.
+    let no_sha = AgentReleaseInfo {
+        version: SERVER_VERSION,
+        sha256: None,
+        exe_path: None,
+    };
+    assert!(no_sha.directive_for("linux", "x86_64", "0.0.0").is_none());
+}
+
+#[tokio::test]
+async fn heartbeat_ack_advertises_update_for_stale_linux_agent() {
+    let (app, _pool, _dir) = test_app(Some("secret"));
+    let (status, body) =
+        post_json(app, "/v1/heartbeats", Some("secret"), heartbeat_payload()).await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body["server_version"], json!(SERVER_VERSION));
+    let update = &body["agent_update"];
+    assert_eq!(update["version"], json!(SERVER_VERSION));
+    assert!(update["path"].as_str().unwrap().contains("os=linux"));
+    assert!(!update["sha256"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn heartbeat_ack_omits_update_for_matching_version() {
+    let (app, _pool, _dir) = test_app(Some("secret"));
+    let mut payload = heartbeat_payload();
+    payload["agent"]["version"] = json!(SERVER_VERSION);
+    let (status, body) = post_json(app, "/v1/heartbeats", Some("secret"), payload).await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body["server_version"], json!(SERVER_VERSION));
+    assert!(body.get("agent_update").is_none() || body["agent_update"].is_null());
+}
+
+#[tokio::test]
+async fn agent_binary_endpoint_requires_auth() {
+    let (app, _pool, _dir) = test_app(Some("secret"));
+    let status = get_request(app, "/v1/agent/binary?os=linux&arch=x86_64", None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn agent_binary_endpoint_rejects_unsupported_platform() {
+    let (app, _pool, _dir) = test_app(Some("secret"));
+    let status = get_request(
+        app,
+        "/v1/agent/binary?os=windows&arch=x86_64",
+        Some("secret"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Why

Version drift between the cortex server and its host agents silently broke Docker/syslog ingestion (the deployed agent binary predated *unified host log forwarding* while the legacy central-pull path was disabled). This adds a self-healing mechanism so the fleet can't drift again.

## What

**Server** (`src/heartbeat.rs`)
- The heartbeat `202` ack now carries `server_version` + an optional `agent_update` directive `{version, path, sha256}`, computed from the reporting agent's os/arch/version vs the server's own binary (`AgentReleaseInfo`, sha256 of `current_exe`).
- New authenticated `GET /v1/agent/binary?os=&arch=` streams the server's own running binary (phase 1: `linux/x86_64`).

**Agent** (`src/agent/self_update.rs` + `src/heartbeat_agent.rs`)
- Parses the ack; when behind, downloads over the bearer-authenticated channel → verifies sha256 → validates the staged binary runs and self-reports the expected version → hardlinks a `.bak` → atomic swap → re-exec.
- Bounded rollback: marker cleared on first healthy heartbeat; after 3 unconfirmed restarts, restore `.bak` and re-exec the previous binary.
- Gated by `CORTEX_AGENT_AUTO_UPDATE` (default on); off = drift logged only.

## Tests
7 self-update unit + 6 server-side (directive logic, ack contents, endpoint auth/platform gating). clippy + fmt clean; nextest green.

## Follow-ups
- syslog-mcp-76uzd — bootstrap remote agents to ≥1.22.0 (one-time; they predate directive parsing)
- syslog-mcp-s5f85 — phase 2: GitHub-release fallback for windows/non-x86_64 agents

Refs: syslog-mcp-esxxg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds heartbeat‑coordinated server→agent auto‑update to keep agents in lockstep and prevent version drift that broke Docker/syslog ingestion. Addresses syslog-mcp-esxxg.

- **New Features**
  - Heartbeat 202 ack now includes `server_version` and an optional `agent_update` directive `{version, path, sha256}`.
  - New authenticated `GET /v1/agent/binary?os=&arch=` streams the server’s running binary (phase 1: `linux/x86_64`).
  - Agent consumes the directive; on drift it downloads with bearer auth, verifies SHA‑256, validates `--version`, stages with `.bak`, atomically swaps, and re‑execs.
  - Bounded rollback: after 3 unconfirmed restarts, restore `.bak`; cleared on the first healthy heartbeat.
  - Controlled by `CORTEX_AGENT_AUTO_UPDATE` (default on). When off, drift is logged only.

- **Migration**
  - No manual steps for `linux/x86_64` agents; they auto‑converge.
  - To opt out, set `CORTEX_AGENT_AUTO_UPDATE=false`.
  - Non‑`linux/x86_64` agents unchanged for now (phase 2 will add a fallback).

<sup>Written for commit e8c3a3abb04c6ef1c137f5007f52e411d231eb20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

