### PR TITLE
fix(cli): topic-correlate dispatch panic, correlate positional error, silent_hosts dedup (1.32.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.1] - 2026-06-19
+
+### Fixed
+
+- **`cortex topic-correlate` panicked from the CLI.** `topic-correlate` is in
+  `TOP_LEVEL_COMMANDS` and `parse_command`, but was missing from `Mode::parse`'s
+  top-level command gate in `main.rs`, so it parsed successfully and then hit the
+  `unreachable!()` fallthrough — `cortex topic-correlate <topic>` panicked with
+  `internal error: entered unreachable code`. Added it to the allowlist (it now
+  also accepts the global `--http`/`--token` flags like its siblings) with a
+  `Mode::parse` regression test covering both the single-term and multi-term
+  (`squirts dockersocket`) forms.
+- **`cortex correlate <non-time>` gave a cryptic error.** `correlate`'s sole
+  positional is a reference *time*, so `cortex correlate squirts dockersocket`
+  fed `squirts` into the time parser and surfaced
+  `unrecognized time value 'squirts'`. The error is now actionable: it explains
+  the positional is a reference time and points at
+  `cortex topic-correlate squirts …` (entity correlation) or
+  `--reference-time <time> --host squirts`.
+- **`silent_hosts` flagged dormant case/FQDN host variants as silent.** It read
+  the raw, case-sensitive `hosts` table, so a quiet `shart` identity was reported
+  silent even while the live `SHART` kept forwarding. It now routes through
+  `list_hosts()` (the same case/FQDN dedupe added in 1.32.0, taking the latest
+  `last_seen`), so the merged machine is correctly considered alive; genuinely
+  dormant hosts are still flagged.
+
 ## [1.32.0] - 2026-06-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `list_hosts()` (the same case/FQDN dedupe added in 1.32.0, taking the latest
   `last_seen`), so the merged machine is correctly considered alive; genuinely
   dormant hosts are still flagged.
+- **`clock_skew` reported one machine once per casing.** Its `GROUP BY hostname`
+  was case-sensitive, so `SHART`/`shart` showed as two skew rows. The case/FQDN
+  canonicalization is now factored into a shared `canonical_host_keys` helper
+  (reused by `hosts`) and applied to `clock_skew`, merging variants into one row
+  with summed samples, a sample-weighted average skew, and widened min/max.
+- **The "HTTP flags only apply to query commands" error listed a stale command
+  set.** Its hardcoded enumeration had drifted (it omitted `topic-correlate`,
+  `correlate-state`, `silent-hosts`, `clock-skew`, `map`, … — implying those
+  reject `--http`). It no longer enumerates: it names the offending argument and
+  points at `--server <url>` / `--http=<url>`, so it can't drift again.
+
+### Added
+
+- **`--http=<url>` shortcut.** Enables HTTP transport and sets the server in one
+  curl-style flag (e.g. `cortex --http=http://host:3100 search foo`). Bare
+  `--http` is unchanged (a value-less flag, so `cortex --http search foo` still
+  treats `search` as the command); a server URL after bare `--http` was silently
+  left as a stray positional before.
 
 ## [1.32.0] - 2026-06-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.32.0"
+version = "1.32.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "1.32.0"
+version = "1.32.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.32.0}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.32.1}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.32.0",
+  "version": "1.32.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.32.0",
+      "identifier": "ghcr.io/jmagar/cortex:v1.32.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli/parse_logs.rs
+++ b/src/cli/parse_logs.rs
@@ -410,7 +410,19 @@ pub(crate) fn parse_correlate(args: &[String]) -> Result<CliCommand> {
                 )?)
             }
             _ if arg.starts_with('-') => bail!("unknown correlate option: {arg}"),
-            _ if parsed.reference_time.is_empty() => parsed.reference_time = norm_time(arg)?,
+            _ if parsed.reference_time.is_empty() => {
+                // correlate's sole positional is the reference *time*. A non-time
+                // value (a hostname, app, …) otherwise hits norm_time and yields
+                // a cryptic "unrecognized time value" — redirect to the command
+                // that actually correlates by entity.
+                parsed.reference_time = norm_time(arg.clone()).map_err(|_| {
+                    anyhow::anyhow!(
+                        "correlate's positional argument is a reference time (e.g. `1h`, `2026-06-01`, or an RFC3339 timestamp), but got `{arg}`. \
+To correlate everything related to a host, app, or topic, use `cortex topic-correlate {arg}`; \
+to anchor correlate on a time and filter by host, pass `--reference-time <time> --host {arg}`."
+                    )
+                })?;
+            }
             _ => bail!("unexpected correlate argument: {arg}"),
         }
     }

--- a/src/cli/parse_tests.rs
+++ b/src/cli/parse_tests.rs
@@ -547,6 +547,22 @@ fn parse_correlate_state_rejects_unknown_flag() {
     assert!(err.contains("unknown correlate-state option"), "got: {err}");
 }
 
+#[test]
+fn parse_correlate_nontime_positional_points_to_topic_correlate() {
+    // `correlate squirts dockersocket` fed `squirts` into the time parser and
+    // produced a cryptic "unrecognized time value". The error must now explain
+    // that the positional is a reference time and point at topic-correlate.
+    let err = parse_command(vec![
+        "correlate".to_string(),
+        "squirts".to_string(),
+        "dockersocket".to_string(),
+    ])
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("reference time"), "got: {err}");
+    assert!(err.contains("topic-correlate squirts"), "got: {err}");
+}
+
 // Regression: every CLI flag whose value is bound into a SQL timestamp
 // comparison must route through the shared time parser, so relative/keyword
 // input is normalized to RFC3339 (and non-time input is rejected) rather than

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -217,6 +217,21 @@ impl GlobalFlags {
             // Two flag families: bare "--http", and value-bearing
             // "--server"/"--token" which accept "--flag VALUE" or "--flag=VALUE".
             let arg = args[i].as_str();
+            // `--http=<url>` is a convenience shortcut: enable HTTP transport AND
+            // set the server in one flag (curl-style). Bare `--http` stays a flag
+            // with no value so `cortex --http search foo` keeps `search` as the
+            // command rather than swallowing it as a URL.
+            if let Some(value) = strip_eq_prefix(arg, "--http") {
+                if value.is_empty() {
+                    bail!(
+                        "--http=<url> requires a value; use bare --http with --server <url>, or --http=<url>"
+                    );
+                }
+                out.force_http = true;
+                out.server = Some(value.to_string());
+                args.remove(i);
+                continue;
+            }
             if arg == "--http" {
                 out.force_http = true;
                 args.remove(i);
@@ -402,6 +417,30 @@ mod tests {
         );
         assert_eq!(args, strings(&["search", "disk", "--json"]));
         assert_eq!(flags.http_flag_trigger(), Some("--http"));
+    }
+
+    #[test]
+    fn global_flags_http_equals_url_sets_server_and_transport() {
+        // `--http=<url>` is the curl-style shortcut: enables HTTP transport AND
+        // sets the server, so a URL no longer has to go through `--server`.
+        let mut args = strings(&["--http=http://localhost:40110", "topic-correlate", "axon"]);
+        let flags = GlobalFlags::extract(&mut args).unwrap();
+        assert_eq!(
+            flags,
+            GlobalFlags {
+                force_http: true,
+                server: Some("http://localhost:40110".into()),
+                token: None,
+            }
+        );
+        assert_eq!(args, strings(&["topic-correlate", "axon"]));
+    }
+
+    #[test]
+    fn global_flags_http_equals_empty_is_rejected() {
+        let mut args = strings(&["--http=", "stats"]);
+        let err = GlobalFlags::extract(&mut args).unwrap_err().to_string();
+        assert!(err.contains("--http=<url> requires a value"), "got: {err}");
     }
 
     #[test]

--- a/src/db/analytics.rs
+++ b/src/db/analytics.rs
@@ -1307,6 +1307,9 @@ pub struct ClockSkewEntry {
     pub max_skew_secs: f64,
 }
 
+// Per-raw-hostname skew stats. Ordering/limit and the case/FQDN variant merge
+// happen in Rust (see `clock_skew`) so we must fetch every host here, not a
+// SQL-LIMIT-ed prefix that could split a machine's variants across the cutoff.
 const CLOCK_SKEW_SQL: &str = "
     SELECT hostname,
            COUNT(*),
@@ -1315,24 +1318,75 @@ const CLOCK_SKEW_SQL: &str = "
            MAX((julianday(received_at) - julianday(timestamp)) * 86400)
       FROM logs INDEXED BY idx_logs_received_at
      WHERE received_at >= ?1
-     GROUP BY hostname
-     ORDER BY ABS(AVG((julianday(received_at) - julianday(timestamp)) * 86400)) DESC
-     LIMIT ?2";
+     GROUP BY hostname";
 
 pub fn clock_skew(pool: &DbPool, since: &str, limit: Option<u32>) -> Result<Vec<ClockSkewEntry>> {
     let conn = pool.get()?;
-    let limit = limit.map(i64::from).unwrap_or(i64::MAX);
     let mut stmt = conn.prepare(CLOCK_SKEW_SQL)?;
-    let rows = stmt.query_map(params![since, limit], |r| {
-        Ok(ClockSkewEntry {
-            hostname: r.get(0)?,
-            samples: r.get(1)?,
-            avg_skew_secs: r.get::<_, Option<f64>>(2)?.unwrap_or(0.0),
-            min_skew_secs: r.get::<_, Option<f64>>(3)?.unwrap_or(0.0),
-            max_skew_secs: r.get::<_, Option<f64>>(4)?.unwrap_or(0.0),
-        })
-    })?;
-    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    let rows: Vec<ClockSkewEntry> = stmt
+        .query_map(params![since], |r| {
+            Ok(ClockSkewEntry {
+                hostname: r.get(0)?,
+                samples: r.get(1)?,
+                avg_skew_secs: r.get::<_, Option<f64>>(2)?.unwrap_or(0.0),
+                min_skew_secs: r.get::<_, Option<f64>>(3)?.unwrap_or(0.0),
+                max_skew_secs: r.get::<_, Option<f64>>(4)?.unwrap_or(0.0),
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    // Merge case/FQDN variants of one machine (e.g. `SHART`/`shart`) into a single
+    // skew row: sum samples, recombine the mean as a sample-weighted average, and
+    // widen min/max. Without this a host's clock skew is reported once per casing.
+    let names: Vec<String> = rows.iter().map(|r| r.hostname.clone()).collect();
+    let canon = super::queries::canonical_host_keys(&names);
+    let mut merged: std::collections::HashMap<String, ClockSkewEntry> =
+        std::collections::HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for row in rows {
+        let key = canon
+            .get(&row.hostname)
+            .cloned()
+            .unwrap_or_else(|| row.hostname.clone());
+        match merged.get_mut(&key) {
+            Some(acc) => {
+                let total = acc.samples + row.samples;
+                if total > 0 {
+                    acc.avg_skew_secs = (acc.avg_skew_secs * acc.samples as f64
+                        + row.avg_skew_secs * row.samples as f64)
+                        / total as f64;
+                }
+                acc.min_skew_secs = acc.min_skew_secs.min(row.min_skew_secs);
+                acc.max_skew_secs = acc.max_skew_secs.max(row.max_skew_secs);
+                acc.samples = total;
+            }
+            None => {
+                order.push(key.clone());
+                merged.insert(
+                    key.clone(),
+                    ClockSkewEntry {
+                        hostname: key,
+                        ..row
+                    },
+                );
+            }
+        }
+    }
+    let mut out: Vec<ClockSkewEntry> = order
+        .into_iter()
+        .map(|k| merged.remove(&k).expect("key inserted above"))
+        .collect();
+    // Largest absolute skew first (preserving the prior ORDER BY).
+    out.sort_by(|a, b| {
+        b.avg_skew_secs
+            .abs()
+            .partial_cmp(&a.avg_skew_secs.abs())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    if let Some(limit) = limit {
+        out.truncate(limit as usize);
+    }
+    Ok(out)
 }
 
 // -----------------------------------------------------------------------------

--- a/src/db/analytics.rs
+++ b/src/db/analytics.rs
@@ -1253,36 +1253,31 @@ pub struct SilentHostEntry {
 }
 
 pub fn silent_hosts(pool: &DbPool, cutoff: &str, now_unix: i64) -> Result<Vec<SilentHostEntry>> {
-    let conn = pool.get()?;
-    let mut stmt = conn.prepare(
-        "SELECT hostname, first_seen, last_seen, log_count
-         FROM hosts
-         WHERE last_seen < ?1
-         ORDER BY last_seen ASC",
-    )?;
-    let rows = stmt.query_map(params![cutoff], |r| {
-        let hostname: String = r.get(0)?;
-        let first_seen: String = r.get(1)?;
-        let last_seen: String = r.get(2)?;
-        let log_count: i64 = r.get(3)?;
-        Ok((hostname, first_seen, last_seen, log_count))
-    })?;
-    let mut out = Vec::new();
-    for row in rows {
-        let (hostname, first_seen, last_seen, log_count) = row?;
-        let typical_interval_secs = compute_interval(&first_seen, &last_seen, log_count);
-        let silent_for_secs = chrono::DateTime::parse_from_rfc3339(&last_seen)
-            .map(|dt| now_unix - dt.timestamp())
-            .unwrap_or(0);
-        out.push(SilentHostEntry {
-            hostname,
-            first_seen,
-            last_seen,
-            log_count,
-            typical_interval_secs,
-            silent_for_secs,
-        });
-    }
+    // Route through list_hosts so case/FQDN variants of one machine are merged
+    // (taking the latest last_seen) BEFORE applying the silence cutoff. Reading
+    // the raw `hosts` table here would flag a dormant `shart` identity as silent
+    // while the live `SHART` keeps forwarding — the merged host is correctly
+    // considered alive.
+    let mut out: Vec<SilentHostEntry> = super::queries::list_hosts(pool)?
+        .into_iter()
+        .filter(|h| h.last_seen.as_str() < cutoff)
+        .map(|h| {
+            let typical_interval_secs = compute_interval(&h.first_seen, &h.last_seen, h.log_count);
+            let silent_for_secs = chrono::DateTime::parse_from_rfc3339(&h.last_seen)
+                .map(|dt| now_unix - dt.timestamp())
+                .unwrap_or(0);
+            SilentHostEntry {
+                hostname: h.hostname,
+                first_seen: h.first_seen,
+                last_seen: h.last_seen,
+                log_count: h.log_count,
+                typical_interval_secs,
+                silent_for_secs,
+            }
+        })
+        .collect();
+    // Longest-silent first (oldest last_seen), preserving the prior ORDER BY ASC.
+    out.sort_by(|a, b| a.last_seen.cmp(&b.last_seen));
     Ok(out)
 }
 

--- a/src/db/analytics_tests.rs
+++ b/src/db/analytics_tests.rs
@@ -823,7 +823,7 @@ fn clock_skew_plan_uses_received_at_range_index() {
     let sql = format!("EXPLAIN QUERY PLAN {CLOCK_SKEW_SQL}");
     let mut stmt = conn.prepare(&sql).unwrap();
     let rows = stmt
-        .query_map(rusqlite::params!["2026-01-01T00:00:00Z", 100_i64], |row| {
+        .query_map(rusqlite::params!["2026-01-01T00:00:00Z"], |row| {
             row.get::<_, String>(3)
         })
         .unwrap()
@@ -1354,4 +1354,47 @@ fn silent_hosts_merges_case_variants_before_cutoff() {
         names.iter().any(|n| n == "steamy"),
         "genuinely-dormant STEAMY (lowercased) must still be flagged: {names:?}"
     );
+}
+
+#[test]
+fn clock_skew_merges_case_variants() {
+    // Regression: clock_skew GROUP BY hostname was case-sensitive, so `SHART` and
+    // `shart` reported as two separate skew rows. They must merge into one host
+    // with summed samples and a sample-weighted average skew.
+    let (pool, _d) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            entry("2026-01-01T00:00:00Z", "SHART", "info", None, "a"),
+            entry("2026-01-01T00:00:00Z", "SHART", "info", None, "b"),
+            entry("2026-01-01T00:00:00Z", "shart", "info", None, "c"),
+        ],
+    )
+    .unwrap();
+    let conn = pool.get().unwrap();
+    // SHART rows skew +10s, the shart row skews +40s.
+    for (msg, received_at) in [
+        ("a", "2026-01-01T00:00:10Z"),
+        ("b", "2026-01-01T00:00:10Z"),
+        ("c", "2026-01-01T00:00:40Z"),
+    ] {
+        conn.execute(
+            "UPDATE logs SET received_at = ?1 WHERE message = ?2",
+            rusqlite::params![received_at, msg],
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    let result = clock_skew(&pool, "2026-01-01T00:00:00Z", None).unwrap();
+    assert_eq!(result.len(), 1, "SHART/shart must collapse to one host");
+    assert_eq!(result[0].hostname, "shart");
+    assert_eq!(result[0].samples, 3);
+    // Sample-weighted: (10 + 10 + 40) / 3 = 20.
+    assert!(
+        (result[0].avg_skew_secs - 20.0).abs() < 0.5,
+        "weighted avg skew should be ~20s, got {}",
+        result[0].avg_skew_secs
+    );
+    assert!((result[0].max_skew_secs - 40.0).abs() < 0.5);
 }

--- a/src/db/analytics_tests.rs
+++ b/src/db/analytics_tests.rs
@@ -1308,3 +1308,50 @@ fn timeline_rollup_status_reports_watermark() {
     assert!(after.source_max_id > 0);
     assert!(after.refreshed_at.is_some());
 }
+
+#[test]
+fn silent_hosts_merges_case_variants_before_cutoff() {
+    // Regression: silent_hosts read the raw, case-sensitive `hosts` table, so a
+    // dormant `shart` identity was flagged as silent even though the live `SHART`
+    // kept forwarding. Routing through list_hosts() merges case/FQDN variants
+    // (latest last_seen wins) first, so the machine is correctly considered alive.
+    let (pool, _d) = test_pool();
+    insert_logs_batch(
+        &pool,
+        &[
+            entry("2026-06-19T20:00:00Z", "SHART", "info", None, "live"),
+            entry("2026-06-11T06:00:00Z", "shart", "info", None, "old"),
+            entry("2026-06-11T06:00:00Z", "STEAMY", "info", None, "old"),
+        ],
+    )
+    .unwrap();
+    // hosts.last_seen is stamped with insert-time `now`; pin it explicitly.
+    let conn = pool.get().unwrap();
+    for (host, last_seen) in [
+        ("SHART", "2026-06-19T20:00:00.000Z"),
+        ("shart", "2026-06-11T06:00:00.000Z"),
+        ("STEAMY", "2026-06-11T06:00:00.000Z"),
+    ] {
+        conn.execute(
+            "UPDATE hosts SET last_seen = ?1 WHERE hostname = ?2",
+            rusqlite::params![last_seen, host],
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    let now_unix = chrono::DateTime::parse_from_rfc3339("2026-06-19T21:00:00Z")
+        .unwrap()
+        .timestamp();
+    let silent = silent_hosts(&pool, "2026-06-15T00:00:00.000Z", now_unix).unwrap();
+    let names: Vec<String> = silent.iter().map(|h| h.hostname.clone()).collect();
+
+    assert!(
+        !names.iter().any(|n| n == "shart"),
+        "merged shart is live (SHART forwarding) and must not be flagged silent: {names:?}"
+    );
+    assert!(
+        names.iter().any(|n| n == "steamy"),
+        "genuinely-dormant STEAMY (lowercased) must still be flagged: {names:?}"
+    );
+}

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -449,9 +449,42 @@ fn get_error_summary_sql(
 
 /// Lowercase, trim, and strip trailing dots from a hostname so case and a
 /// trailing FQDN dot don't split one machine into several host rows. Does not
-/// fold FQDNs to short names — that's [`dedupe_hosts`]'s data-driven step.
-fn case_fold_host(raw: &str) -> String {
+/// fold FQDNs to short names — that's [`canonical_host_keys`]'s data-driven step.
+pub(crate) fn case_fold_host(raw: &str) -> String {
     raw.trim().trim_end_matches('.').to_ascii_lowercase()
+}
+
+/// Map each input hostname to its canonical identity, applying two folds:
+/// 1. **Case / trailing-dot** via [`case_fold_host`] (`SHART` → `shart`).
+/// 2. **FQDN → short name, only when the short name independently exists** among
+///    the inputs (`tootie.<tailnet>` → `tootie` when a bare `tootie` is present,
+///    but `host.docker.internal` is left alone). This never invents a merge that
+///    could mask a distinct machine.
+///
+/// Shared by `dedupe_hosts` (the `hosts` action) and `clock_skew` so every
+/// host-keyed view collapses the same case/FQDN variants.
+pub(crate) fn canonical_host_keys(
+    hostnames: &[String],
+) -> std::collections::HashMap<String, String> {
+    let cased: Vec<(String, String)> = hostnames
+        .iter()
+        .map(|h| (h.clone(), case_fold_host(h)))
+        .collect();
+    let shorts: std::collections::HashSet<&str> = cased
+        .iter()
+        .filter(|(_, c)| !c.is_empty() && !c.contains('.'))
+        .map(|(_, c)| c.as_str())
+        .collect();
+    cased
+        .iter()
+        .map(|(raw, c)| {
+            let canonical = match c.split_once('.') {
+                Some((head, _)) if shorts.contains(head) => head.to_string(),
+                _ => c.clone(),
+            };
+            (raw.clone(), canonical)
+        })
+        .collect()
 }
 
 /// Merge host rows that refer to the same machine. Two folds are applied:
@@ -468,25 +501,16 @@ fn case_fold_host(raw: &str) -> String {
 /// Merged rows sum `log_count`, take the earliest `first_seen` and latest
 /// `last_seen`, and display the canonical (lowercased) name.
 fn dedupe_hosts(rows: Vec<HostEntry>) -> Vec<HostEntry> {
-    // Pass 1: case-fold every hostname alongside its row.
-    let folded: Vec<(String, HostEntry)> = rows
-        .into_iter()
-        .map(|h| (case_fold_host(&h.hostname), h))
-        .collect();
-    // Standalone short names (no dot, non-empty) are the only valid fold targets.
-    let shorts: std::collections::HashSet<&str> = folded
-        .iter()
-        .filter(|(k, _)| !k.is_empty() && !k.contains('.'))
-        .map(|(k, _)| k.as_str())
-        .collect();
-    // Pass 2: group by canonical key, preserving first-seen insertion order.
+    let names: Vec<String> = rows.iter().map(|h| h.hostname.clone()).collect();
+    let canon = canonical_host_keys(&names);
+    // Group by canonical key, preserving first-seen insertion order.
     let mut merged: std::collections::HashMap<String, HostEntry> = std::collections::HashMap::new();
     let mut order: Vec<String> = Vec::new();
-    for (cased, entry) in &folded {
-        let canonical = match cased.split_once('.') {
-            Some((head, _)) if shorts.contains(head) => head.to_string(),
-            _ => cased.clone(),
-        };
+    for entry in rows {
+        let canonical = canon
+            .get(&entry.hostname)
+            .cloned()
+            .unwrap_or_else(|| case_fold_host(&entry.hostname));
         match merged.get_mut(&canonical) {
             Some(acc) => {
                 acc.log_count += entry.log_count;

--- a/src/main.rs
+++ b/src/main.rs
@@ -669,15 +669,18 @@ impl Mode {
                 })))
             }
             _ if global != cli::GlobalFlags::default() => {
-                // Global HTTP flags only apply to CLI query commands. Surface
-                // a precise error rather than letting them be silently
-                // ignored for `serve mcp`, `setup`, etc.
+                // Global HTTP flags were given but what's left isn't a recognized
+                // query command. Rather than enumerate commands (a list that
+                // silently drifts — it once omitted topic-correlate and a dozen
+                // others), name the offending args and point at the most common
+                // mistake: a bare `--http` followed by a URL that should be
+                // `--server <url>` (or `--http=<url>`).
+                let leftover = remaining.join(" ");
                 anyhow::bail!(
-                    "--http / --server / --token only apply to CLI query commands \
-                     (search, tail, errors, hosts, sessions, incident, entity, graph, ai, shell, agent-command, heartbeat, correlate, stats, db, file-tail); \
-                     compose, service, setup, inventory, and deploy are local-only and reject HTTP flags; \
-                     got: {}",
-                    args.join(" ")
+                    "global HTTP flags (--http, --server <url>, --token <token>) apply only to the query CLI, \
+                     but `{leftover}` is not a recognized query command. \
+                     To point at a server use `--server <url>` or `--http=<url>` (bare `--http` takes no value). \
+                     Local-only commands (compose, service, setup, deploy, inventory) reject HTTP flags."
                 );
             }
             _ => match cli::CliCommand::parse(args.clone()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -653,6 +653,7 @@ impl Mode {
                         | "host-state"
                         | "fleet-state"
                         | "correlate-state"
+                        | "topic-correlate"
                         | "file-tail"
                         | "__complete"
                         | "completions"

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -51,6 +51,28 @@ fn mode_parse_accepts_heartbeat_state_commands() {
 }
 
 #[test]
+fn mode_parse_accepts_topic_correlate() {
+    // Regression: topic-correlate is in TOP_LEVEL_COMMANDS + parse_command but was
+    // missing from Mode::parse's top-level command gate, so `cortex topic-correlate
+    // <topic>` parsed successfully and then hit the `unreachable!()` fallthrough →
+    // panic. Both the single-term and the multi-term (screenshot) forms must route
+    // cleanly to a CLI invocation.
+    assert!(matches!(
+        Mode::parse(vec!["topic-correlate".into(), "axon".into()]).unwrap(),
+        Mode::Cli(_)
+    ));
+    assert!(matches!(
+        Mode::parse(vec![
+            "topic-correlate".into(),
+            "squirts".into(),
+            "dockersocket".into(),
+        ])
+        .unwrap(),
+        Mode::Cli(_)
+    ));
+}
+
+#[test]
 fn mode_parse_rejects_unknown_commands() {
     let err = Mode::parse(vec!["serve".into(), "http".into()]).unwrap_err();
     assert!(err.to_string().contains("unknown CLI command"));


### PR DESCRIPTION
Three fixes surfaced from a live CLI session (screenshot) plus the host-dedup follow-up from 1.32.0.

## Fixes

### `cortex topic-correlate` panicked from the CLI
`topic-correlate` is in `TOP_LEVEL_COMMANDS` and `parse_command`, but was missing from `Mode::parse`'s top-level command gate in `main.rs` — so it parsed successfully and then hit the `unreachable!()` fallthrough:
```
$ cortex topic-correlate squirts dockersocket
thread 'main' panicked: internal error: entered unreachable code: known CLI commands are handled above
```
Added it to the allowlist (it now also accepts the global `--http`/`--token` flags like its siblings). **Verified live:** `cortex topic-correlate squirts dockersocket` → `49 entities resolved, 21496 expanded, 200 timeline rows`.

### `cortex correlate <non-time>` gave a cryptic error
`correlate`'s sole positional is a reference *time*, so `correlate squirts dockersocket` fed `squirts` into the time parser → `unrecognized time value 'squirts'`. The error is now actionable — it names the positional as a reference time and points at `cortex topic-correlate squirts …` or `--reference-time <time> --host squirts`.

### `silent_hosts` flagged dormant case/FQDN host variants
It read the raw, case-sensitive `hosts` table, so a quiet `shart` identity was reported silent while the live `SHART` kept forwarding. It now routes through `list_hosts()` (the case/FQDN dedupe from 1.32.0, latest `last_seen` wins), so the merged machine is correctly alive; genuinely dormant hosts are still flagged.

## Tests
- `Mode::parse` regression for `topic-correlate` (single- and multi-term forms — the exact panic inputs).
- `parse_correlate` non-time positional → asserts the actionable error.
- DB-backed `silent_hosts` test: live `SHART` + dormant `shart` merge (not silent); dormant `STEAMY` still flagged.
- clippy + fmt clean; pre-push `--all-features` suite green; version sync OK at **1.32.1**.

## Note (out of scope)
Global `--http`/`--token` flags only bind in the `--flag=value` form; the space-separated form hits a stale guard. This is **pre-existing** and affects `stats`/`correlate-state` identically — flagging for a separate cleanup, not touched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a `cortex topic-correlate` dispatch panic, makes `correlate`’s positional error actionable, dedupes hosts in `silent_hosts`, merges host variants in `clock_skew`, and improves HTTP flag handling. Adds a `--http=<url>` shortcut. Sets version to 1.32.1 and updates tags.

- **Bug Fixes**
  - Added `topic-correlate` to `Mode::parse` so `cortex topic-correlate <topic>` runs without panicking; now also accepts global `--http`/`--token`.
  - Improved `cortex correlate <non-time>` error to explain the positional is a reference time and suggest `cortex topic-correlate <term>` or `--reference-time <time> --host <host>`.
  - Routed `silent_hosts` through `list_hosts()` to merge case/FQDN variants (latest `last_seen` wins) before cutoff, preventing false “silent” flags.
  - `clock_skew` now merges case/FQDN host variants into one row (summed samples, sample‑weighted avg skew, widened min/max) to avoid duplicate entries per casing.
  - Replaced the drifting “HTTP flags only apply to query commands” list with a clear error that names the offending arg and points to `--server <url>` / `--http=<url>`.

- **New Features**
  - Added `--http=<url>` to enable HTTP transport and set the server in one flag; bare `--http` remains value‑less, and `--http=` is rejected.

<sup>Written for commit 6aa61c0090333f208eea8d4bae2f06f1e6bd2bc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for v1.32.1

**Bug Fixes**
- Fixed `cortex topic-correlate` command failing with an unreachable error
- Improved error message for `cortex correlate` command when using invalid reference time values, with guidance to alternative commands
- Fixed host dormancy detection to correctly handle case-insensitive and FQDN variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->