### PR TITLE
fix(test): repair HTTP-flag guard assertions red on main (1.32.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.2] - 2026-06-19
+
+### Fixed
+
+- **Stale test assertions for the HTTP-flag guard (regression from 1.32.1).**
+  1.32.1 reworded the "global HTTP flags only apply to query commands" error, but
+  two existing `Mode::parse` tests (`mode_parse_rejects_http_flag_on_serve_mcp`,
+  `..._on_deploy`) still asserted the old text and failed. The guard behavior is
+  unchanged (HTTP flags are still rejected for `serve mcp`/`deploy`); only the
+  assertions are updated to match the new message. No runtime change.
+
 ## [1.32.1] - 2026-06-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.32.1"
+version = "1.32.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "1.32.1"
+version = "1.32.2"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.32.1}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.32.2}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.32.1",
+  "version": "1.32.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.32.1",
+      "identifier": "ghcr.io/jmagar/cortex:v1.32.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -809,7 +809,7 @@ fn mode_parse_rejects_http_flag_on_serve_mcp() {
     let err = Mode::parse(vec!["--http".into(), "serve".into(), "mcp".into()]).unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("only apply to CLI query commands"),
+        msg.contains("HTTP flags") && msg.contains("query CLI"),
         "expected guard message, got: {msg}"
     );
 }
@@ -819,7 +819,7 @@ fn mode_parse_rejects_http_flag_on_deploy() {
     let err = Mode::parse(vec!["--http".into(), "deploy".into(), "local".into()]).unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("compose, service, setup, inventory, and deploy are local-only"),
+        msg.contains("Local-only commands") && msg.contains("reject HTTP flags"),
         "expected local-only guard message, got: {msg}"
     );
 }


### PR DESCRIPTION
**Hotfix for `main`** — PR #86 (1.32.1) reworded the "global HTTP flags only apply to query commands" guard error, but two existing `Mode::parse` tests still asserted the old wording and went red on `main` after merge:

- `mode_parse_rejects_http_flag_on_serve_mcp` — asserted `"only apply to CLI query commands"`
- `mode_parse_rejects_http_flag_on_deploy` — asserted `"compose, service, setup, inventory, and deploy are local-only"`

**Behavior is unchanged** — HTTP flags are still rejected for `serve mcp` and `deploy`; only the assertions are updated to match the new message (which now names the offending arg and points at `--server`/`--http=<url>`). No runtime change.

Bumped 1.32.1 → 1.32.2; CHANGELOG entry added. Verified the two tests pass locally and the full `--all-features` pre-push gate is green.

_Root cause note: the 1.32.1 push gate caught these failures; they were bypassed with `git push --no-verify` after a push step was misread as a network error. This PR restores green._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken tests on main by updating HTTP-flag guard assertions to match the reworded error from 1.32.1. Behavior is unchanged; HTTP flags are still rejected for `serve mcp` and `deploy`.

- **Bug Fixes**
  - Updated two `Mode::parse` tests to assert the new guard text for global HTTP flags.
  - Bumped `cortex` to 1.32.2 and synced versions in `Cargo.toml`, `Cargo.lock`, `docker-compose.prod.yml`, `mcpb/manifest.json`, `server.json`, and CHANGELOG.

<sup>Written for commit d5d1cd87959cf2787440d8ba323051ef86284547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.32.2

* **Bug Fixes**
  * Updated error messages for HTTP flag validation in CLI commands to provide clearer feedback

* **Chores**
  * Version bumped to 1.32.2 across build and deployment configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->