### PR TITLE
feat(cli): flagless common case — positionals + smart defaults (CLI ergonomics Plan 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-06-16
+
+### Added
+
+- **Flagless common case (positionals + smart defaults)** — a bare positional now binds to each action's primary selector: `cortex tail dookie` and `cortex host-state dookie` set `--host`, `cortex search "oom killer"` sets the query. `tail` and `search` apply a default limit of 50 and `errors` defaults to a last-hour window when you omit the flags, so the everyday commands need no flags at all. The positional mapping and defaults are declarative metadata on `ACTION_SPECS` (`positional`/`defaults`), applied through shared `argdefaults` helpers — not per-command special-casing. Per-command `--help` examples now lead with the flagless form.
+
+### Changed
+
+- **`cortex tail <arg>` now treats `<arg>` as a hostname, not a line count.** Use `-n`/`--limit` for the count (e.g. `cortex tail dookie -n 100`). This is the only behavioral break in the positional rework; the old bare-number-as-count form is removed.
+
 ## [1.26.1] - 2026-06-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.1] - 2026-06-16
+
+### Fixed
+
+- **Silent wrong results from relative time on `apps`/`clock-skew`/`compare`/`correlate-state`/`host-state`/`notify recent`/`ai *`** — these commands captured their time-window flags (`--since`/`--until`, `--reference-time`, compare's `--a-from`/`--a-to`/`--b-from`/`--b-to`, notify's `--since`) as raw strings and bound them straight into SQL timestamp comparisons. A relative value like `1h` was compared *lexically* against RFC3339 timestamps (`timestamp >= '1h'`), silently returning wrong rows with no error. All such flags now route through a shared `norm_time` helper, so relative/keyword forms normalize to RFC3339 and non-time input is rejected. (`timeline`/`patterns`/`incident`/`correlate` in `parse_logs.rs` are addressed by the Plan 1 review fix.) `service logs` is unaffected — its `--since`/`--until` are forwarded to `docker compose logs`, not bound into cortex SQL.
+
 ## [1.27.0] - 2026-06-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2410,7 +2410,9 @@ start and verify with `cortex --http db status`.
 
 ---
 
-[Unreleased]: https://github.com/jmagar/cortex/compare/v1.26.1...HEAD
+[Unreleased]: https://github.com/jmagar/cortex/compare/v1.27.1...HEAD
+[1.27.1]: https://github.com/jmagar/cortex/compare/v1.27.0...v1.27.1
+[1.27.0]: https://github.com/jmagar/cortex/compare/v1.26.1...v1.27.0
 [1.26.1]: https://github.com/jmagar/cortex/compare/v1.26.0...v1.26.1
 [1.26.0]: https://github.com/jmagar/cortex/compare/v1.25.1...v1.26.0
 [1.25.1]: https://github.com/jmagar/cortex/compare/v1.20.0...v1.25.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.26.1"
+version = "1.27.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.27.0"
+version = "1.27.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.26.1"
+version = "1.27.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cortex"
-version = "1.27.0"
+version = "1.27.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -978,6 +978,10 @@ Both modes use the same config and environment variable loader. `cortex mcp` is 
 The direct CLI uses the same shared service layer as the MCP tool, so results and validation match the MCP actions without needing an MCP client:
 
 ```bash
+cortex search "oom killer"                 # bare query; default limit 50
+cortex tail dookie                         # bare positional → --host; default n=50
+cortex errors                              # defaults to the last hour
+cortex host-state tootie                   # bare positional → --host
 cortex search 'error AND nginx' --host proxy --limit 10
 cortex tail -n 20 --app kernel
 cortex errors --since 2026-01-01T00:00:00Z

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.27.0}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.27.1}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by scripts/bump-version.sh (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.26.1}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.27.0}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -105,7 +105,7 @@ Flags:
 | Flag | Description |
 | --- | --- |
 | positional `HOST` | Hostname filter — shorthand for `--host` |
-| `-n N`, `--n N`, `--limit N` | Number of rows to return (default 50) |
+| `-n N`, `--limit N` | Number of rows to return (default 50) |
 | `--host HOST` | Exact claimed hostname filter |
 | `--source SOURCE` | Exact source identifier filter |
 | `--app APP` | Application/process name filter |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -64,11 +64,13 @@ cortex search 'error AND nginx' --limit 5 --json
 
 ### `cortex search`
 
-Search logs with optional FTS5 query and filters.
+Search logs with optional FTS5 query and filters. The query is a bare positional;
+with no `--limit` the result count defaults to **50**.
 
 ```bash
+cortex search "oom killer"                       # bare query, limit 50
 cortex search 'error AND nginx' --host proxy --limit 10
-cortex search '"disk full"' --source 10.0.0.5:514 --since 2026-01-01T00:00:00Z
+cortex search --grep "smoke-test" --since 1h     # literal text, last hour
 ```
 
 Flags:
@@ -76,30 +78,34 @@ Flags:
 | Flag | Description |
 | --- | --- |
 | positional query | Optional SQLite FTS5 query. Multiple words are joined with spaces. |
+| `--grep TEXT` | Literal (FTS5-safe) substring; mutually exclusive with the positional query |
 | `--host HOST` | Exact claimed hostname filter |
 | `--source SOURCE` | Exact source identifier filter |
 | `--severity LEVEL` | Syslog severity filter: `emerg`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug` |
 | `--app APP` | Application/process name filter |
-| `--since TIME` | RFC3339 start timestamp |
-| `--until TIME` | RFC3339 end timestamp |
-| `--limit N` | Maximum returned rows |
+| `--since TIME` | Start of window — relative (`1h`, `2d`, `yesterday`) or RFC3339 |
+| `--until TIME` | End of window — relative or RFC3339 |
+| `--limit N` | Maximum returned rows (default 50) |
 | `--json` | Print JSON response |
 
 ### `cortex tail`
 
-Return recent log entries, optionally filtered by host, source, or app.
+Return recent log entries, optionally filtered by host, source, or app. A bare
+positional argument is a hostname (shorthand for `--host`); with no `-n`/`--limit`
+the row count defaults to **50**.
 
 ```bash
-cortex tail -n 20
-cortex tail 50 --host nas --app kernel
+cortex tail                       # 50 most recent across all hosts
+cortex tail dookie                # bare positional → --host dookie
+cortex tail nas --app kernel -n 100
 ```
 
 Flags:
 
 | Flag | Description |
 | --- | --- |
-| positional `N` | Number of rows to return |
-| `-n N`, `--n N` | Number of rows to return |
+| positional `HOST` | Hostname filter — shorthand for `--host` |
+| `-n N`, `--n N`, `--limit N` | Number of rows to return (default 50) |
 | `--host HOST` | Exact claimed hostname filter |
 | `--source SOURCE` | Exact source identifier filter |
 | `--app APP` | Application/process name filter |
@@ -107,10 +113,12 @@ Flags:
 
 ### `cortex errors`
 
-Summarize error and warning counts by host and severity.
+Summarize error and warning counts by host and severity. With no `--since` the
+window defaults to the **last hour**.
 
 ```bash
-cortex errors
+cortex errors                     # last hour
+cortex errors --since 6h --limit 50
 cortex errors --since 2026-01-01T00:00:00Z --until 2026-01-02T00:00:00Z --json
 ```
 
@@ -118,8 +126,8 @@ Flags:
 
 | Flag | Description |
 | --- | --- |
-| `--since TIME` | RFC3339 start timestamp |
-| `--until TIME` | RFC3339 end timestamp |
+| `--since TIME` | Start of window — relative (`1h`, `6h`, `yesterday`) or RFC3339 (default: last hour) |
+| `--until TIME` | End of window — relative or RFC3339 |
 | `--json` | Print JSON response |
 
 ### `cortex hosts`
@@ -683,10 +691,11 @@ Flags:
 
 ### `cortex host-state`
 
-Return the latest bounded heartbeat state for one host.
+Return the latest bounded heartbeat state for one host. A bare positional
+argument is a hostname (shorthand for `--host`).
 
 ```bash
-cortex host-state --host tootie
+cortex host-state tootie          # bare positional → --host tootie
 cortex host-state --host-id host-a --limit 5 --json
 ```
 
@@ -694,6 +703,7 @@ Flags:
 
 | Flag | Description |
 | --- | --- |
+| positional `HOST` | Hostname — shorthand for `--host` |
 | `--host-id ID` | Authoritative heartbeat host identity |
 | `--host HOST` | Self-reported hostname fallback (must resolve to one host) |
 | `--since TIME` | Minimum `sampled_at` timestamp (ISO 8601) |

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.26.1",
+  "version": "1.27.0",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -226,6 +226,20 @@ run_cortex_ai_add() {
     CORTEX_DB_PATH="$db_path" "$cortex_bin" ai add --file "$fixture" --json
 }
 
+# Resolve the cortex CLI binary (env CORTEX_BIN, PATH, or debug build), echoing
+# its path. Returns 127 when no binary is found.
+resolve_cortex_bin() {
+    if [[ -n "${CORTEX_BIN:-}" ]]; then
+        echo "$CORTEX_BIN"
+    elif command -v cortex >/dev/null 2>&1; then
+        command -v cortex
+    elif [[ -x "target/debug/cortex" ]]; then
+        echo "target/debug/cortex"
+    else
+        return 127
+    fi
+}
+
 seed_ai_fixture() {
     [[ -f "$AI_SMOKE_FIXTURE" ]] || return 1
 
@@ -1171,6 +1185,32 @@ if command -v sqlite3 >/dev/null 2>&1; then
     fi
 else
     echo "SKIP: enrichment smoke — sqlite3 not available"
+fi
+
+# ── CLI positionals + zero-flag defaults (Plan 3) ─────────────────────────────
+echo ""
+echo "CLI: positionals + defaults"
+if CLI_BIN="$(resolve_cortex_bin)"; then
+    # `cortex tail dookie` — bare positional binds to --host; default n=50.
+    CLI_TAIL_HOST="${SEED_HOST:-$(mcp_call hosts 2>/dev/null | python3 -c "import sys,json; h=json.load(sys.stdin).get('hostnames') or json.load(sys.stdin).get('hosts') or []; print(h[0] if h else '')" 2>/dev/null)}"
+    if [[ -n "$CLI_TAIL_HOST" ]]; then
+        if "$CLI_BIN" tail "$CLI_TAIL_HOST" -n 1 >/dev/null 2>&1; then
+            pass "cli: tail positional host (cortex tail $CLI_TAIL_HOST -n 1)"
+        else
+            fail "cli: tail positional host (cortex tail $CLI_TAIL_HOST -n 1)"
+        fi
+    else
+        skip "cli: tail positional host (no known hostname to target)"
+    fi
+
+    # `cortex errors` — no flags; default 1h window applied.
+    if "$CLI_BIN" errors >/dev/null 2>&1; then
+        pass "cli: errors default window (cortex errors)"
+    else
+        fail "cli: errors default window (cortex errors)"
+    fi
+else
+    skip "cli: positional/default checks require the cortex binary (set CORTEX_BIN or build it)"
 fi
 
 # ─── Phase 4: Summary ────────────────────────────────────────────────────────

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1192,7 +1192,15 @@ echo ""
 echo "CLI: positionals + defaults"
 if CLI_BIN="$(resolve_cortex_bin)"; then
     # `cortex tail dookie` — bare positional binds to --host; default n=50.
-    CLI_TAIL_HOST="${SEED_HOST:-$(mcp_call hosts 2>/dev/null | python3 -c "import sys,json; h=json.load(sys.stdin).get('hostnames') or json.load(sys.stdin).get('hosts') or []; print(h[0] if h else '')" 2>/dev/null)}"
+    CLI_TAIL_HOST="${SEED_HOST:-$(mcp_call hosts 2>/dev/null | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+hostnames = d.get("hostnames") or []
+if not hostnames:
+    hosts = d.get("hosts") or []
+    hostnames = [h.get("hostname") for h in hosts if isinstance(h, dict) and h.get("hostname")]
+print(hostnames[0] if hostnames else "")
+' 2>/dev/null)}"
     if [[ -n "$CLI_TAIL_HOST" ]]; then
         if "$CLI_BIN" tail "$CLI_TAIL_HOST" -n 1 >/dev/null 2>&1; then
             pass "cli: tail positional host (cortex tail $CLI_TAIL_HOST -n 1)"

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.26.1",
+  "version": "1.27.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.26.1",
+      "identifier": "ghcr.io/jmagar/cortex:v1.27.0",
       "transport": {
         "type": "stdio"
       },

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.27.0",
+  "version": "1.27.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.27.0",
+      "identifier": "ghcr.io/jmagar/cortex:v1.27.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,7 @@ mod timearg;
 
 pub(crate) use config_cmd::run_config;
 pub(crate) use heartbeat_agent::run_heartbeat_no_db;
-pub(crate) use parse_common::{FlagCursor, parse_i64_flag, parse_u32_flag};
+pub(crate) use parse_common::{FlagCursor, norm_time, parse_i64_flag, parse_u32_flag};
 pub(crate) use setup::install_self;
 pub(crate) use setup::run_setup;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,7 @@ pub(crate) use run::ENV_USE_HTTP;
 pub(crate) use run::{CliMode, GlobalFlags, run};
 
 mod ai_watch;
+mod argdefaults;
 pub(crate) mod color;
 mod complete;
 mod completions;
@@ -102,6 +103,17 @@ pub(crate) fn registry_flags(cli_command: &str) -> &'static [cortex::mcp::FlagSp
 /// Copy-paste examples for a CLI command (empty slice when none).
 pub(crate) fn registry_examples(cli_command: &str) -> &'static [&'static str] {
     cortex::mcp::examples_for(&cli_command.replace('-', "_")).unwrap_or(&[])
+}
+
+/// Canonical flag a bare positional binds to for a CLI command (`None` = the
+/// command takes no positional).
+pub(crate) fn registry_positional(cli_command: &str) -> Option<&'static str> {
+    cortex::mcp::positional_for(&cli_command.replace('-', "_"))
+}
+
+/// Zero-flag defaults for a CLI command (empty defaults when none).
+pub(crate) fn registry_defaults(cli_command: &str) -> cortex::mcp::Defaults {
+    cortex::mcp::defaults_for(&cli_command.replace('-', "_"))
 }
 
 /// `cortex __complete <ctx> ...` — print shell-completion candidates to stdout.

--- a/src/cli/argdefaults.rs
+++ b/src/cli/argdefaults.rs
@@ -1,0 +1,64 @@
+//! Declarative positional binding + zero-flag defaults, driven by `ACTION_SPECS`.
+//!
+//! These helpers keep the per-action `parse_*` functions free of bespoke
+//! positional / default logic: each parser collects its leftover positional
+//! tokens, then asks this module what they mean for the given action. The
+//! action name may be passed in either CLI (`host-state`) or MCP (`host_state`)
+//! form — the registry facade normalises hyphens to underscores.
+
+use anyhow::{Result, bail};
+
+/// Bind the collected positional tokens for `action` to its positional flag's
+/// value.
+///
+/// - `Ok(None)` — the action has a positional but none was supplied (leave the
+///   field at its parsed/default value), or the action takes no positional and
+///   none was supplied.
+/// - `Ok(Some(v))` — the single positional `v` to bind to the action's
+///   positional flag.
+/// - `Err` — positionals were supplied but the action accepts none, or more
+///   than one positional was supplied.
+pub(crate) fn positional_value(action: &str, positionals: &[String]) -> Result<Option<String>> {
+    let accepts = crate::cli::registry_positional(action).is_some();
+    match (accepts, positionals.len()) {
+        (false, 0) => Ok(None),
+        (false, _) => bail!(
+            "unexpected argument '{}'; this command takes no positional argument",
+            positionals[0]
+        ),
+        (true, 0) => Ok(None),
+        (true, 1) => Ok(Some(positionals[0].clone())),
+        (true, _) => bail!(
+            "expected at most one positional argument, got {}",
+            positionals.len()
+        ),
+    }
+}
+
+/// The effective `--limit`: the user's value if set, else the action default.
+pub(crate) fn effective_limit(action: &str, user: Option<u32>) -> Option<u32> {
+    user.or_else(|| crate::cli::registry_defaults(action).limit)
+}
+
+/// The effective `--since`: the user's value if set, else the action default
+/// resolved to an absolute RFC3339 string via the shared time parser.
+///
+/// The default is stored as a relative literal (e.g. `"1h"`); we run it through
+/// `parse_time_arg` so callers always receive an absolute timestamp, matching
+/// what an explicit `--since 1h` would have produced.
+pub(crate) fn effective_since(action: &str, user: Option<String>) -> Result<Option<String>> {
+    if let Some(v) = user {
+        return Ok(Some(v));
+    }
+    match crate::cli::registry_defaults(action).since {
+        Some(rel) => Ok(Some(crate::cli::timearg::parse_time_arg(
+            rel,
+            chrono::Utc::now(),
+        )?)),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+#[path = "argdefaults_tests.rs"]
+mod tests;

--- a/src/cli/argdefaults_tests.rs
+++ b/src/cli/argdefaults_tests.rs
@@ -1,0 +1,59 @@
+use super::*;
+
+#[test]
+fn bind_positional_returns_value_for_action_with_positional() {
+    // tail binds a bare positional to --host.
+    let bound = positional_value("tail", &["dookie".to_string()]).unwrap();
+    assert_eq!(bound.as_deref(), Some("dookie"));
+}
+
+#[test]
+fn bind_positional_none_when_no_token_given() {
+    assert_eq!(positional_value("tail", &[]).unwrap(), None);
+}
+
+#[test]
+fn bind_positional_errors_when_action_takes_none() {
+    // hosts takes no positional; a stray arg is an error.
+    let err = positional_value("hosts", &["oops".to_string()])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("unexpected"), "{err}");
+}
+
+#[test]
+fn bind_positional_errors_when_more_than_one_given() {
+    let err = positional_value("tail", &["a".to_string(), "b".to_string()])
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("at most one"), "{err}");
+}
+
+#[test]
+fn apply_default_limit_only_when_unset() {
+    assert_eq!(effective_limit("tail", None), Some(50)); // default applied
+    assert_eq!(effective_limit("tail", Some(5)), Some(5)); // user wins
+    assert_eq!(effective_limit("status", None), None); // no default
+}
+
+#[test]
+fn effective_since_resolves_default_window_to_absolute() {
+    // errors defaults to a 1h window; absent a user value we get an absolute
+    // RFC3339 timestamp (normalised to +00:00 by the time parser).
+    let resolved = effective_since("errors", None)
+        .unwrap()
+        .expect("default applied");
+    assert!(resolved.ends_with("+00:00"), "{resolved}");
+}
+
+#[test]
+fn effective_since_user_value_wins() {
+    let user = Some("2026-01-01T00:00:00+00:00".to_string());
+    assert_eq!(effective_since("errors", user.clone()).unwrap(), user);
+}
+
+#[test]
+fn effective_since_none_when_no_default() {
+    // tail has no since default.
+    assert_eq!(effective_since("tail", None).unwrap(), None);
+}

--- a/src/cli/commands/apps.rs
+++ b/src/cli/commands/apps.rs
@@ -6,7 +6,7 @@
 use anyhow::{Result, bail};
 
 use super::super::args::{AppsArgs, CliCommand};
-use super::super::{FlagCursor, parse_u32_flag};
+use super::super::{FlagCursor, norm_time, parse_u32_flag};
 
 pub(crate) fn parse_apps(args: &[String]) -> Result<CliCommand> {
     let mut parsed = AppsArgs::default();
@@ -17,9 +17,9 @@ pub(crate) fn parse_apps(args: &[String]) -> Result<CliCommand> {
         } else if let Some(v) = flags.match_value(&arg, "--host")? {
             parsed.host = Some(v);
         } else if let Some(v) = flags.match_value(&arg, "--since")? {
-            parsed.since = Some(v);
+            parsed.since = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--until")? {
-            parsed.until = Some(v);
+            parsed.until = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--limit")? {
             parsed.limit = Some(parse_u32_flag("--limit", v)?);
         } else if let Some(v) = flags.match_value(&arg, "--offset")? {

--- a/src/cli/commands/clock_skew.rs
+++ b/src/cli/commands/clock_skew.rs
@@ -6,7 +6,7 @@
 use anyhow::{Result, bail};
 
 use super::super::args::{CliCommand, ClockSkewArgs};
-use super::super::{FlagCursor, parse_u32_flag};
+use super::super::{FlagCursor, norm_time, parse_u32_flag};
 
 pub(crate) fn parse_clock_skew(args: &[String]) -> Result<CliCommand> {
     let mut parsed = ClockSkewArgs::default();
@@ -15,7 +15,7 @@ pub(crate) fn parse_clock_skew(args: &[String]) -> Result<CliCommand> {
         if arg == "--json" {
             parsed.json = true;
         } else if let Some(v) = flags.match_value(&arg, "--since")? {
-            parsed.since = Some(v);
+            parsed.since = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--limit")? {
             parsed.limit = Some(parse_u32_flag("--limit", v)?);
         } else {

--- a/src/cli/commands/compare.rs
+++ b/src/cli/commands/compare.rs
@@ -8,8 +8,8 @@
 
 use anyhow::{Result, bail};
 
-use super::super::FlagCursor;
 use super::super::args::{CliCommand, CompareArgs};
+use super::super::{FlagCursor, norm_time};
 
 pub(crate) fn parse_compare(args: &[String]) -> Result<CliCommand> {
     let mut parsed = CompareArgs::default();
@@ -18,13 +18,13 @@ pub(crate) fn parse_compare(args: &[String]) -> Result<CliCommand> {
         if arg == "--json" {
             parsed.json = true;
         } else if let Some(v) = flags.match_value(&arg, "--a-from")? {
-            parsed.a_from = Some(v);
+            parsed.a_from = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--a-to")? {
-            parsed.a_to = Some(v);
+            parsed.a_to = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--b-from")? {
-            parsed.b_from = Some(v);
+            parsed.b_from = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--b-to")? {
-            parsed.b_to = Some(v);
+            parsed.b_to = Some(norm_time(v)?);
         } else {
             bail!("unknown compare option: {arg}");
         }

--- a/src/cli/commands/correlate_state.rs
+++ b/src/cli/commands/correlate_state.rs
@@ -6,7 +6,7 @@
 use anyhow::{Result, bail};
 
 use super::super::args::{CliCommand, CorrelateStateArgs};
-use super::super::{FlagCursor, parse_u32_flag};
+use super::super::{FlagCursor, norm_time, parse_u32_flag};
 
 pub(crate) fn parse_correlate_state(args: &[String]) -> Result<CliCommand> {
     let mut parsed = CorrelateStateArgs::default();
@@ -15,7 +15,7 @@ pub(crate) fn parse_correlate_state(args: &[String]) -> Result<CliCommand> {
         if arg == "--json" {
             parsed.json = true;
         } else if let Some(v) = flags.match_value(&arg, "--reference-time")? {
-            parsed.reference_time = Some(v);
+            parsed.reference_time = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--window-minutes")? {
             parsed.window_minutes = Some(parse_u32_flag("--window-minutes", v)?);
         } else if let Some(v) = flags.match_value(&arg, "--host")? {

--- a/src/cli/commands/host_state.rs
+++ b/src/cli/commands/host_state.rs
@@ -5,11 +5,13 @@
 
 use anyhow::{Result, bail};
 
+use super::super::argdefaults::positional_value;
 use super::super::args::{CliCommand, HostStateArgs};
 use super::super::{FlagCursor, parse_u32_flag};
 
 pub(crate) fn parse_host_state(args: &[String]) -> Result<CliCommand> {
     let mut parsed = HostStateArgs::default();
+    let mut positionals: Vec<String> = Vec::new();
     let mut flags = FlagCursor::new(args);
     while let Some(arg) = flags.next() {
         if arg == "--json" {
@@ -22,7 +24,7 @@ pub(crate) fn parse_host_state(args: &[String]) -> Result<CliCommand> {
             parsed.since = Some(v);
         } else if let Some(v) = flags.match_value(&arg, "--limit")? {
             parsed.limit = Some(parse_u32_flag("--limit", v)?);
-        } else {
+        } else if arg.starts_with('-') {
             bail!(
                 "{}",
                 super::super::suggest::unknown_option(
@@ -31,7 +33,13 @@ pub(crate) fn parse_host_state(args: &[String]) -> Result<CliCommand> {
                     &["--json", "--host-id", "--host", "--since", "--limit"],
                 )
             );
+        } else {
+            // A bare positional binds to --host (e.g. `cortex host-state dookie`).
+            positionals.push(arg);
         }
+    }
+    if let Some(host) = positional_value("host_state", &positionals)? {
+        parsed.host = Some(host);
     }
     if parsed.host_id.is_none() && parsed.host.is_none() {
         bail!(

--- a/src/cli/commands/host_state.rs
+++ b/src/cli/commands/host_state.rs
@@ -7,7 +7,7 @@ use anyhow::{Result, bail};
 
 use super::super::argdefaults::positional_value;
 use super::super::args::{CliCommand, HostStateArgs};
-use super::super::{FlagCursor, parse_u32_flag};
+use super::super::{FlagCursor, norm_time, parse_u32_flag};
 
 pub(crate) fn parse_host_state(args: &[String]) -> Result<CliCommand> {
     let mut parsed = HostStateArgs::default();
@@ -21,7 +21,7 @@ pub(crate) fn parse_host_state(args: &[String]) -> Result<CliCommand> {
         } else if let Some(v) = flags.match_value(&arg, "--host")? {
             parsed.host = Some(v);
         } else if let Some(v) = flags.match_value(&arg, "--since")? {
-            parsed.since = Some(v);
+            parsed.since = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--limit")? {
             parsed.limit = Some(parse_u32_flag("--limit", v)?);
         } else if arg.starts_with('-') {

--- a/src/cli/commands/host_state.rs
+++ b/src/cli/commands/host_state.rs
@@ -39,6 +39,9 @@ pub(crate) fn parse_host_state(args: &[String]) -> Result<CliCommand> {
         }
     }
     if let Some(host) = positional_value("host_state", &positionals)? {
+        if parsed.host.is_some() {
+            bail!("--host and a positional host are mutually exclusive");
+        }
         parsed.host = Some(host);
     }
     if parsed.host_id.is_none() && parsed.host.is_none() {

--- a/src/cli/commands/notify.rs
+++ b/src/cli/commands/notify.rs
@@ -5,7 +5,7 @@
 use anyhow::{Result, anyhow, bail};
 
 use super::super::args::{CliCommand, NotifyCommand, NotifyRecentArgs, NotifyTestArgs};
-use super::super::{FlagCursor, parse_i64_flag};
+use super::super::{FlagCursor, norm_time, parse_i64_flag};
 
 /// Dispatch `cortex notify <subcommand> [args]`.
 pub(crate) fn parse_notify(args: &[String]) -> Result<CliCommand> {
@@ -35,7 +35,7 @@ fn parse_notify_recent(args: &[String]) -> Result<CliCommand> {
         } else if let Some(v) = flags.match_value(&arg, "--rule-id")? {
             parsed.rule_id = Some(v);
         } else if let Some(v) = flags.match_value(&arg, "--since")? {
-            parsed.since = Some(v);
+            parsed.since = Some(norm_time(v)?);
         } else if let Some(v) = flags.match_value(&arg, "--limit")? {
             parsed.limit = Some(parse_i64_flag("--limit", v)?);
         } else {

--- a/src/cli/commands/notify_tests.rs
+++ b/src/cli/commands/notify_tests.rs
@@ -28,7 +28,11 @@ fn parse_notify_recent_rejects_non_time_since() {
     let err = parse_notify(&strings(&["recent", "--since", "-3600"]))
         .unwrap_err()
         .to_string();
-    assert!(!err.is_empty());
+    // Must fail specifically on the time value, not some unrelated parser error.
+    assert!(
+        err.contains("time") || err.contains("--since"),
+        "expected a time-specific error, got: {err}"
+    );
 }
 
 fn strings(values: &[&str]) -> Vec<String> {

--- a/src/cli/commands/notify_tests.rs
+++ b/src/cli/commands/notify_tests.rs
@@ -1,19 +1,34 @@
 use super::*;
 
 #[test]
-fn parse_notify_recent_accepts_negative_since_and_limit() {
-    let args = strings(&["recent", "--since", "-3600", "--limit", "-1", "--json"]);
+fn parse_notify_recent_normalizes_since_and_accepts_negative_limit() {
+    // `--since` is bound into `fired_at >= ?` so it must normalize to RFC3339
+    // (a relative `1h` becomes an absolute timestamp). A negative `--limit`
+    // parses here and is range-checked later at dispatch.
+    let args = strings(&["recent", "--since", "1h", "--limit", "-1", "--json"]);
 
     let command = parse_notify(&args).unwrap();
 
     match command {
         CliCommand::Notify(NotifyCommand::Recent(args)) => {
-            assert_eq!(args.since.as_deref(), Some("-3600"));
+            assert!(
+                args.since.as_deref().unwrap().ends_with("+00:00"),
+                "since not normalized: {:?}",
+                args.since
+            );
             assert_eq!(args.limit, Some(-1));
             assert!(args.json);
         }
         other => panic!("unexpected command: {other:?}"),
     }
+}
+
+#[test]
+fn parse_notify_recent_rejects_non_time_since() {
+    let err = parse_notify(&strings(&["recent", "--since", "-3600"]))
+        .unwrap_err()
+        .to_string();
+    assert!(!err.is_empty());
 }
 
 fn strings(values: &[&str]) -> Vec<String> {

--- a/src/cli/parse_ai.rs
+++ b/src/cli/parse_ai.rs
@@ -5,7 +5,8 @@ use super::parse_ai_more::{
     parse_ai_investigate, parse_ai_similar,
 };
 use super::parse_common::{
-    FlagCursor, parse_output_args, parse_positive_u64_flag, parse_u32_flag, value_after_equals,
+    FlagCursor, norm_time, parse_output_args, parse_positive_u64_flag, parse_u32_flag,
+    value_after_equals,
 };
 use super::{
     AiAbuseArgs, AiAddArgs, AiBlocksArgs, AiCheckpointsArgs, AiCommand, AiContextArgs,
@@ -87,8 +88,8 @@ pub(crate) fn parse_ai_search(args: &[String]) -> Result<CliCommand> {
             "--json" => parsed.json = true,
             "--project" => parsed.project = Some(flags.value("--project")?),
             "--tool" => parsed.tool = Some(flags.value("--tool")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             "--limit" => parsed.limit = Some(parse_u32_flag("--limit", flags.value("--limit")?)?),
             _ if arg.starts_with("--project=") => {
                 parsed.project = Some(value_after_equals(arg, "--project")?)
@@ -97,10 +98,10 @@ pub(crate) fn parse_ai_search(args: &[String]) -> Result<CliCommand> {
                 parsed.tool = Some(value_after_equals(arg, "--tool")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ if arg.starts_with("--limit=") => {
                 parsed.limit = Some(parse_u32_flag(
@@ -127,8 +128,8 @@ pub(crate) fn parse_ai_abuse(args: &[String]) -> Result<CliCommand> {
             "--json" => parsed.json = true,
             "--project" => parsed.project = Some(flags.value("--project")?),
             "--tool" => parsed.tool = Some(flags.value("--tool")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             "--limit" => parsed.limit = Some(parse_u32_flag("--limit", flags.value("--limit")?)?),
             "--before" => {
                 parsed.before = Some(parse_u32_flag("--before", flags.value("--before")?)?)
@@ -142,10 +143,10 @@ pub(crate) fn parse_ai_abuse(args: &[String]) -> Result<CliCommand> {
                 parsed.tool = Some(value_after_equals(arg, "--tool")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ if arg.starts_with("--limit=") => {
                 parsed.limit = Some(parse_u32_flag(
@@ -189,8 +190,8 @@ pub(crate) fn parse_ai_correlate(args: &[String]) -> Result<CliCommand> {
             "--host" => parsed.host = Some(flags.value("--host")?),
             "--source" => parsed.source = Some(flags.value("--source")?),
             "--app" => parsed.app = Some(flags.value("--app")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             "--window-minutes" => {
                 parsed.window_minutes = Some(parse_u32_flag(
                     "--window-minutes",
@@ -228,10 +229,10 @@ pub(crate) fn parse_ai_correlate(args: &[String]) -> Result<CliCommand> {
             }
             _ if arg.starts_with("--app=") => parsed.app = Some(value_after_equals(arg, "--app")?),
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ if arg.starts_with("--window-minutes=") => {
                 parsed.window_minutes = Some(parse_u32_flag(
@@ -269,8 +270,8 @@ pub(crate) fn parse_ai_blocks(args: &[String]) -> Result<CliCommand> {
             "--json" => parsed.json = true,
             "--project" => parsed.project = Some(flags.value("--project")?),
             "--tool" => parsed.tool = Some(flags.value("--tool")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             "--limit" => {
                 parsed.limit = Some(parse_u32_flag("--limit", flags.value("--limit")?)? as usize)
             }
@@ -284,10 +285,10 @@ pub(crate) fn parse_ai_blocks(args: &[String]) -> Result<CliCommand> {
                 parsed.tool = Some(value_after_equals(arg, "--tool")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ if arg.starts_with("--limit=") => {
                 parsed.limit =
@@ -358,16 +359,16 @@ pub(crate) fn parse_ai_tools(args: &[String]) -> Result<CliCommand> {
         match arg.as_str() {
             "--json" => parsed.json = true,
             "--project" => parsed.project = Some(flags.value("--project")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             _ if arg.starts_with("--project=") => {
                 parsed.project = Some(value_after_equals(arg, "--project")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ => bail!("unknown ai tools option: {arg}"),
         }
@@ -382,16 +383,16 @@ pub(crate) fn parse_ai_projects(args: &[String]) -> Result<CliCommand> {
         match arg.as_str() {
             "--json" => parsed.json = true,
             "--tool" => parsed.tool = Some(flags.value("--tool")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             _ if arg.starts_with("--tool=") => {
                 parsed.tool = Some(value_after_equals(arg, "--tool")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ => bail!("unknown ai projects option: {arg}"),
         }
@@ -407,12 +408,12 @@ pub(crate) fn parse_ai_index(args: &[String]) -> Result<CliCommand> {
             "--json" => parsed.json = true,
             "--path" => parsed.path = Some(flags.value("--path")?),
             "--force" => parsed.force = true,
-            "--since" => parsed.since = Some(flags.value("--since")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
             _ if arg.starts_with("--path=") => {
                 parsed.path = Some(value_after_equals(arg, "--path")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ => bail!("unknown ai index option: {arg}"),
         }

--- a/src/cli/parse_ai_more.rs
+++ b/src/cli/parse_ai_more.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow, bail};
 
-use super::parse_common::{FlagCursor, parse_u32_flag, value_after_equals};
+use super::parse_common::{FlagCursor, norm_time, parse_u32_flag, value_after_equals};
 use super::{
     AiAskHistoryArgs, AiAssessArgs, AiCommand, AiIncidentContextArgs, AiIncidentsArgs,
     AiInvestigateArgs, AiOutputDetail, AiSimilarArgs, CliCommand,
@@ -15,8 +15,8 @@ pub(crate) fn parse_ai_similar(args: &[String]) -> Result<CliCommand> {
             "--host" => parsed.host = Some(flags.value("--host")?),
             "--app" => parsed.app = Some(flags.value("--app")?),
             "--severity-min" => parsed.severity_min = Some(flags.value("--severity-min")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             "--window-minutes" => {
                 parsed.window_minutes = Some(parse_u32_flag(
                     "--window-minutes",
@@ -32,10 +32,10 @@ pub(crate) fn parse_ai_similar(args: &[String]) -> Result<CliCommand> {
                 parsed.severity_min = Some(value_after_equals(arg, "--severity-min")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ if arg.starts_with("--window-minutes=") => {
                 parsed.window_minutes = Some(parse_u32_flag(
@@ -69,18 +69,18 @@ pub(crate) fn parse_ai_ask_history(args: &[String]) -> Result<CliCommand> {
             "--json" => parsed.json = true,
             "--host" => parsed.host = Some(flags.value("--host")?),
             "--app" => parsed.app = Some(flags.value("--app")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             "--limit" => parsed.limit = Some(parse_u32_flag("--limit", flags.value("--limit")?)?),
             _ if arg.starts_with("--host=") => {
                 parsed.host = Some(value_after_equals(arg, "--host")?)
             }
             _ if arg.starts_with("--app=") => parsed.app = Some(value_after_equals(arg, "--app")?),
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ if arg.starts_with("--limit=") => {
                 parsed.limit = Some(parse_u32_flag(
@@ -105,15 +105,19 @@ pub(crate) fn parse_ai_incident_context(args: &[String]) -> Result<CliCommand> {
     while let Some(arg) = flags.next() {
         match arg.as_str() {
             "--json" => parsed.json = true,
-            "--since" => parsed.since = flags.value("--since")?,
-            "--until" => parsed.until = flags.value("--until")?,
+            "--since" => parsed.since = norm_time(flags.value("--since")?)?,
+            "--until" => parsed.until = norm_time(flags.value("--until")?)?,
             "--host" => parsed.host = Some(flags.value("--host")?),
             "--app" => parsed.app = Some(flags.value("--app")?),
             "--query" => parsed.query = Some(flags.value("--query")?),
             "--severity-min" => parsed.severity_min = Some(flags.value("--severity-min")?),
             "--limit" => parsed.limit = Some(parse_u32_flag("--limit", flags.value("--limit")?)?),
-            _ if arg.starts_with("--since=") => parsed.since = value_after_equals(arg, "--since")?,
-            _ if arg.starts_with("--until=") => parsed.until = value_after_equals(arg, "--until")?,
+            _ if arg.starts_with("--since=") => {
+                parsed.since = norm_time(value_after_equals(arg, "--since")?)?
+            }
+            _ if arg.starts_with("--until=") => {
+                parsed.until = norm_time(value_after_equals(arg, "--until")?)?
+            }
             _ if arg.starts_with("--host=") => {
                 parsed.host = Some(value_after_equals(arg, "--host")?)
             }
@@ -151,8 +155,8 @@ pub(crate) fn parse_ai_incidents(args: &[String]) -> Result<CliCommand> {
             "--json" => parsed.json = true,
             "--project" => parsed.project = Some(flags.value("--project")?),
             "--tool" => parsed.tool = Some(flags.value("--tool")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             "--limit" => parsed.limit = Some(parse_u32_flag("--limit", flags.value("--limit")?)?),
             "--window-minutes" => {
                 parsed.window_minutes = Some(parse_u32_flag(
@@ -168,10 +172,10 @@ pub(crate) fn parse_ai_incidents(args: &[String]) -> Result<CliCommand> {
                 parsed.tool = Some(value_after_equals(arg, "--tool")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ if arg.starts_with("--limit=") => {
                 parsed.limit = Some(parse_u32_flag(
@@ -203,8 +207,8 @@ pub(crate) fn parse_ai_investigate(args: &[String]) -> Result<CliCommand> {
             "--json" => parsed.json = true,
             "--project" => parsed.project = Some(flags.value("--project")?),
             "--tool" => parsed.tool = Some(flags.value("--tool")?),
-            "--since" => parsed.since = Some(flags.value("--since")?),
-            "--until" => parsed.until = Some(flags.value("--until")?),
+            "--since" => parsed.since = Some(norm_time(flags.value("--since")?)?),
+            "--until" => parsed.until = Some(norm_time(flags.value("--until")?)?),
             "--limit" => parsed.limit = Some(parse_u32_flag("--limit", flags.value("--limit")?)?),
             "--window-minutes" => {
                 parsed.window_minutes = Some(parse_u32_flag(
@@ -234,10 +238,10 @@ pub(crate) fn parse_ai_investigate(args: &[String]) -> Result<CliCommand> {
                 parsed.tool = Some(value_after_equals(arg, "--tool")?)
             }
             _ if arg.starts_with("--since=") => {
-                parsed.since = Some(value_after_equals(arg, "--since")?)
+                parsed.since = Some(norm_time(value_after_equals(arg, "--since")?)?)
             }
             _ if arg.starts_with("--until=") => {
-                parsed.until = Some(value_after_equals(arg, "--until")?)
+                parsed.until = Some(norm_time(value_after_equals(arg, "--until")?)?)
             }
             _ if arg.starts_with("--limit=") => {
                 parsed.limit = Some(parse_u32_flag(
@@ -316,8 +320,8 @@ pub(crate) fn parse_ai_assess(args: &[String]) -> Result<CliCommand> {
             "--model" => model = Some(flags.value("--model")?),
             "--project" => project = Some(flags.value("--project")?),
             "--tool" => tool = Some(flags.value("--tool")?),
-            "--since" => from = Some(flags.value("--since")?),
-            "--until" => to = Some(flags.value("--until")?),
+            "--since" => from = Some(norm_time(flags.value("--since")?)?),
+            "--until" => to = Some(norm_time(flags.value("--until")?)?),
             "--limit" => limit = Some(parse_u32_flag("--limit", flags.value("--limit")?)?),
             "--window-minutes" => {
                 window_minutes = Some(parse_u32_flag(
@@ -337,8 +341,12 @@ pub(crate) fn parse_ai_assess(args: &[String]) -> Result<CliCommand> {
                 project = Some(value_after_equals(arg, "--project")?)
             }
             _ if arg.starts_with("--tool=") => tool = Some(value_after_equals(arg, "--tool")?),
-            _ if arg.starts_with("--since=") => from = Some(value_after_equals(arg, "--since")?),
-            _ if arg.starts_with("--until=") => to = Some(value_after_equals(arg, "--until")?),
+            _ if arg.starts_with("--since=") => {
+                from = Some(norm_time(value_after_equals(arg, "--since")?)?)
+            }
+            _ if arg.starts_with("--until=") => {
+                to = Some(norm_time(value_after_equals(arg, "--until")?)?)
+            }
             _ if arg.starts_with("--limit=") => {
                 limit = Some(parse_u32_flag(
                     "--limit",

--- a/src/cli/parse_ai_more_tests.rs
+++ b/src/cli/parse_ai_more_tests.rs
@@ -23,8 +23,8 @@ fn parse_ai_similar_and_ask_history_accept_all_filters() {
         "--host=host1",
         "--app=cortex",
         "--severity-min=err",
-        "--since=t0",
-        "--until=t1",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-01T00:10:00Z",
         "--window-minutes=45",
         "--limit=8",
         "disk",
@@ -43,8 +43,8 @@ fn parse_ai_similar_and_ask_history_accept_all_filters() {
     let ask = parse_ai_ask_history(&strings(&[
         "--host=host1",
         "--app=cortex",
-        "--since=t0",
-        "--until=t1",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-01T00:10:00Z",
         "--limit=5",
         "--json",
         "why",
@@ -87,8 +87,8 @@ fn parse_ai_incident_context_accepts_full_filter_set() {
 
     match command {
         crate::cli::CliCommand::Ai(crate::cli::AiCommand::IncidentContext(args)) => {
-            assert_eq!(args.since, "2026-01-01T00:00:00Z");
-            assert_eq!(args.until, "2026-01-01T00:10:00Z");
+            assert_eq!(args.since, "2026-01-01T00:00:00+00:00");
+            assert_eq!(args.until, "2026-01-01T00:10:00+00:00");
             assert_eq!(args.query.as_deref(), Some("panic"));
             assert_eq!(args.limit, Some(12));
             assert!(args.json);
@@ -102,8 +102,8 @@ fn parse_ai_incidents_accepts_terms_and_window_filters() {
     let command = parse_ai_incidents(&strings(&[
         "--project=/repo",
         "--tool=Bash",
-        "--since=t0",
-        "--until=t1",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-01T00:10:00Z",
         "--limit=13",
         "--window-minutes=60",
         "--term=panic",
@@ -153,8 +153,8 @@ fn parse_ai_investigate_accepts_incident_filters_and_limits() {
     let command = parse_ai_investigate(&strings(&[
         "--project=/repo",
         "--tool=Edit",
-        "--since=t0",
-        "--until=t1",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-01T00:10:00Z",
         "--limit=21",
         "--window-minutes=30",
         "--correlation-window-minutes=7",
@@ -185,8 +185,8 @@ fn parse_ai_assess_accepts_incident_and_investigation_filters() {
         "--model=gemini-test",
         "--project=/repo",
         "--tool=Bash",
-        "--since=t0",
-        "--until=t1",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-01T00:10:00Z",
         "--limit=34",
         "--window-minutes=44",
         "--correlation-window-minutes=9",
@@ -221,7 +221,11 @@ fn parse_ai_more_reports_required_query_and_unexpected_argument_errors() {
         (parse_ai_ask_history, vec!["--limit=1"], "requires a query"),
         (
             parse_ai_incident_context,
-            vec!["--since=t0", "--until=t1", "extra"],
+            vec![
+                "--since=2026-01-01T00:00:00Z",
+                "--until=2026-01-01T00:10:00Z",
+                "extra",
+            ],
             "unexpected positional argument",
         ),
         (

--- a/src/cli/parse_ai_tests.rs
+++ b/src/cli/parse_ai_tests.rs
@@ -80,8 +80,8 @@ fn parse_ai_search_abuse_and_correlate_accept_equals_forms() {
     let abuse = parse_ai_abuse(&strings(&[
         "--project=/repo",
         "--tool=Bash",
-        "--since=old",
-        "--until=new",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-02T00:00:00Z",
         "--limit=10",
         "--before=2",
         "--after=3",
@@ -108,8 +108,8 @@ fn parse_ai_search_abuse_and_correlate_accept_equals_forms() {
         "--host=host1",
         "--source=10.0.0.8",
         "--app=cortex",
-        "--since=t0",
-        "--until=t1",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-02T00:00:00Z",
         "--window-minutes=15",
         "--severity-min=warn",
         "--limit=20",
@@ -142,8 +142,8 @@ fn parse_ai_inventory_and_indexing_commands_accept_flags() {
 
     let tools = parse_ai_tools(&strings(&[
         "--project=/repo",
-        "--since=a",
-        "--until=b",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-02T00:00:00Z",
         "--json",
     ]))
     .unwrap();
@@ -155,26 +155,30 @@ fn parse_ai_inventory_and_indexing_commands_accept_flags() {
         other => panic!("unexpected command: {other:?}"),
     }
 
-    let projects =
-        parse_ai_projects(&strings(&["--tool=Write", "--since=a", "--until=b"])).unwrap();
+    let projects = parse_ai_projects(&strings(&[
+        "--tool=Write",
+        "--since=2026-01-01T00:00:00Z",
+        "--until=2026-01-02T00:00:00Z",
+    ]))
+    .unwrap();
     match projects {
         crate::cli::CliCommand::Ai(crate::cli::AiCommand::Projects(args)) => {
             assert_eq!(args.tool.as_deref(), Some("Write"));
-            assert_eq!(args.until.as_deref(), Some("b"));
+            assert_eq!(args.until.as_deref(), Some("2026-01-02T00:00:00+00:00"));
         }
         other => panic!("unexpected command: {other:?}"),
     }
 
     let index = parse_ai_index(&strings(&[
         "--path=/tmp/transcripts",
-        "--since=2026",
+        "--since=2026-01-01T00:00:00Z",
         "--force",
     ]))
     .unwrap();
     match index {
         crate::cli::CliCommand::Ai(crate::cli::AiCommand::Index(args)) => {
             assert_eq!(args.path.as_deref(), Some("/tmp/transcripts"));
-            assert_eq!(args.since.as_deref(), Some("2026"));
+            assert_eq!(args.since.as_deref(), Some("2026-01-01T00:00:00+00:00"));
             assert!(args.force);
         }
         other => panic!("unexpected command: {other:?}"),

--- a/src/cli/parse_common.rs
+++ b/src/cli/parse_common.rs
@@ -1,6 +1,23 @@
 use anyhow::{Result, anyhow, bail};
 
 use super::OutputArgs;
+
+/// Normalize a user-supplied time value to an RFC3339 string.
+///
+/// Accepts relative forms (`1h`, `30m`, `2d`, `yesterday`, `now`), bare dates
+/// (`YYYY-MM-DD`, `YYYY-MM-DD HH:MM`), and RFC3339, delegating to
+/// [`super::timearg::parse_time_arg`]. Non-time input is rejected with a clear
+/// error.
+///
+/// Every CLI flag that ends up bound into a SQL timestamp comparison MUST route
+/// its value through this. Storing the raw string instead lets a value like
+/// `"1h"` be compared *lexically* against RFC3339 timestamps — `timestamp >=
+/// '1h'` matches nothing and returns wrong results with no error (a silent
+/// failure).
+pub(crate) fn norm_time(raw: String) -> Result<String> {
+    super::timearg::parse_time_arg(&raw, chrono::Utc::now())
+}
+
 pub(crate) struct FlagCursor<'a> {
     args: &'a [String],
     index: usize,

--- a/src/cli/parse_logs.rs
+++ b/src/cli/parse_logs.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 
+use super::argdefaults::{effective_limit, effective_since, positional_value};
 use super::parse_common::{FlagCursor, parse_output_args, parse_u32_flag, value_after_equals};
 use super::timearg::parse_time_arg;
 use super::{
@@ -88,6 +89,7 @@ pub(crate) fn parse_search(args: &[String]) -> Result<CliCommand> {
     if parsed.grep.as_deref().is_some_and(|g| g.trim().is_empty()) {
         bail!("--grep requires non-empty text");
     }
+    parsed.limit = effective_limit("search", parsed.limit);
     Ok(CliCommand::Search(parsed))
 }
 
@@ -198,6 +200,7 @@ pub(crate) fn parse_filter(args: &[String]) -> Result<CliCommand> {
 
 pub(crate) fn parse_tail(args: &[String]) -> Result<CliCommand> {
     let mut parsed = TailArgs::default();
+    let mut positionals: Vec<String> = Vec::new();
     let mut flags = FlagCursor::new(args);
     while let Some(arg) = flags.next() {
         match arg.as_str() {
@@ -217,9 +220,15 @@ pub(crate) fn parse_tail(args: &[String]) -> Result<CliCommand> {
                 parsed.n = Some(parse_u32_flag("--n", value_after_equals(arg, "--n")?)?)
             }
             _ if arg.starts_with('-') => bail!("unknown tail option: {arg}"),
-            _ => parsed.n = Some(parse_u32_flag("n", arg)?),
+            // A bare positional binds to --host (e.g. `cortex tail dookie`); the
+            // result count is set with -n/--limit.
+            _ => positionals.push(arg),
         }
     }
+    if let Some(host) = positional_value("tail", &positionals)? {
+        parsed.host = Some(host);
+    }
+    parsed.n = effective_limit("tail", parsed.n);
     Ok(CliCommand::Tail(parsed))
 }
 
@@ -247,6 +256,8 @@ pub(crate) fn parse_errors(args: &[String]) -> Result<CliCommand> {
             _ => bail!("unknown errors option: {arg}"),
         }
     }
+    // Default to a recent window (last hour) when the user gives no --since.
+    parsed.since = effective_since("errors", parsed.since)?;
     Ok(CliCommand::Errors(parsed))
 }
 

--- a/src/cli/parse_logs.rs
+++ b/src/cli/parse_logs.rs
@@ -208,7 +208,7 @@ pub(crate) fn parse_tail(args: &[String]) -> Result<CliCommand> {
             "--host" => parsed.host = Some(flags.value("--host")?),
             "--source" => parsed.source = Some(flags.value("--source")?),
             "--app" => parsed.app = Some(flags.value("--app")?),
-            "--n" | "-n" => parsed.n = Some(parse_u32_flag(&arg, flags.value(&arg)?)?),
+            "--n" | "-n" | "--limit" => parsed.n = Some(parse_u32_flag(&arg, flags.value(&arg)?)?),
             _ if arg.starts_with("--host=") => {
                 parsed.host = Some(value_after_equals(arg, "--host")?)
             }
@@ -219,6 +219,12 @@ pub(crate) fn parse_tail(args: &[String]) -> Result<CliCommand> {
             _ if arg.starts_with("--n=") => {
                 parsed.n = Some(parse_u32_flag("--n", value_after_equals(arg, "--n")?)?)
             }
+            _ if arg.starts_with("--limit=") => {
+                parsed.n = Some(parse_u32_flag(
+                    "--limit",
+                    value_after_equals(arg, "--limit")?,
+                )?)
+            }
             _ if arg.starts_with('-') => bail!("unknown tail option: {arg}"),
             // A bare positional binds to --host (e.g. `cortex tail dookie`); the
             // result count is set with -n/--limit.
@@ -226,6 +232,9 @@ pub(crate) fn parse_tail(args: &[String]) -> Result<CliCommand> {
         }
     }
     if let Some(host) = positional_value("tail", &positionals)? {
+        if parsed.host.is_some() {
+            bail!("--host and a positional host are mutually exclusive");
+        }
         parsed.host = Some(host);
     }
     parsed.n = effective_limit("tail", parsed.n);

--- a/src/cli/parse_logs_tests.rs
+++ b/src/cli/parse_logs_tests.rs
@@ -316,3 +316,69 @@ fn filter_and_sessions_normalize_relative_from() {
         args.since
     );
 }
+
+#[test]
+fn tail_positional_sets_host_and_default_limit() {
+    let cmd = parse_tail(&strings(&["dookie"])).unwrap();
+    let crate::cli::CliCommand::Tail(args) = cmd else {
+        panic!("expected Tail")
+    };
+    assert_eq!(args.host.as_deref(), Some("dookie"));
+    assert_eq!(args.n, Some(50)); // default applied when -n/--limit omitted
+}
+
+#[test]
+fn tail_explicit_limit_overrides_default() {
+    let cmd = parse_tail(&strings(&["dookie", "-n", "10"])).unwrap();
+    let crate::cli::CliCommand::Tail(args) = cmd else {
+        panic!("expected Tail")
+    };
+    assert_eq!(args.host.as_deref(), Some("dookie"));
+    assert_eq!(args.n, Some(10));
+}
+
+#[test]
+fn tail_rejects_two_positionals() {
+    let err = parse_tail(&strings(&["dookie", "tootie"]))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("at most one"), "{err}");
+}
+
+#[test]
+fn search_applies_default_limit() {
+    let cmd = parse_search(&strings(&["oom"])).unwrap();
+    let crate::cli::CliCommand::Search(args) = cmd else {
+        panic!("expected Search")
+    };
+    assert_eq!(args.query.as_deref(), Some("oom"));
+    assert_eq!(args.limit, Some(50));
+}
+
+#[test]
+fn search_explicit_limit_overrides_default() {
+    let cmd = parse_search(&strings(&["oom", "--limit", "5"])).unwrap();
+    let crate::cli::CliCommand::Search(args) = cmd else {
+        panic!("expected Search")
+    };
+    assert_eq!(args.limit, Some(5));
+}
+
+#[test]
+fn errors_defaults_to_one_hour_window() {
+    let cmd = parse_errors(&strings(&[])).unwrap();
+    let crate::cli::CliCommand::Errors(args) = cmd else {
+        panic!("expected Errors")
+    };
+    let since = args.since.expect("default since applied");
+    assert!(since.ends_with("+00:00"), "{since}"); // absolute RFC3339 from the 1h default
+}
+
+#[test]
+fn errors_explicit_since_overrides_default() {
+    let cmd = parse_errors(&strings(&["--since", "2026-01-01T00:00:00Z"])).unwrap();
+    let crate::cli::CliCommand::Errors(args) = cmd else {
+        panic!("expected Errors")
+    };
+    assert_eq!(args.since.as_deref(), Some("2026-01-01T00:00:00+00:00"));
+}

--- a/src/cli/parse_logs_tests.rs
+++ b/src/cli/parse_logs_tests.rs
@@ -348,6 +348,28 @@ fn tail_rejects_two_positionals() {
 }
 
 #[test]
+fn tail_accepts_limit_flag_for_count() {
+    // `--limit` is a documented alias for `-n`; both set the row count.
+    for cmd in [
+        parse_tail(&strings(&["--limit", "7"])).unwrap(),
+        parse_tail(&strings(&["--limit=7"])).unwrap(),
+    ] {
+        let crate::cli::CliCommand::Tail(args) = cmd else {
+            panic!("expected Tail")
+        };
+        assert_eq!(args.n, Some(7));
+    }
+}
+
+#[test]
+fn tail_positional_and_host_flag_are_mutually_exclusive() {
+    let err = parse_tail(&strings(&["bar", "--host", "foo"]))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("mutually exclusive"), "{err}");
+}
+
+#[test]
 fn search_applies_default_limit() {
     let cmd = parse_search(&strings(&["oom"])).unwrap();
     let crate::cli::CliCommand::Search(args) = cmd else {
@@ -374,6 +396,16 @@ fn errors_defaults_to_one_hour_window() {
     };
     let since = args.since.expect("default since applied");
     assert!(since.ends_with("+00:00"), "{since}"); // absolute RFC3339 from the 1h default
+    // Pin the actual one-hour semantics, not just the shape: the default window
+    // should land ~1h before now (allow slack for clock + execution time).
+    let parsed = chrono::DateTime::parse_from_rfc3339(&since).expect("rfc3339");
+    let age_min = chrono::Utc::now()
+        .signed_duration_since(parsed.with_timezone(&chrono::Utc))
+        .num_minutes();
+    assert!(
+        (55..=65).contains(&age_min),
+        "default window should be ~1h ago, was {age_min} min: {since}"
+    );
 }
 
 #[test]

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -272,6 +272,19 @@ fn parse_host_state_binds_bare_positional_to_host() {
 }
 
 #[test]
+fn parse_host_state_positional_and_host_flag_are_mutually_exclusive() {
+    let err = parse_command(vec![
+        "host-state".to_string(),
+        "dookie".to_string(),
+        "--host".to_string(),
+        "tootie".to_string(),
+    ])
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("mutually exclusive"), "{err}");
+}
+
+#[test]
 fn parse_host_state_requires_host_selector_with_usage() {
     let err = parse_command(vec!["host-state".to_string()])
         .unwrap_err()
@@ -559,13 +572,24 @@ fn time_flags_normalize_relative_across_state_admin_and_ai_commands() {
     };
     assert!(c.since.unwrap().ends_with("+00:00"));
 
-    // compare --a-from (and the other three share the code path)
-    let CliCommand::Compare(cmp) =
-        parse_command(vec!["compare".into(), "--a-from".into(), "1h".into()]).unwrap()
-    else {
-        panic!("expected Compare")
-    };
-    assert!(cmp.a_from.unwrap().ends_with("+00:00"));
+    // compare: each of the four window flags normalizes independently.
+    for flag in ["--a-from", "--a-to", "--b-from", "--b-to"] {
+        let CliCommand::Compare(cmp) =
+            parse_command(vec!["compare".into(), flag.into(), "1h".into()]).unwrap()
+        else {
+            panic!("expected Compare")
+        };
+        let v = match flag {
+            "--a-from" => cmp.a_from,
+            "--a-to" => cmp.a_to,
+            "--b-from" => cmp.b_from,
+            _ => cmp.b_to,
+        };
+        assert!(
+            v.unwrap().ends_with("+00:00"),
+            "compare {flag} should normalize"
+        );
+    }
 
     // correlate-state --reference-time
     let CliCommand::CorrelateState(cs) = parse_command(vec![

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -1,6 +1,6 @@
 use super::super::{
-    FileTailAddArgs, FileTailCommand, FileTailListArgs, HeartbeatAgentArgs, HeartbeatCommand,
-    InventoryArgs, InventoryCommand, OutputArgs,
+    AiCommand, FileTailAddArgs, FileTailCommand, FileTailListArgs, HeartbeatAgentArgs,
+    HeartbeatCommand, InventoryArgs, InventoryCommand, OutputArgs,
 };
 use super::*;
 
@@ -532,4 +532,110 @@ fn parse_correlate_state_rejects_unknown_flag() {
         .unwrap_err()
         .to_string();
     assert!(err.contains("unknown correlate-state option"), "got: {err}");
+}
+
+// Regression: every CLI flag whose value is bound into a SQL timestamp
+// comparison must route through the shared time parser, so relative/keyword
+// input is normalized to RFC3339 (and non-time input is rejected) rather than
+// stored raw and compared lexically — a silent-failure source. parse_logs's
+// search/filter/tail/errors/timeline/patterns/incident/correlate are covered
+// elsewhere; this pins the previously-unnormalized commands.
+#[test]
+fn time_flags_normalize_relative_across_state_admin_and_ai_commands() {
+    // apps --since/--until
+    let CliCommand::Apps(a) =
+        parse_command(vec!["apps".into(), "--since".into(), "1h".into()]).unwrap()
+    else {
+        panic!("expected Apps")
+    };
+    let s = a.since.expect("apps since");
+    assert!(s.ends_with("+00:00"), "apps --since not normalized: {s}");
+
+    // clock-skew --since
+    let CliCommand::ClockSkew(c) =
+        parse_command(vec!["clock-skew".into(), "--since".into(), "2d".into()]).unwrap()
+    else {
+        panic!("expected ClockSkew")
+    };
+    assert!(c.since.unwrap().ends_with("+00:00"));
+
+    // compare --a-from (and the other three share the code path)
+    let CliCommand::Compare(cmp) =
+        parse_command(vec!["compare".into(), "--a-from".into(), "1h".into()]).unwrap()
+    else {
+        panic!("expected Compare")
+    };
+    assert!(cmp.a_from.unwrap().ends_with("+00:00"));
+
+    // correlate-state --reference-time
+    let CliCommand::CorrelateState(cs) = parse_command(vec![
+        "correlate-state".into(),
+        "--reference-time".into(),
+        "1h".into(),
+    ])
+    .unwrap() else {
+        panic!("expected CorrelateState")
+    };
+    assert!(cs.reference_time.unwrap().ends_with("+00:00"));
+
+    // host-state (bare positional host) --since
+    let CliCommand::HostState(hs) = parse_command(vec![
+        "host-state".into(),
+        "dookie".into(),
+        "--since".into(),
+        "30m".into(),
+    ])
+    .unwrap() else {
+        panic!("expected HostState")
+    };
+    assert!(hs.since.unwrap().ends_with("+00:00"));
+
+    // ai search --since
+    let CliCommand::Ai(AiCommand::Search(ai)) = parse_command(vec![
+        "ai".into(),
+        "search".into(),
+        "boom".into(),
+        "--since".into(),
+        "1h".into(),
+    ])
+    .unwrap() else {
+        panic!("expected Ai Search")
+    };
+    assert!(ai.since.unwrap().ends_with("+00:00"));
+}
+
+#[test]
+fn time_flags_reject_non_time_values() {
+    for cmd in [
+        vec!["apps".to_string(), "--since".into(), "notatime".into()],
+        vec![
+            "clock-skew".to_string(),
+            "--since".into(),
+            "notatime".into(),
+        ],
+        vec!["compare".to_string(), "--a-from".into(), "notatime".into()],
+        vec![
+            "correlate-state".to_string(),
+            "--reference-time".into(),
+            "notatime".into(),
+        ],
+        vec![
+            "host-state".to_string(),
+            "dookie".into(),
+            "--since".into(),
+            "notatime".into(),
+        ],
+        vec![
+            "ai".to_string(),
+            "search".into(),
+            "q".into(),
+            "--since".into(),
+            "notatime".into(),
+        ],
+    ] {
+        assert!(
+            parse_command(cmd.clone()).is_err(),
+            "expected error for {cmd:?}"
+        );
+    }
 }

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -263,6 +263,15 @@ fn parse_routes_host_state() {
 }
 
 #[test]
+fn parse_host_state_binds_bare_positional_to_host() {
+    let cmd = parse_command(vec!["host-state".to_string(), "dookie".to_string()]).unwrap();
+    let CliCommand::HostState(args) = cmd else {
+        panic!("expected HostState")
+    };
+    assert_eq!(args.host.as_deref(), Some("dookie"));
+}
+
+#[test]
 fn parse_host_state_requires_host_selector_with_usage() {
     let err = parse_command(vec!["host-state".to_string()])
         .unwrap_err()

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -415,7 +415,7 @@ fn parse_ai_index_collects_reindex_controls() {
         parsed,
         CliCommand::Ai(AiCommand::Index(AiIndexArgs {
             path: Some("/tmp/session.jsonl".into()),
-            since: Some("2026-05-14T00:00:00Z".into()),
+            since: Some("2026-05-14T00:00:00+00:00".into()),
             force: true,
             json: true,
         }))
@@ -1470,7 +1470,7 @@ fn parse_clock_skew_with_since() {
         .expect("parse clock-skew");
     match cmd {
         CliCommand::ClockSkew(args) => {
-            assert_eq!(args.since.as_deref(), Some("2026-05-20T00:00:00Z"));
+            assert_eq!(args.since.as_deref(), Some("2026-05-20T00:00:00+00:00"));
             assert!(!args.json);
         }
         other => panic!("expected ClockSkew, got {other:?}"),
@@ -1512,8 +1512,8 @@ fn parse_compare_with_ranges() {
     .expect("parse compare");
     match cmd {
         CliCommand::Compare(args) => {
-            assert_eq!(args.a_from.as_deref(), Some("2026-05-20T00:00:00Z"));
-            assert_eq!(args.b_to.as_deref(), Some("2026-05-21T23:59:59Z"));
+            assert_eq!(args.a_from.as_deref(), Some("2026-05-20T00:00:00+00:00"));
+            assert_eq!(args.b_to.as_deref(), Some("2026-05-21T23:59:59+00:00"));
         }
         other => panic!("expected Compare, got {other:?}"),
     }

--- a/src/cli_tests.rs
+++ b/src/cli_tests.rs
@@ -81,8 +81,10 @@ fn parse_search_collects_query_and_filters() {
 }
 
 #[test]
-fn parse_tail_accepts_positional_count() {
-    let parsed = CliCommand::parse(strings(&["tail", "10", "--host", "router"])).unwrap();
+fn parse_tail_binds_positional_to_host_with_explicit_count() {
+    // Plan 3 semantics: a bare positional binds to --host; the result count
+    // comes from -n/--limit (no longer a bare-number positional).
+    let parsed = CliCommand::parse(strings(&["tail", "router", "-n", "10"])).unwrap();
 
     assert_eq!(
         parsed,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -15,8 +15,8 @@ mod routes;
 mod schemas;
 mod tools;
 
-pub use action_flags::{FlagSpec, ValueKind};
-pub use actions::{description_for, examples_for, flags_for};
+pub use action_flags::{Defaults, FlagSpec, ValueKind};
+pub use actions::{defaults_for, description_for, examples_for, flags_for, positional_for};
 pub use rmcp_server::{
     CortexRmcpServer, rmcp_server, streamable_http_config, streamable_http_service,
 };

--- a/src/mcp/action_flags.rs
+++ b/src/mcp/action_flags.rs
@@ -32,6 +32,31 @@ pub enum ValueKind {
     Time,
 }
 
+/// Zero-flag defaults applied to an action when the user omits them.
+///
+/// Kept deliberately small: the only knobs worth defaulting at the CLI layer
+/// are the result `limit` and the start-of-window `since`. `None` in either
+/// field means "leave it to the server / unbounded" — i.e. no default.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Defaults {
+    /// Default `--limit` when the user passes none (`None` = server default).
+    pub limit: Option<u32>,
+    /// Default `--since` window when unset, expressed as a relative literal the
+    /// time parser understands (e.g. `"1h"`). `None` = unbounded.
+    pub since: Option<&'static str>,
+}
+
+impl Defaults {
+    /// Const constructor for the empty (no-defaults) case, usable inside the
+    /// `const ACTION_SPECS` table where `Default::default()` cannot be called.
+    pub const fn new() -> Self {
+        Self {
+            limit: None,
+            since: None,
+        }
+    }
+}
+
 pub(super) const SEVERITIES: &[&str] = &[
     "emerg", "alert", "crit", "err", "warning", "notice", "info", "debug",
 ];

--- a/src/mcp/actions.rs
+++ b/src/mcp/actions.rs
@@ -177,7 +177,8 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         SearchLogs,
         flags: COMMON_LOG_FLAGS,
         examples: &[
-            "cortex search \"oom killer\" --host dookie --since 1h",
+            "cortex search \"oom killer\"",
+            "cortex search \"oom\" --host dookie --since 1h",
             "cortex search --grep \"smoke-test\" --limit 20",
         ],
         positional: Some("--query"),
@@ -199,7 +200,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         Cheap,
         TailLogs,
         flags: COMMON_LOG_FLAGS,
-        examples: &["cortex tail --host dookie -n 100"],
+        examples: &["cortex tail dookie", "cortex tail --host dookie -n 100"],
         positional: Some("--host"),
         defaults: Defaults { limit: Some(50), since: None }
     ),
@@ -210,7 +211,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         Cheap,
         GetErrors,
         flags: COMMON_LOG_FLAGS,
-        examples: &["cortex errors --since 1h"],
+        examples: &["cortex errors", "cortex errors --since 6h --limit 50"],
         positional: None,
         defaults: Defaults { limit: None, since: Some("1h") }
     ),
@@ -237,7 +238,7 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         Moderate,
         HostState,
         flags: &[],
-        examples: &["cortex host-state dookie"],
+        examples: &["cortex host-state dookie", "cortex host-state dookie --since 30m"],
         positional: Some("--host"),
         defaults: Defaults::new()
     ),

--- a/src/mcp/actions.rs
+++ b/src/mcp/actions.rs
@@ -9,7 +9,7 @@
 //! Now there is one metadata table: [`ACTION_SPECS`]. The schema, scope gates,
 //! help text, and action metadata are computed from it.
 
-use super::action_flags::{COMMON_LOG_FLAGS, FlagSpec};
+use super::action_flags::{COMMON_LOG_FLAGS, Defaults, FlagSpec};
 
 /// The scope required to invoke a given action.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,12 +117,19 @@ pub(super) struct ActionSpec {
     pub flags: &'static [FlagSpec],
     /// Copy-paste example invocations.
     pub examples: &'static [&'static str],
+    /// Canonical flag a bare positional argument binds to (`None` = the action
+    /// takes no positional). E.g. `tail dookie` binds the positional to
+    /// `--host`.
+    pub positional: Option<&'static str>,
+    /// Zero-flag defaults applied when the user omits `--limit` / `--since`.
+    pub defaults: Defaults,
 }
 
 macro_rules! action_spec {
-    // Full form: with flag + example metadata.
+    // Canonical form: flags + examples + positional + defaults.
     ($name:literal, $scope:ident, $description:literal, $cost:ident, $handler:ident,
-     flags: $flags:expr, examples: $examples:expr) => {
+     flags: $flags:expr, examples: $examples:expr,
+     positional: $positional:expr, defaults: $defaults:expr) => {
         ActionSpec {
             name: $name,
             scope: Scope::$scope,
@@ -131,13 +138,25 @@ macro_rules! action_spec {
             handler: ActionHandler::$handler,
             flags: $flags,
             examples: $examples,
+            positional: $positional,
+            defaults: $defaults,
         }
+    };
+    // Full form: flag + example metadata, no positional/defaults.
+    ($name:literal, $scope:ident, $description:literal, $cost:ident, $handler:ident,
+     flags: $flags:expr, examples: $examples:expr) => {
+        action_spec!(
+            $name, $scope, $description, $cost, $handler,
+            flags: $flags, examples: $examples,
+            positional: None, defaults: Defaults::new()
+        )
     };
     // Short form: no flag/example metadata yet (defaults to empty).
     ($name:literal, $scope:ident, $description:literal, $cost:ident, $handler:ident) => {
         action_spec!(
             $name, $scope, $description, $cost, $handler,
-            flags: &[], examples: &[]
+            flags: &[], examples: &[],
+            positional: None, defaults: Defaults::new()
         )
     };
 }
@@ -160,7 +179,9 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         examples: &[
             "cortex search \"oom killer\" --host dookie --since 1h",
             "cortex search --grep \"smoke-test\" --limit 20",
-        ]
+        ],
+        positional: Some("--query"),
+        defaults: Defaults { limit: Some(50), since: None }
     ),
     action_spec!(
         "filter",
@@ -178,7 +199,9 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         Cheap,
         TailLogs,
         flags: COMMON_LOG_FLAGS,
-        examples: &["cortex tail --host dookie -n 100"]
+        examples: &["cortex tail --host dookie -n 100"],
+        positional: Some("--host"),
+        defaults: Defaults { limit: Some(50), since: None }
     ),
     action_spec!(
         "errors",
@@ -187,7 +210,9 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         Cheap,
         GetErrors,
         flags: COMMON_LOG_FLAGS,
-        examples: &["cortex errors --since 1h"]
+        examples: &["cortex errors --since 1h"],
+        positional: None,
+        defaults: Defaults { limit: None, since: Some("1h") }
     ),
     action_spec!(
         "hosts",
@@ -210,7 +235,11 @@ pub(super) const ACTION_SPECS: &[ActionSpec] = &[
         Read,
         "Fetch latest bounded heartbeat state for a host",
         Moderate,
-        HostState
+        HostState,
+        flags: &[],
+        examples: &["cortex host-state dookie"],
+        positional: Some("--host"),
+        defaults: Defaults::new()
     ),
     action_spec!(
         "fleet_state",
@@ -534,6 +563,24 @@ pub fn description_for(action: &str) -> Option<&'static str> {
         .iter()
         .find(|s| s.name == action)
         .map(|s| s.description)
+}
+
+/// The canonical flag a bare positional binds to for `action` (`None` when the
+/// action takes no positional or is unknown).
+pub fn positional_for(action: &str) -> Option<&'static str> {
+    ACTION_SPECS
+        .iter()
+        .find(|s| s.name == action)
+        .and_then(|s| s.positional)
+}
+
+/// Zero-flag defaults for `action` (empty defaults when the action is unknown).
+pub fn defaults_for(action: &str) -> Defaults {
+    ACTION_SPECS
+        .iter()
+        .find(|s| s.name == action)
+        .map(|s| s.defaults)
+        .unwrap_or_default()
 }
 
 /// Map an action name to its required MCP scope string.

--- a/src/mcp/actions_tests.rs
+++ b/src/mcp/actions_tests.rs
@@ -42,3 +42,34 @@ fn all_cli_query_actions_have_examples() {
         );
     }
 }
+
+#[test]
+fn tail_binds_positional_to_host_and_defaults_limit() {
+    assert_eq!(positional_for("tail"), Some("--host"));
+    assert_eq!(defaults_for("tail").limit, Some(50));
+}
+
+#[test]
+fn search_positional_binds_to_query() {
+    assert_eq!(positional_for("search"), Some("--query"));
+    assert_eq!(defaults_for("search").limit, Some(50));
+}
+
+#[test]
+fn errors_defaults_to_one_hour_window() {
+    assert_eq!(positional_for("errors"), None);
+    assert_eq!(defaults_for("errors").since, Some("1h"));
+}
+
+#[test]
+fn host_state_binds_positional_to_host() {
+    assert_eq!(positional_for("host_state"), Some("--host"));
+}
+
+#[test]
+fn actions_without_positional_metadata_default_to_none() {
+    assert_eq!(positional_for("hosts"), None);
+    let d = defaults_for("hosts");
+    assert_eq!(d.limit, None);
+    assert_eq!(d.since, None);
+}


### PR DESCRIPTION
**Stacked on #80** (base = `claude/cli-plan2-completion-rename`). Retarget down the stack as #79 → #80 merge.

## Summary

Plan 3 of the CLI ergonomics effort — make the everyday commands flagless.

- **Positionals** — a bare argument binds to each action's primary selector, declared in `ACTION_SPECS`: `cortex tail dookie` / `cortex host-state dookie` → `--host`, `cortex search "oom killer"` → the query.
- **Smart defaults** — `tail` and `search` default to `limit 50`; `errors` defaults to a **last-hour** window. Declared as `defaults` metadata on the registry, resolved through the Plan 1 time parser.
- **Declarative, not special-cased** — new `positional`/`defaults` fields on `ActionSpec` + shared `src/cli/argdefaults.rs` helpers (`positional_value`, `effective_limit`, `effective_since`). The per-action parsers just collect leftover positionals and ask the registry.
- **Help + docs** — per-command `--help` examples now lead with the flagless form; `docs/CLI.md` + README updated; smoke-test exercises the positional/default forms.

### ⚠️ Behavioral break
`cortex tail <arg>` now treats `<arg>` as a **hostname**, not a line count. Use `-n`/`--limit` for the count (`cortex tail dookie -n 100`). The old bare-number-as-count form is removed. (Documented in CHANGELOG + the now-fixed `docs/CLI.md` example.)

Version: 1.26.1 → **1.27.0** (feat → minor).

## Docs pass
Audited the full docs tree for this stack: no stale request-flag vocabulary remains (Plan 2 + the #80 review cleaned it); fixed the one now-broken example (`cortex tail 50 …`); documented positionals/defaults across `docs/CLI.md`, README, and registry help. Plugin skills use the MCP action form (unchanged args), so they needed no positional updates.

## Test Plan
- [x] `cargo test -p cortex` — 10 suites, **0 failures** (post-rebase onto #80)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `scripts/check-version-sync.sh` — all 4 files at v1.27.0
- [x] New unit tests: registry positional/defaults metadata, `argdefaults` helpers, and parser behavior for tail/search/errors/host-state (incl. positional-conflict + default-override cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make common `cortex` commands work without flags by binding a bare positional to the primary selector and applying smart defaults. Also normalize time-window flags to RFC3339 to fix wrong results from relative inputs like `1h`.

- **Bug Fixes**
  - Time flags are now normalized via `norm_time`, so relative values resolve to RFC3339 and non-time input is rejected; affects `apps`, `clock-skew`, `compare`, `correlate-state`, `host-state`, `notify recent`, and all `ai` commands.
  - `tail` now supports `--limit` (alias for `-n`), and using a positional host together with `--host` clearly errors as “mutually exclusive”.

- **Migration**
  - Breaking: `cortex tail <arg>` now treats `<arg>` as a hostname, not a count. Use `-n`/`--limit` for the line count (e.g., `cortex tail dookie -n 100`).

<sup>Written for commit a96032bd43e46a122cb94ad983a66de8912c7bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added positional argument support for commands, enabling shorthand invocations (e.g., hostname as direct argument).
  * Implemented intelligent defaults for result limits and time windows across commands.

* **Bug Fixes**
  * Fixed incorrect relative time results from unnormalized time window inputs.

* **Documentation**
  * Expanded CLI documentation with practical examples and clearer parameter descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->