### PR TITLE
fix(deploy): fully config-preserving agent upgrades — preserve token/target/docker (1.32.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.4] - 2026-06-19
+
+### Fixed
+
+- **`cortex deploy agent` upgrades are now fully config-preserving.** 1.32.3 began
+  carrying forward custom env (file-tails) and mounts, but the heartbeat **token**,
+  **target**, and the **docker/journald** booleans were still rebuilt from flags —
+  so a flag-less redeploy would drop the token (breaking heartbeat auth) and reset
+  docker ingest to off. The Unraid deploy now resolves every managed key with
+  **flag > persisted > default** precedence: an explicit flag wins, otherwise the
+  value from the host's `heartbeat-agent.env` is kept, otherwise a built-in default
+  fills first-time deploys. `--docker`/`--journald` became `Option<bool>` so "not
+  passed" is distinct from "false" (and thus preserves the existing setting);
+  journald stays forced-false inside the container. Custom keys (file-tails) and
+  non-standard mounts continue to carry through. New pure helpers
+  (`parse_env_file`, `resolve_agent_env`) with unit tests covering flag-less
+  preservation, flag override, and first-deploy defaults.
+
 ## [1.32.3] - 2026-06-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.32.3"
+version = "1.32.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "1.32.3"
+version = "1.32.4"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.32.3}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.32.4}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.32.3",
+  "version": "1.32.4",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.32.3",
+  "version": "1.32.4",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.32.3",
+      "identifier": "ghcr.io/jmagar/cortex:v1.32.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/agent_deploy.rs
+++ b/src/agent_deploy.rs
@@ -41,8 +41,10 @@ impl HostProbe {
 pub struct AgentDeployConfig {
     pub target: Option<String>,
     pub token: Option<String>,
-    pub docker: bool,
-    pub journald: bool,
+    /// `None` = not specified on the CLI → preserve the host's existing value on
+    /// an upgrade (rather than reset to the default).
+    pub docker: Option<bool>,
+    pub journald: Option<bool>,
 }
 
 #[derive(Debug, Clone)]
@@ -329,10 +331,10 @@ fn run_deploy(host: &str, local_binary: &Path, config: &AgentDeployConfig) -> io
     if let Some(t) = &config.token {
         env_pairs.push(format!("CORTEX_HEARTBEAT_TOKEN={}", shell_quote(t)));
     }
-    if config.docker {
+    if config.docker == Some(true) {
         env_pairs.push("CORTEX_AGENT_DOCKER=true".to_string());
     }
-    if config.journald {
+    if config.journald == Some(true) {
         env_pairs.push("CORTEX_AGENT_JOURNALD=true".to_string());
     }
     if let Some(syslog_target) = deploy_syslog_target(config.target.as_deref()) {
@@ -381,13 +383,18 @@ fn run_deploy_unraid(
     ssh_run(host, &format!("mkdir -p {UNRAID_APPDATA}"))?;
     ssh_run(host, &format!("docker pull {image}"))?;
 
-    // Config-preserving upgrade: carry forward any custom env (e.g. a Plex
-    // CORTEX_AGENT_FILE_TAILS) from the persisted env file, and any custom mounts
-    // (e.g. the host log dir that file-tail reads) from the running container, so
-    // a redeploy doesn't reset the agent to flag defaults. Both reads are
-    // best-effort (`|| true`): a first-time deploy has neither.
-    let preserved_env = preserved_custom_env(
-        &ssh_capture(host, &format!("cat {UNRAID_ENV} 2>/dev/null || true")).unwrap_or_default(),
+    // Config-preserving upgrade: resolve the container env from the host's
+    // persisted heartbeat-agent.env (flag > persisted > default per key, custom
+    // keys like CORTEX_AGENT_FILE_TAILS carried through), and carry forward any
+    // non-standard mounts (e.g. the host log dir a file-tail reads) from the
+    // running container. Both reads are best-effort (`|| true`): a first-time
+    // deploy has neither, and resolve_agent_env falls back to flag defaults.
+    let env_pairs = resolve_agent_env(
+        &parse_env_file(
+            &ssh_capture(host, &format!("cat {UNRAID_ENV} 2>/dev/null || true"))
+                .unwrap_or_default(),
+        ),
+        config,
     );
     let custom_mounts: String = preserved_custom_mount_flags(
         &ssh_capture(
@@ -398,44 +405,8 @@ fn run_deploy_unraid(
     )
     .concat();
 
-    // Build env key=value pairs for both the persistent env file and the -e flags
-    // passed directly to docker run. We use -e flags (not --env-file) to avoid
-    // any shell-quoting or whitespace ambiguity that arises when writing values
-    // via `echo` over SSH and then reading them back with Docker's env-file parser.
-    let target = config
-        .target
-        .as_deref()
-        .unwrap_or(crate::heartbeat_agent::DEFAULT_TARGET);
-    let mut env_pairs: Vec<(String, String)> = vec![
-        ("CORTEX_HEARTBEAT_TARGET".into(), target.to_string()),
-        ("RUST_LOG".into(), "warn".into()),
-        (
-            "CORTEX_SYSLOG_TARGET".into(),
-            deploy_syslog_target(Some(target)).unwrap_or_else(|| "127.0.0.1:1514".into()),
-        ),
-        (
-            "CORTEX_AGENT_DOCKER".into(),
-            if config.docker { "true" } else { "false" }.into(),
-        ),
-        (
-            "CORTEX_AGENT_DOCKER_URL".into(),
-            crate::heartbeat_agent::DEFAULT_DOCKER_URL.into(),
-        ),
-        // journald has no meaning inside a container — suppress it for Unraid.
-        ("CORTEX_AGENT_JOURNALD".into(), "false".into()),
-        (
-            "CORTEX_AGENT_SYSLOG_FILE".into(),
-            UNRAID_CONTAINER_SYSLOG.into(),
-        ),
-    ];
-    if let Some(t) = &config.token {
-        env_pairs.push(("CORTEX_HEARTBEAT_TOKEN".into(), t.clone()));
-    }
-    // Append any preserved custom env so it lands in both the env file and the
-    // -e flags below (managed keys already set above win over any stale copy).
-    env_pairs.extend(preserved_env);
-
-    // Write a persistent env file for reference / manual restarts, then chmod 600.
+    // Persist the resolved env (reference / manual restarts), then chmod 600. The
+    // -e flags below pass values verbatim to docker run (no env-file parsing).
     let mut write_cmd = format!("rm -f {UNRAID_ENV}");
     for (k, v) in &env_pairs {
         write_cmd.push_str(&format!(
@@ -496,20 +467,109 @@ fn deploy_syslog_target(heartbeat_target: Option<&str>) -> Option<String> {
         })
 }
 
-/// Env keys the deploy sets from its CLI flags. Anything else found in an
-/// existing agent env file (e.g. `CORTEX_AGENT_FILE_TAILS`) is custom config a
-/// prior deploy or manual edit added, and an upgrade must carry it forward
-/// rather than reset the agent to flag defaults.
-const MANAGED_ENV_KEYS: &[&str] = &[
-    "CORTEX_HEARTBEAT_TARGET",
-    "RUST_LOG",
-    "CORTEX_SYSLOG_TARGET",
-    "CORTEX_AGENT_DOCKER",
-    "CORTEX_AGENT_DOCKER_URL",
-    "CORTEX_AGENT_JOURNALD",
-    "CORTEX_AGENT_SYSLOG_FILE",
-    "CORTEX_HEARTBEAT_TOKEN",
-];
+/// Parse an existing `heartbeat-agent.env` into ordered `(key, value)` pairs.
+/// Splits on the first `=` so values containing `=`/spaces/`:` (file-tail specs)
+/// round-trip intact; blank lines and comments are skipped.
+fn parse_env_file(contents: &str) -> Vec<(String, String)> {
+    contents
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .filter_map(|line| line.split_once('='))
+        .map(|(k, v)| (k.trim().to_string(), v.to_string()))
+        .filter(|(k, _)| !k.is_empty())
+        .collect()
+}
+
+/// Resolve the agent container env for a (re)deploy using precedence
+/// **flag > persisted > default** for each managed key, then carry every other
+/// key from the persisted env through unchanged (e.g. `CORTEX_AGENT_FILE_TAILS`).
+///
+/// This makes an upgrade config-preserving: running `cortex deploy agent` with no
+/// flags keeps the host's existing target, token, docker/journald settings, and
+/// custom additions, instead of resetting them to defaults. Output order is
+/// deterministic (managed block in a fixed order, then custom keys sorted).
+fn resolve_agent_env(
+    persisted: &[(String, String)],
+    config: &AgentDeployConfig,
+) -> Vec<(String, String)> {
+    use std::collections::{HashMap, HashSet};
+    let prev: HashMap<&str, &str> = persisted
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let prev_get = |k: &str| prev.get(k).map(|s| s.to_string());
+
+    // Effective heartbeat target (flag > persisted > default) drives syslog derivation.
+    let target = config
+        .target
+        .clone()
+        .or_else(|| prev_get("CORTEX_HEARTBEAT_TARGET"))
+        .unwrap_or_else(|| crate::heartbeat_agent::DEFAULT_TARGET.to_string());
+
+    // A new --target re-derives the syslog target; otherwise keep the persisted
+    // value (falling back to a derivation for first-time deploys).
+    let syslog_target = if config.target.is_some() {
+        deploy_syslog_target(Some(&target)).unwrap_or_else(|| "127.0.0.1:1514".into())
+    } else {
+        prev_get("CORTEX_SYSLOG_TARGET")
+            .or_else(|| deploy_syslog_target(Some(&target)))
+            .unwrap_or_else(|| "127.0.0.1:1514".into())
+    };
+
+    let bool_key = |flag: Option<bool>, key: &str| -> String {
+        match flag {
+            Some(b) => b.to_string(),
+            None => prev_get(key).unwrap_or_else(|| "false".into()),
+        }
+    };
+
+    let mut out: Vec<(String, String)> = vec![
+        ("CORTEX_HEARTBEAT_TARGET".into(), target),
+        (
+            "RUST_LOG".into(),
+            prev_get("RUST_LOG").unwrap_or_else(|| "warn".into()),
+        ),
+        ("CORTEX_SYSLOG_TARGET".into(), syslog_target),
+        (
+            "CORTEX_AGENT_DOCKER".into(),
+            bool_key(config.docker, "CORTEX_AGENT_DOCKER"),
+        ),
+        (
+            "CORTEX_AGENT_DOCKER_URL".into(),
+            prev_get("CORTEX_AGENT_DOCKER_URL")
+                .unwrap_or_else(|| crate::heartbeat_agent::DEFAULT_DOCKER_URL.to_string()),
+        ),
+        // journald is meaningless inside a container — always false on Unraid,
+        // regardless of any flag or persisted value.
+        ("CORTEX_AGENT_JOURNALD".into(), "false".into()),
+        (
+            "CORTEX_AGENT_SYSLOG_FILE".into(),
+            prev_get("CORTEX_AGENT_SYSLOG_FILE")
+                .unwrap_or_else(|| UNRAID_CONTAINER_SYSLOG.to_string()),
+        ),
+    ];
+    // Token: flag wins, else preserve the persisted token. Omitted if neither
+    // exists (no auth configured).
+    if let Some(token) = config
+        .token
+        .clone()
+        .or_else(|| prev_get("CORTEX_HEARTBEAT_TOKEN"))
+    {
+        out.push(("CORTEX_HEARTBEAT_TOKEN".into(), token));
+    }
+
+    // Carry remaining custom keys (file-tails, etc.) in stable sorted order.
+    let managed: HashSet<&str> = out.iter().map(|(k, _)| k.as_str()).collect();
+    let mut custom: Vec<(String, String)> = persisted
+        .iter()
+        .filter(|(k, _)| !managed.contains(k.as_str()))
+        .cloned()
+        .collect();
+    custom.sort_by(|a, b| a.0.cmp(&b.0));
+    out.extend(custom);
+    out
+}
 
 /// Container mount destinations the deploy always provides itself. A mount with
 /// any other destination (e.g. host log dirs a file-tail reads) is custom and
@@ -524,19 +584,6 @@ const STANDARD_MOUNT_DESTS: &[&str] = &[
 /// mount. Uses `{{"\t"}}`/`{{"\n"}}` (Go interprets those) so the separators are
 /// real control chars, not literal backslash sequences.
 const MOUNT_INSPECT_TMPL: &str = r#"{{range .Mounts}}{{.Source}}{{"\t"}}{{.Destination}}{{"\t"}}{{if .RW}}rw{{else}}ro{{end}}{{"\n"}}{{end}}"#;
-
-/// Parse an existing agent env file into the (key, value) pairs whose keys are
-/// NOT managed by deploy flags — the custom additions an upgrade preserves.
-/// Splits on the first `=` so values containing `=`/spaces/`:` (file-tail specs)
-/// round-trip intact.
-fn preserved_custom_env(existing_env_file: &str) -> Vec<(String, String)> {
-    existing_env_file
-        .lines()
-        .filter_map(|line| line.split_once('='))
-        .map(|(k, v)| (k.trim().to_string(), v.to_string()))
-        .filter(|(k, _)| !k.is_empty() && !MANAGED_ENV_KEYS.contains(&k.as_str()))
-        .collect()
-}
 
 /// From `MOUNT_INSPECT_TMPL` output, return `-v source:dest[:ro]` flags for any
 /// mount whose destination the deploy doesn't already provide, so a custom mount

--- a/src/agent_deploy_tests.rs
+++ b/src/agent_deploy_tests.rs
@@ -246,8 +246,8 @@ exit 0
         &AgentDeployConfig {
             target: Some("https://cortex.example.test:3100".to_string()),
             token: Some("heartbeat token".to_string()),
-            docker: true,
-            journald: true,
+            docker: Some(true),
+            journald: Some(true),
         },
     );
 
@@ -324,8 +324,8 @@ exit 0
         &AgentDeployConfig {
             target: Some("https://cortex.example.test".to_string()),
             token: Some("secret".to_string()),
-            docker: false,
-            journald: true,
+            docker: Some(false),
+            journald: Some(true),
         },
     );
 
@@ -359,31 +359,90 @@ exit 0
     assert!(log.contains("--host-id-path /mnt/user/appdata/cortex/heartbeat-host-id"));
 }
 
+fn env_get<'a>(env: &'a [(String, String)], key: &str) -> Option<&'a str> {
+    env.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+}
+
 #[test]
-fn preserved_custom_env_keeps_custom_keys_and_drops_managed() {
-    let existing = "\
-CORTEX_HEARTBEAT_TARGET=https://cortex.tootie.tv
-RUST_LOG=warn
-CORTEX_HEARTBEAT_TOKEN=secret
-CORTEX_AGENT_FILE_TAILS=/host/plex-logs/Plex Media Server.log:plex
-CUSTOM_THING=foo=bar baz
-";
-    let kept = preserved_custom_env(existing);
-    // Managed keys (target, RUST_LOG, token) are dropped — the deploy sets those.
-    assert!(
-        !kept
-            .iter()
-            .any(|(k, _)| MANAGED_ENV_KEYS.contains(&k.as_str()))
+fn resolve_agent_env_flagless_upgrade_preserves_everything() {
+    // The whole point: `cortex deploy agent` with NO flags keeps the host's
+    // existing token, target, docker setting, and custom Plex file-tail.
+    let persisted = vec![
+        (
+            "CORTEX_HEARTBEAT_TARGET".into(),
+            "https://cortex.tootie.tv".into(),
+        ),
+        ("CORTEX_SYSLOG_TARGET".into(), "100.88.16.79:1514".into()),
+        ("CORTEX_AGENT_DOCKER".into(), "true".into()),
+        ("CORTEX_HEARTBEAT_TOKEN".into(), "the-secret".into()),
+        (
+            "CORTEX_AGENT_FILE_TAILS".into(),
+            "/host/plex-logs/Plex Media Server.log:plex".into(),
+        ),
+    ];
+    let env = resolve_agent_env(&persisted, &AgentDeployConfig::default());
+    assert_eq!(env_get(&env, "CORTEX_HEARTBEAT_TOKEN"), Some("the-secret"));
+    assert_eq!(
+        env_get(&env, "CORTEX_HEARTBEAT_TARGET"),
+        Some("https://cortex.tootie.tv")
     );
-    // The Plex file-tail (value has a space AND a colon) round-trips intact.
-    let ft = kept
-        .iter()
-        .find(|(k, _)| k == "CORTEX_AGENT_FILE_TAILS")
-        .expect("file-tail preserved");
-    assert_eq!(ft.1, "/host/plex-logs/Plex Media Server.log:plex");
-    // A value containing '=' splits only on the first '='.
-    let custom = kept.iter().find(|(k, _)| k == "CUSTOM_THING").unwrap();
-    assert_eq!(custom.1, "foo=bar baz");
+    assert_eq!(
+        env_get(&env, "CORTEX_SYSLOG_TARGET"),
+        Some("100.88.16.79:1514")
+    );
+    // Preserved as true — NOT reset to the false default.
+    assert_eq!(env_get(&env, "CORTEX_AGENT_DOCKER"), Some("true"));
+    // The file-tail (value has a space AND a colon) round-trips intact.
+    assert_eq!(
+        env_get(&env, "CORTEX_AGENT_FILE_TAILS"),
+        Some("/host/plex-logs/Plex Media Server.log:plex")
+    );
+}
+
+#[test]
+fn resolve_agent_env_flags_override_persisted() {
+    let persisted = vec![
+        (
+            "CORTEX_HEARTBEAT_TARGET".into(),
+            "https://old.example".into(),
+        ),
+        ("CORTEX_HEARTBEAT_TOKEN".into(), "old-token".into()),
+        ("CORTEX_AGENT_DOCKER".into(), "true".into()),
+    ];
+    let cfg = AgentDeployConfig {
+        target: Some("https://new.example".into()),
+        token: Some("new-token".into()),
+        docker: Some(false),
+        journald: None,
+    };
+    let env = resolve_agent_env(&persisted, &cfg);
+    assert_eq!(
+        env_get(&env, "CORTEX_HEARTBEAT_TARGET"),
+        Some("https://new.example")
+    );
+    assert_eq!(env_get(&env, "CORTEX_HEARTBEAT_TOKEN"), Some("new-token"));
+    assert_eq!(env_get(&env, "CORTEX_AGENT_DOCKER"), Some("false"));
+}
+
+#[test]
+fn resolve_agent_env_first_deploy_defaults_and_omits_absent_token() {
+    let env = resolve_agent_env(&[], &AgentDeployConfig::default());
+    // No token anywhere → omitted entirely (no empty/garbage token written).
+    assert_eq!(env_get(&env, "CORTEX_HEARTBEAT_TOKEN"), None);
+    assert_eq!(env_get(&env, "CORTEX_AGENT_DOCKER"), Some("false"));
+    assert_eq!(env_get(&env, "RUST_LOG"), Some("warn"));
+}
+
+#[test]
+fn parse_env_file_splits_on_first_equals_and_skips_blanks_and_comments() {
+    let parsed = parse_env_file("A=1\n\n# comment\nB=x=y z\n");
+    assert_eq!(
+        parsed,
+        vec![
+            ("A".to_string(), "1".to_string()),
+            ("B".to_string(), "x=y z".to_string()),
+        ]
+    );
 }
 
 #[test]
@@ -405,5 +464,5 @@ fn preserved_custom_mount_flags_keeps_only_nonstandard_mounts() {
 #[test]
 fn preserved_custom_mount_flags_empty_on_first_deploy() {
     assert!(preserved_custom_mount_flags("").is_empty());
-    assert!(preserved_custom_env("").is_empty());
+    assert!(parse_env_file("").is_empty());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,8 +253,8 @@ fn run_deploy_agent(
     explicit_hosts: Vec<String>,
     target: Option<String>,
     token: Option<String>,
-    docker: bool,
-    journald: bool,
+    docker: Option<bool>,
+    journald: Option<bool>,
     binary: Option<String>,
 ) -> Result<()> {
     use cortex::agent_deploy::{
@@ -537,8 +537,9 @@ enum DeployCommandKind {
         hosts: Vec<String>,
         target: Option<String>,
         token: Option<String>,
-        docker: bool,
-        journald: bool,
+        /// `None` = flag not passed → preserve the host's existing value.
+        docker: Option<bool>,
+        journald: Option<bool>,
         binary: Option<String>,
     },
 }
@@ -850,8 +851,9 @@ fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
     let mut agent_hosts: Vec<String> = Vec::new();
     let mut agent_target: Option<String> = None;
     let mut agent_token: Option<String> = None;
-    let mut agent_docker = false;
-    let mut agent_journald = false;
+    // `None` = flag not passed → preserve the host's existing setting on upgrade.
+    let mut agent_docker: Option<bool> = None;
+    let mut agent_journald: Option<bool> = None;
     let mut agent_binary: Option<String> = None;
     let mut i = 0usize;
     while i < rest.len() {
@@ -898,8 +900,8 @@ fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
                         .clone(),
                 );
             }
-            "--docker" if subcommand == "agent" => agent_docker = true,
-            "--journald" if subcommand == "agent" => agent_journald = true,
+            "--docker" if subcommand == "agent" => agent_docker = Some(true),
+            "--journald" if subcommand == "agent" => agent_journald = Some(true),
             other if subcommand == "remote" && !other.starts_with('-') => {
                 if host.replace(other.to_string()).is_some() {
                     anyhow::bail!("deploy remote accepts exactly one host");

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -458,8 +458,8 @@ fn parse_deploy_agent_preserves_all_options() {
     assert_eq!(hosts, vec!["tootie".to_string(), "dookie".to_string()]);
     assert_eq!(target.as_deref(), Some("https://cortex.example.test"));
     assert_eq!(token.as_deref(), Some("secret"));
-    assert!(docker);
-    assert!(journald);
+    assert_eq!(docker, Some(true));
+    assert_eq!(journald, Some(true));
     assert_eq!(binary.as_deref(), Some("/tmp/cortex"));
 }
 


### PR DESCRIPTION
## Problem
1.32.3 made `cortex deploy agent` carry forward custom env (file-tails) and mounts, but the **heartbeat token**, **target**, and the **docker/journald** booleans were still rebuilt from CLI flags. So a *flag-less* redeploy (the common upgrade case) would:
- **drop `CORTEX_HEARTBEAT_TOKEN`** → break the agent's heartbeat auth, and
- **reset `CORTEX_AGENT_DOCKER` to false** → silently stop Docker log ingest.

The config was persisted in the host's `heartbeat-agent.env` all along — the deploy just wasn't reading it.

## Fix
The Unraid deploy now resolves **every** managed env key with **`flag > persisted > default`** precedence (`resolve_agent_env`):
- explicit flag wins,
- else the value from the host's existing `heartbeat-agent.env`,
- else a built-in default (first-time deploys).

`--docker`/`--journald` became `Option<bool>` so "not passed" is distinct from "false" (preserving the existing setting on upgrade). `journald` stays forced-false inside the container. Custom keys (file-tails) and non-standard mounts still carry through (from 1.32.3).

## Tests
New pure helpers `parse_env_file` + `resolve_agent_env` with unit tests:
- flag-less upgrade preserves token, target, syslog, `docker=true`, and the Plex file-tail
- explicit flags override persisted values
- first deploy uses defaults and **omits** an absent token (no empty/garbage token)
- `--docker`/`--journald` Option plumbing through main.rs

24 lib + 3 bin deploy tests green; clippy + fmt clean. Bumped 1.32.3 → 1.32.4.

## Why this PR exists
Caught *before* deploying: a flag-less `cortex deploy agent` on tootie/shart would have dropped their heartbeat token. After this lands, the fleet upgrade is genuinely hands-free.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fully preserve agent config on Unraid upgrades. A flag-less `cortex deploy agent` now keeps the heartbeat token, target, and Docker setting to avoid broken heartbeats and lost Docker logs.

- Bug Fixes
  - Resolve env with flag > persisted > default via `resolve_agent_env` and `parse_env_file`.
  - `--docker` and `--journald` are now `Option<bool>`; not passed preserves existing. `journald` remains forced false in-container.
  - Carry forward custom env (e.g., file tails) and non-standard mounts.
  - Added unit tests for flag-less upgrades, flag overrides, and first deploy defaults. Bumped version to 1.32.4.

<sup>Written for commit 9a569e8e98e5e6def11c0db2991bad21e2f6cef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

