### PR TITLE
fix(notifications): render error signatures readably and break Apprise feedback loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.1] - 2026-06-18
+
+### Fixed
+
+- **Recurring-error notifications were unreadable.** `escape_for_notification` stripped `<` and `>` from notification titles/bodies as injection hardening, but the payload is sent as markdown and the error-signature normalizer emits placeholder tokens (`<n>`, `<hex>`, `<ip>`, `<path>`, `<str>`, `<json>`, `<uuid>`, `<ts>`). Stripping the brackets collapsed every signature into unreadable runs (`<n>:<n>:<n>` → `n:n:n`, `<str>` → `str`, `<path>` → `path`). The function now HTML-escapes `&`/`<`/`>` (and keeps the `@` → `＠` mention guard), so placeholders render verbatim while tag/markup injection stays neutralised.
+
+### Added
+
+- **Error-detection exclusion patterns break the notification feedback loop.** New `[error_detection].exclude_patterns` (env `CORTEX_ERROR_DETECTION_EXCLUDE_PATTERNS`, comma-separated): case-insensitive message substrings whose log rows are skipped during scanning — they are never tracked as signatures and never notified, while the scan cursor still advances past them. Defaults cover Apprise's own delivery log lines (`Delivered Stateless Notification`, `Sent Gotify notification`, `POST /notify`), so cortex no longer re-detects its own POST-to-Apprise delivery records (forwarded back in via syslog) as recurring errors and notifies on them in a loop. Set to `[]` to disable.
+
 ## [1.28.0] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.28.0"
+version = "1.28.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "1.28.0"
+version = "1.28.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/config.toml
+++ b/config.toml
@@ -106,3 +106,23 @@ dispatcher_interval_secs = 30
 evaluator_interval_secs = 30
 dedup_window_secs = 3600
 max_retry_attempts = 8
+
+[error_detection]
+# Background scan that groups recurring warning/error logs into signatures and
+# notifies on unacknowledged ones above frequency_threshold (per 1h window).
+enabled = false
+scan_interval_secs = 3600
+max_rows_per_cycle = 50000
+frequency_threshold = 30
+# Case-insensitive message substrings whose log rows are skipped during
+# scanning. Breaks the notification feedback loop: cortex POSTs to Apprise's
+# /notify endpoint, Apprise logs the delivery, those logs are forwarded back
+# into cortex and would otherwise be re-detected as recurring errors. Defaults
+# cover Apprise's own delivery log lines. Set to [] to disable, or extend for
+# other notification backends. Env: CORTEX_ERROR_DETECTION_EXCLUDE_PATTERNS
+# (comma-separated).
+exclude_patterns = [
+    "Delivered Stateless Notification",
+    "Sent Gotify notification",
+    "POST /notify",
+]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.28.0}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.28.1}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.28.0",
+  "version": "1.28.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.28.0",
+      "identifier": "ghcr.io/jmagar/cortex:v1.28.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/app/error_detection/scanner.rs
+++ b/src/app/error_detection/scanner.rs
@@ -68,9 +68,16 @@ pub(crate) async fn run_error_scan(
 
         let pool_chunk = Arc::clone(&pool);
         let frequency_threshold = cfg.frequency_threshold;
+        let exclude_patterns = cfg.exclude_patterns.clone();
         let result = tokio::task::spawn_blocking(move || {
             let _permit = permit;
-            process_chunk(&pool_chunk, last_id, chunk_size, frequency_threshold)
+            process_chunk(
+                &pool_chunk,
+                last_id,
+                chunk_size,
+                frequency_threshold,
+                &exclude_patterns,
+            )
         })
         .await??;
 
@@ -101,6 +108,7 @@ pub(crate) fn process_chunk(
     last_id: i64,
     chunk_size: i64,
     frequency_threshold: u32,
+    exclude_patterns: &[String],
 ) -> Result<ChunkResult> {
     let mut conn = pool.get()?;
 
@@ -155,7 +163,24 @@ pub(crate) fn process_chunk(
 
     let mut groups: HashMap<String, Group> = HashMap::new();
 
+    // Lowercased exclusion needles, computed once per chunk. Rows whose message
+    // matches are skipped entirely (not tracked as signatures and never
+    // notified). The cursor still advances past them via `max_id` above, so the
+    // skip is permanent rather than reprocessed next cycle.
+    let exclude_needles: Vec<String> = exclude_patterns
+        .iter()
+        .map(|p| p.to_lowercase())
+        .filter(|p| !p.is_empty())
+        .collect();
+
     for row in &rows {
+        if !exclude_needles.is_empty() {
+            let message_lc = row.message.to_lowercase();
+            if exclude_needles.iter().any(|n| message_lc.contains(n)) {
+                continue;
+            }
+        }
+
         let template = normalize_template(&row.message);
         let hash = signature_hash(&template);
 

--- a/src/app/error_detection/scanner_tests.rs
+++ b/src/app/error_detection/scanner_tests.rs
@@ -42,7 +42,7 @@ fn test_process_chunk_skips_below_cursor() {
     }
 
     // Set cursor to 2: only row with id > 2 should be processed
-    let result = process_chunk(&pool, 2, 200, 1).unwrap();
+    let result = process_chunk(&pool, 2, 200, 1, &[]).unwrap();
 
     // Only 1 row (id=3) should be returned
     assert_eq!(
@@ -64,7 +64,7 @@ fn test_process_chunk_does_not_notify_below_threshold() {
     }
 
     // frequency_threshold=5; only 3 rows inserted
-    let result = process_chunk(&pool, 0, 200, 5).unwrap();
+    let result = process_chunk(&pool, 0, 200, 5, &[]).unwrap();
     assert_eq!(result.rows_in_chunk, 3);
 
     // No outbox row should have been inserted
@@ -95,7 +95,7 @@ fn test_process_chunk_notifies_above_threshold() {
     }
 
     // threshold=5; 6 rows inserted → should notify
-    let result = process_chunk(&pool, 0, 200, 5).unwrap();
+    let result = process_chunk(&pool, 0, 200, 5, &[]).unwrap();
     assert_eq!(result.rows_in_chunk, 6);
 
     let conn = pool.get().unwrap();
@@ -113,6 +113,54 @@ fn test_process_chunk_notifies_above_threshold() {
 }
 
 #[test]
+fn test_process_chunk_skips_excluded_patterns() {
+    let (pool, _dir) = test_pool();
+    {
+        let conn = pool.get().unwrap();
+        // Notification-delivery log lines (the feedback loop): well above the
+        // frequency threshold, but they must be skipped entirely.
+        for _ in 0..10 {
+            insert_log(
+                &conn,
+                "apprise: Sent Gotify notification",
+                "warning",
+                "tootie",
+            );
+        }
+        // A genuine error that must still be detected and counted.
+        for _ in 0..6 {
+            insert_log(&conn, "disk full on /var", "err", "host1");
+        }
+    }
+
+    let exclude = vec!["Sent Gotify notification".to_string()];
+    let result = process_chunk(&pool, 0, 200, 5, &exclude).unwrap();
+    // All 16 rows advance the cursor (skipped rows are not reprocessed).
+    assert_eq!(result.rows_in_chunk, 16);
+
+    let conn = pool.get().unwrap();
+    // The excluded pattern must not be tracked as a signature at all.
+    let excluded_sig: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM error_signatures WHERE template LIKE '%notification%'",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(excluded_sig, 0, "excluded rows must not become signatures");
+
+    // Exactly one notification — for the real error, not the delivery logs.
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM notifications_outbox WHERE rule_id = 'unaddressed_error_signature'",
+            [],
+            |r| r.get::<_, i64>(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1, "only the genuine error notifies; loop is broken");
+}
+
+#[test]
 fn test_process_chunk_suppressed_when_acked() {
     let (pool, _dir) = test_pool();
     {
@@ -124,7 +172,7 @@ fn test_process_chunk_suppressed_when_acked() {
     }
 
     // First pass: process the chunk so the signature is written
-    let result = process_chunk(&pool, 0, 200, 5).unwrap();
+    let result = process_chunk(&pool, 0, 200, 5, &[]).unwrap();
     assert_eq!(result.rows_in_chunk, 6);
 
     // Manually acknowledge the signature
@@ -163,7 +211,7 @@ fn test_process_chunk_suppressed_when_acked() {
 
     // Second pass: with cursor advanced past original rows
     let cursor = result.new_cursor;
-    let result2 = process_chunk(&pool, cursor, 200, 5).unwrap();
+    let result2 = process_chunk(&pool, cursor, 200, 5, &[]).unwrap();
     assert_eq!(result2.rows_in_chunk, 3);
 
     // Outbox should still be empty because the signature is acked

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,6 +177,14 @@ pub struct ErrorDetectionConfig {
     /// Minimum count of firings in a 1h window before a signature is
     /// considered "notable". Default: 30.
     pub frequency_threshold: u32,
+    /// Case-insensitive message substrings whose matching log rows are skipped
+    /// during scanning. Used to break notification feedback loops: cortex POSTs
+    /// to Apprise's `/notify` endpoint, Apprise logs the delivery, those logs
+    /// are forwarded back into cortex, and without this filter they would be
+    /// re-detected as recurring errors — triggering yet more notifications.
+    /// Defaults cover Apprise's own delivery log lines. Set to an empty list to
+    /// disable.
+    pub exclude_patterns: Vec<String>,
 }
 
 impl Default for ErrorDetectionConfig {
@@ -186,6 +194,11 @@ impl Default for ErrorDetectionConfig {
             scan_interval_secs: 3600,
             max_rows_per_cycle: 50_000,
             frequency_threshold: 30,
+            exclude_patterns: vec![
+                "Delivered Stateless Notification".to_string(),
+                "Sent Gotify notification".to_string(),
+                "POST /notify".to_string(),
+            ],
         }
     }
 }
@@ -883,6 +896,10 @@ impl Config {
             "CORTEX_ERROR_DETECTION_SCAN_INTERVAL_SECS",
             &mut config.error_detection.scan_interval_secs,
         )?;
+        env_override_list(
+            "CORTEX_ERROR_DETECTION_EXCLUDE_PATTERNS",
+            &mut config.error_detection.exclude_patterns,
+        );
         env_override_bool(
             "CORTEX_NOTIFICATIONS_ENABLED",
             &mut config.notifications.enabled,

--- a/src/notifications/apprise.rs
+++ b/src/notifications/apprise.rs
@@ -162,16 +162,28 @@ impl AppriseClient {
 
 /// Escape log-derived text for safe notification delivery.
 ///
+/// The payload is sent with `"format": "markdown"`, so raw `<`/`>` would be
+/// interpreted as HTML tags by markdown-rendering targets (Gotify, etc.) and
+/// silently dropped. The error-signature normalizer emits placeholder tokens
+/// like `<n>`, `<hex>`, `<ip>`, `<path>`, so stripping the brackets mangled
+/// every signature into unreadable runs (`<n>:<n>:<n>` → `n:n:n`). Instead we
+/// HTML-escape the markup characters: this both renders the placeholders
+/// literally and still neutralises tag/markup injection.
+///
 /// - Replaces `@` with `＠` (U+FF20) to prevent mention injection.
-/// - Strips `<` and `>` to prevent HTML/markup injection.
+/// - Escapes `&`, `<`, `>` to their HTML entities so they render verbatim.
 pub fn escape_for_notification(s: &str) -> String {
-    s.chars()
-        .filter_map(|c| match c {
-            '@' => Some('＠'),
-            '<' | '>' => None,
-            other => Some(other),
-        })
-        .collect()
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '@' => out.push('＠'),
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -187,10 +199,22 @@ mod tests {
     }
 
     #[test]
-    fn escape_strips_angle_brackets() {
+    fn escape_neutralizes_angle_brackets_without_dropping_content() {
+        // Markup is escaped (not executable) but the inner text is preserved,
+        // so HTML/markdown targets cannot be injected yet nothing is silently lost.
         assert_eq!(
             escape_for_notification("<script>alert(1)</script>"),
-            "scriptalert(1)/script"
+            "&lt;script&gt;alert(1)&lt;/script&gt;"
+        );
+    }
+
+    #[test]
+    fn escape_preserves_normalizer_placeholders() {
+        // Regression: signatures emit <n>, <hex>, <path> etc. Stripping the
+        // brackets collapsed them into unreadable runs; escaping keeps them.
+        assert_eq!(
+            escape_for_notification("<n>-<n>-<n>T<n>:<n>:<n> path=<path>"),
+            "&lt;n&gt;-&lt;n&gt;-&lt;n&gt;T&lt;n&gt;:&lt;n&gt;:&lt;n&gt; path=&lt;path&gt;"
         );
     }
 
@@ -198,8 +222,13 @@ mod tests {
     fn escape_combined() {
         assert_eq!(
             escape_for_notification("Out of memory: Killed process 1234 (nginx) <@root>"),
-            "Out of memory: Killed process 1234 (nginx) ＠root"
+            "Out of memory: Killed process 1234 (nginx) &lt;＠root&gt;"
         );
+    }
+
+    #[test]
+    fn escape_ampersand() {
+        assert_eq!(escape_for_notification("a & b"), "a &amp; b");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

The "Recurring error on \<host\>" Gotify notifications were both **unreadable** and **self-perpetuating**. This fixes both.

### 1. Garbled signatures (rendering bug)

`escape_for_notification` (`src/notifications/apprise.rs`) stripped `<` and `>` as injection hardening. But the Apprise payload is sent with `"format": "markdown"`, and the error-signature normalizer emits placeholder tokens — `<n>`, `<hex>`, `<ip>`, `<path>`, `<str>`, `<json>`, `<uuid>`, `<ts>`. Stripping the brackets collapsed every signature into unreadable runs:

| Source template | Old (stripped) | New (escaped) |
|---|---|---|
| `<n>:<n>:<n>` | `n:n:n` | `<n>:<n>:<n>` |
| `from=<str>` | `from=str` | `from=<str>` |
| `path=<path>` | `path=path` | `path=<path>` |

The function now HTML-escapes `&`/`<`/`>` (and keeps the `@` → `＠` mention guard). Placeholders render verbatim in markdown/HTML targets **and** tag/markup injection is still neutralised (`<script>` → `&lt;script&gt;`, not executable) — strictly safer than dropping content.

### 2. Notification feedback loop

cortex POSTs to Apprise's `/notify` endpoint → Apprise logs the delivery (`Delivered Stateless Notification(s)`, `Sent Gotify notification`, access-log `POST /notify`) → those logs are forwarded back into cortex via syslog → the error scanner re-detects them as recurring errors → **more notifications** → repeat. (This is exactly the `tootie` notifications in the original report.)

New `[error_detection].exclude_patterns` (env `CORTEX_ERROR_DETECTION_EXCLUDE_PATTERNS`, comma-separated): case-insensitive message substrings whose log rows are **skipped during scanning** — never tracked as signatures, never notified — while the scan cursor still advances past them (so they aren't reprocessed next cycle). Defaults cover Apprise's own delivery log lines; set to `[]` to disable, or extend for other backends.

## Changes
- `src/notifications/apprise.rs` — HTML-escape instead of strip; updated + added unit tests.
- `src/config.rs` — `exclude_patterns` field, default, and env override.
- `src/app/error_detection/scanner.rs` — skip excluded rows in `process_chunk` (cursor still advances).
- `src/app/error_detection/scanner_tests.rs` — new test proving the loop breaks while genuine errors still notify.
- `config.toml` — documented `[error_detection]` section.
- Version bump 1.28.0 → 1.28.1 + CHANGELOG.

## Testing
- `cargo build`, `cargo clippy --all-targets`, `cargo fmt` — clean.
- `cargo xtask check-release-versions` — 8 files in sync at 1.28.1.
- Targeted suites pass: `test_process_chunk_*` (incl. new `test_process_chunk_skips_excluded_patterns`) and `escape_*`.
- Full `cargo test --lib`: 1411 passed. The 4 failures (`ai_watch`, `doctor`, `heartbeat_agent`, AI-transcript `scanner`) are pre-existing and **environmental** — they assert unreadable-directory / `/proc` / terminal-formatting behavior that can't hold when the test runner is uid 0 in a container; none touch the modules changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJDGutkDN9LGTf1mZvRujp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJDGutkDN9LGTf1mZvRujp)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreadable recurring-error notifications and stops the Apprise/Gotify feedback loop. We now HTML-escape notification text and add `[error_detection].exclude_patterns` to skip delivery logs while advancing the scan cursor.

- **Bug Fixes**
  - Preserve placeholder tokens by escaping `&`, `<`, `>` in `escape_for_notification` (and keep `@` → `＠`).
  - Break loop by skipping case-insensitive message substrings via new `[error_detection].exclude_patterns`; defaults cover Apprise delivery logs (`Delivered Stateless Notification`, `Sent Gotify notification`, `POST /notify`).

- **Migration**
  - No action needed; sensible defaults are enabled. Override with `CORTEX_ERROR_DETECTION_EXCLUDE_PATTERNS` (comma-separated) or set to `[]` to disable.

<sup>Written for commit 35f7a7017c639a8daeea31bb6c3a3af5d41f6e27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

