### PR TITLE
fix(ci): publish ghcr:<version> on main pushes — 1.32.x was never published (1.32.3)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,6 +71,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Publish ghcr:<version> on main pushes, read from Cargo.toml. The
+      # `type=semver` tags below only fire on `v*` tag pushes — but the auto-tag
+      # workflow creates those tags with the default GITHUB_TOKEN, and GitHub
+      # does not trigger workflows from GITHUB_TOKEN-pushed tags (loop
+      # prevention). That left the versioned image (e.g. ghcr:1.32.x) never
+      # published. Tagging from Cargo.toml on the default branch decouples the
+      # version image from the dead tag trigger.
+      - name: Read crate version
+        id: crate
+        run: echo "version=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
@@ -82,6 +93,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=raw,value=${{ steps.crate.outputs.version }},enable={{is_default_branch}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now also tags the image with the `Cargo.toml` version on default-branch pushes
   (`type=raw,value=<version>,enable={{is_default_branch}}`), so every merge to
   `main` publishes `ghcr:<version>` independent of the tag trigger.
+- **`cortex deploy agent` reset custom agent config on every redeploy.** It built
+  the container env from a fixed flag set, overwrote the persisted
+  `heartbeat-agent.env`, and mounted only the three standard paths — so a custom
+  `CORTEX_AGENT_FILE_TAILS` (e.g. a host's Plex log) **and** the host mount it
+  needs were silently dropped on upgrade, even though the value was sitting in the
+  persisted env file. The Unraid deploy is now config-preserving: it carries
+  forward any non-managed env keys from the existing `heartbeat-agent.env` and any
+  non-standard mounts from the running container, so upgrading the binary keeps
+  per-host customizations. (Managed keys still come from the deploy flags.)
 
 ## [1.32.2] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.3] - 2026-06-19
+
+### Fixed
+
+- **Versioned GHCR image was never published for 1.32.x.** `docker-publish.yml`
+  derives the version image tag from `type=semver`, which only fires on `v*`
+  git-tag pushes — but the auto-tag workflow creates those tags with the default
+  `GITHUB_TOKEN`, and GitHub does not trigger workflows from `GITHUB_TOKEN`-pushed
+  tags (loop prevention). So `ghcr.io/jmagar/cortex:1.32.x` was never built, and
+  the fleet agents (pinned to `ghcr:1.31.2`) had no image to update to. The build
+  now also tags the image with the `Cargo.toml` version on default-branch pushes
+  (`type=raw,value=<version>,enable={{is_default_branch}}`), so every merge to
+  `main` publishes `ghcr:<version>` independent of the tag trigger.
+
 ## [1.32.2] - 2026-06-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.32.2"
+version = "1.32.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "1.32.2"
+version = "1.32.3"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.32.2}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.32.3}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.32.2",
+  "version": "1.32.3",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.32.2",
+  "version": "1.32.3",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.32.2",
+      "identifier": "ghcr.io/jmagar/cortex:v1.32.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/agent_deploy.rs
+++ b/src/agent_deploy.rs
@@ -381,6 +381,23 @@ fn run_deploy_unraid(
     ssh_run(host, &format!("mkdir -p {UNRAID_APPDATA}"))?;
     ssh_run(host, &format!("docker pull {image}"))?;
 
+    // Config-preserving upgrade: carry forward any custom env (e.g. a Plex
+    // CORTEX_AGENT_FILE_TAILS) from the persisted env file, and any custom mounts
+    // (e.g. the host log dir that file-tail reads) from the running container, so
+    // a redeploy doesn't reset the agent to flag defaults. Both reads are
+    // best-effort (`|| true`): a first-time deploy has neither.
+    let preserved_env = preserved_custom_env(
+        &ssh_capture(host, &format!("cat {UNRAID_ENV} 2>/dev/null || true")).unwrap_or_default(),
+    );
+    let custom_mounts: String = preserved_custom_mount_flags(
+        &ssh_capture(
+            host,
+            &format!("docker inspect {UNRAID_CONTAINER} --format '{MOUNT_INSPECT_TMPL}' 2>/dev/null || true"),
+        )
+        .unwrap_or_default(),
+    )
+    .concat();
+
     // Build env key=value pairs for both the persistent env file and the -e flags
     // passed directly to docker run. We use -e flags (not --env-file) to avoid
     // any shell-quoting or whitespace ambiguity that arises when writing values
@@ -414,6 +431,9 @@ fn run_deploy_unraid(
     if let Some(t) = &config.token {
         env_pairs.push(("CORTEX_HEARTBEAT_TOKEN".into(), t.clone()));
     }
+    // Append any preserved custom env so it lands in both the env file and the
+    // -e flags below (managed keys already set above win over any stale copy).
+    env_pairs.extend(preserved_env);
 
     // Write a persistent env file for reference / manual restarts, then chmod 600.
     let mut write_cmd = format!("rm -f {UNRAID_ENV}");
@@ -458,6 +478,7 @@ fn run_deploy_unraid(
                -v {UNRAID_APPDATA}:{UNRAID_APPDATA} \
                -v /var/run/docker.sock:/var/run/docker.sock \
                -v {UNRAID_HOST_SYSLOG}:{UNRAID_CONTAINER_SYSLOG}:ro \
+               {custom_mounts}\
                {image} \
                cortex heartbeat agent \
                  --host-id-path {UNRAID_HOST_ID}"
@@ -473,6 +494,91 @@ fn deploy_syslog_target(heartbeat_target: Option<&str>) -> Option<String> {
             heartbeat_target
                 .and_then(crate::agent::AgentStreamsConfig::syslog_target_from_heartbeat)
         })
+}
+
+/// Env keys the deploy sets from its CLI flags. Anything else found in an
+/// existing agent env file (e.g. `CORTEX_AGENT_FILE_TAILS`) is custom config a
+/// prior deploy or manual edit added, and an upgrade must carry it forward
+/// rather than reset the agent to flag defaults.
+const MANAGED_ENV_KEYS: &[&str] = &[
+    "CORTEX_HEARTBEAT_TARGET",
+    "RUST_LOG",
+    "CORTEX_SYSLOG_TARGET",
+    "CORTEX_AGENT_DOCKER",
+    "CORTEX_AGENT_DOCKER_URL",
+    "CORTEX_AGENT_JOURNALD",
+    "CORTEX_AGENT_SYSLOG_FILE",
+    "CORTEX_HEARTBEAT_TOKEN",
+];
+
+/// Container mount destinations the deploy always provides itself. A mount with
+/// any other destination (e.g. host log dirs a file-tail reads) is custom and
+/// must survive an upgrade.
+const STANDARD_MOUNT_DESTS: &[&str] = &[
+    UNRAID_APPDATA,
+    "/var/run/docker.sock",
+    UNRAID_CONTAINER_SYSLOG,
+];
+
+/// `docker inspect --format` template emitting one `source\tdest\trw|ro` line per
+/// mount. Uses `{{"\t"}}`/`{{"\n"}}` (Go interprets those) so the separators are
+/// real control chars, not literal backslash sequences.
+const MOUNT_INSPECT_TMPL: &str = r#"{{range .Mounts}}{{.Source}}{{"\t"}}{{.Destination}}{{"\t"}}{{if .RW}}rw{{else}}ro{{end}}{{"\n"}}{{end}}"#;
+
+/// Parse an existing agent env file into the (key, value) pairs whose keys are
+/// NOT managed by deploy flags — the custom additions an upgrade preserves.
+/// Splits on the first `=` so values containing `=`/spaces/`:` (file-tail specs)
+/// round-trip intact.
+fn preserved_custom_env(existing_env_file: &str) -> Vec<(String, String)> {
+    existing_env_file
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .map(|(k, v)| (k.trim().to_string(), v.to_string()))
+        .filter(|(k, _)| !k.is_empty() && !MANAGED_ENV_KEYS.contains(&k.as_str()))
+        .collect()
+}
+
+/// From `MOUNT_INSPECT_TMPL` output, return `-v source:dest[:ro]` flags for any
+/// mount whose destination the deploy doesn't already provide, so a custom mount
+/// (e.g. host Plex logs) survives an upgrade.
+fn preserved_custom_mount_flags(inspect_mounts: &str) -> Vec<String> {
+    inspect_mounts
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.split('\t');
+            let src = parts.next()?.trim();
+            let dest = parts.next()?.trim();
+            let rw = parts.next().map(str::trim).unwrap_or("rw");
+            if src.is_empty() || dest.is_empty() || STANDARD_MOUNT_DESTS.contains(&dest) {
+                return None;
+            }
+            let spec = if rw == "ro" {
+                format!("{src}:{dest}:ro")
+            } else {
+                format!("{src}:{dest}")
+            };
+            Some(format!("-v {} ", shell_quote(&spec)))
+        })
+        .collect()
+}
+
+/// Run an SSH command and capture stdout. Commands that may legitimately fail
+/// (e.g. inspecting a not-yet-existing container) should append `|| true` so the
+/// ssh invocation itself succeeds and returns empty output.
+fn ssh_capture(host: &str, cmd: &str) -> io::Result<String> {
+    let out = Command::new("ssh")
+        .args([
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            "LogLevel=ERROR",
+            host,
+            cmd,
+        ])
+        .output()?;
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
 fn ssh_run(host: &str, cmd: &str) -> io::Result<()> {

--- a/src/agent_deploy_tests.rs
+++ b/src/agent_deploy_tests.rs
@@ -358,3 +358,52 @@ exit 0
     assert!(log.contains("cortex heartbeat agent"));
     assert!(log.contains("--host-id-path /mnt/user/appdata/cortex/heartbeat-host-id"));
 }
+
+#[test]
+fn preserved_custom_env_keeps_custom_keys_and_drops_managed() {
+    let existing = "\
+CORTEX_HEARTBEAT_TARGET=https://cortex.tootie.tv
+RUST_LOG=warn
+CORTEX_HEARTBEAT_TOKEN=secret
+CORTEX_AGENT_FILE_TAILS=/host/plex-logs/Plex Media Server.log:plex
+CUSTOM_THING=foo=bar baz
+";
+    let kept = preserved_custom_env(existing);
+    // Managed keys (target, RUST_LOG, token) are dropped — the deploy sets those.
+    assert!(
+        !kept
+            .iter()
+            .any(|(k, _)| MANAGED_ENV_KEYS.contains(&k.as_str()))
+    );
+    // The Plex file-tail (value has a space AND a colon) round-trips intact.
+    let ft = kept
+        .iter()
+        .find(|(k, _)| k == "CORTEX_AGENT_FILE_TAILS")
+        .expect("file-tail preserved");
+    assert_eq!(ft.1, "/host/plex-logs/Plex Media Server.log:plex");
+    // A value containing '=' splits only on the first '='.
+    let custom = kept.iter().find(|(k, _)| k == "CUSTOM_THING").unwrap();
+    assert_eq!(custom.1, "foo=bar baz");
+}
+
+#[test]
+fn preserved_custom_mount_flags_keeps_only_nonstandard_mounts() {
+    let inspect = format!(
+        "{appdata}\t{appdata}\trw\n\
+         /var/run/docker.sock\t/var/run/docker.sock\trw\n\
+         /var/log/syslog\t{syslog}\tro\n\
+         /mnt/cache/appdata/plex/Logs\t/host/plex-logs\tro\n",
+        appdata = UNRAID_APPDATA,
+        syslog = UNRAID_CONTAINER_SYSLOG,
+    );
+    let flags = preserved_custom_mount_flags(&inspect);
+    // Only the custom Plex-logs mount survives; the 3 standard ones are dropped.
+    assert_eq!(flags.len(), 1, "got: {flags:?}");
+    assert!(flags[0].contains("/mnt/cache/appdata/plex/Logs:/host/plex-logs:ro"));
+}
+
+#[test]
+fn preserved_custom_mount_flags_empty_on_first_deploy() {
+    assert!(preserved_custom_mount_flags("").is_empty());
+    assert!(preserved_custom_env("").is_empty());
+}


### PR DESCRIPTION
## Problem
`ghcr.io/jmagar/cortex:1.32.0` and `:1.32.2` were **never published** (verified: only `1.31.0/1.31.2/1.31.4` exist on GHCR). The fleet agents pinned to `ghcr:1.31.2` therefore had no image to update to, and a manual deploy fails with `manifest unknown`.

## Root cause
`docker-publish.yml` derives the version image tag from `type=semver,pattern={{version}}`, which **only fires on `v*` git-tag pushes**. But the auto-tag workflow creates those tags with the default `GITHUB_TOKEN`, and **GitHub does not trigger workflows from `GITHUB_TOKEN`-pushed tags** (loop prevention). So the tag-triggered `docker-publish` run never happens — confirmed: every `docker-publish` run is `event=push branch=main` or `pull_request`, never a tag ref.

## Fix
Add `type=raw,value=<Cargo.toml version>,enable={{is_default_branch}}` to the image tags, reading the version from `Cargo.toml`. Now **every merge to `main` publishes `ghcr:<version>`** — independent of the dead tag trigger. (The `type=semver` tags are left in place for any future PAT-based tag pushes.)

## Verification
- The missing `ghcr:1.32.2` was published out-of-band by dispatching `docker-publish` against the `v1.32.2` tag (`workflow_dispatch` sets the ref, so `type=semver` fires) — confirmed pullable.
- After this merges, the 1.32.3 main push will publish `ghcr:1.32.3` via the new raw tag, validating the fix end-to-end.

Bumped 1.32.2 → 1.32.3; CHANGELOG added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish versioned images to `ghcr.io/jmagar/cortex:<version>` on every `main` push and make Unraid agent upgrades keep custom config. Bumps to `1.32.3` and updates references.

- **Bug Fixes**
  - GHCR images for `1.32.x` were never built because `docker-publish` only tagged on `v*` pushes; now read the version from `Cargo.toml` and add `type=raw,value=<version>,enable={{is_default_branch}}` while keeping existing semver tags.
  - Unraid `cortex deploy agent` wiped per-host config on redeploy; it now preserves non-managed env keys from the existing `heartbeat-agent.env` and non-standard mounts from the running container (helpers with tests added).

<sup>Written for commit ccffca64c21834437606db3d35c510b59bee4050. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker image publishing to correctly generate and publish versioned image tags when changes are pushed to the default branch.

* **Chores**
  * Version bumped to 1.32.3 across all configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->