### PR TITLE
fix: normalize worktree AI session projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.4] - 2026-06-23
+
 ## [1.33.3] - 2026-06-22
 
 ## [1.33.2] - 2026-06-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.33.4] - 2026-06-23
 
+### Fixed
+
+- **AI transcript sessions from worktrees are attributed to the durable project
+  root.** Cortex now normalizes repo-local `.worktrees`, Claude
+  `.claude/worktrees`, and validated Codex app worktree paths before storing
+  `ai_project`, so worktree sessions group with the project they belong to
+  instead of fragmenting under temporary checkout paths.
+
 ## [1.33.3] - 2026-06-22
 
 ## [1.33.2] - 2026-06-21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -665,7 +665,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34caa94a67aadf36b12807811390033f73eff0e3789feb596925ace787b13efe"
 dependencies = [
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.5",
  "libm",
  "rand_core 0.10.1",
 ]
@@ -2724,7 +2724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
 dependencies = [
  "const-oid 0.10.2",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.5",
  "crypto-primes",
  "digest 0.11.3",
  "pkcs1 0.8.0-rc.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "1.33.3"
+version = "1.33.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "1.33.3"
+version = "1.33.4"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.33.3}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-1.33.4}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "1.33.3",
+  "version": "1.33.4",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "1.33.3",
+  "version": "1.33.4",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v1.33.3",
+      "identifier": "ghcr.io/jmagar/cortex:v1.33.4",
       "transport": {
         "type": "stdio"
       },

--- a/src/agent_deploy_tests.rs
+++ b/src/agent_deploy_tests.rs
@@ -125,7 +125,10 @@ fn unraid_constants_wire_socket_and_host_syslog() {
 }
 
 #[test]
+#[serial]
 fn deploy_syslog_target_derives_from_heartbeat_url() {
+    let _guard = EnvGuard::remove("CORTEX_SYSLOG_TARGET");
+
     assert_eq!(
         deploy_syslog_target(Some("https://cortex.example.test:3100")),
         Some("cortex.example.test:1514".to_string())

--- a/src/ai_project.rs
+++ b/src/ai_project.rs
@@ -1,0 +1,65 @@
+//! AI project identity normalization shared by transcript ingest paths.
+
+use std::{fs, path::Path};
+
+/// Normalize AI project paths that point at temporary worktrees back to the
+/// durable project root used by Cortex's session inventory.
+pub(crate) fn normalize_ai_project_path(project: &str) -> String {
+    let project = project.trim();
+    if project.is_empty() || project.contains("://") {
+        return project.to_string();
+    }
+    if let Some(root) = project_local_worktree_root(project) {
+        return root;
+    }
+    project.to_string()
+}
+
+/// Normalize project paths that can be proven against the local filesystem.
+///
+/// This is intentionally used by the scanner, not the live syslog enrichment
+/// path, because Codex app worktree resolution may read a `.git` pointer.
+pub(crate) fn normalize_local_ai_project_path(project: &str) -> String {
+    let normalized = normalize_ai_project_path(project);
+    if normalized != project.trim() {
+        return normalized;
+    }
+    if let Some(root) = codex_app_worktree_project_from_git(project.trim()) {
+        return root;
+    }
+    normalized
+}
+
+fn project_local_worktree_root(project: &str) -> Option<String> {
+    ["/.worktrees/", "/.claude/worktrees/"]
+        .into_iter()
+        .find_map(|marker| {
+            project
+                .find(marker)
+                .and_then(|idx| (idx > 0).then(|| project[..idx].to_string()))
+        })
+}
+
+fn codex_app_worktree_project_from_git(project: &str) -> Option<String> {
+    let marker = "/.codex/worktrees/";
+    let idx = project.find(marker)?;
+    let rest = &project[idx + marker.len()..];
+    let mut segments = rest.split('/').filter(|segment| !segment.is_empty());
+    let worktree_id = segments.next()?;
+    let repo = segments.next()?;
+    let worktree = Path::new(&project[..idx])
+        .join(".codex/worktrees")
+        .join(worktree_id)
+        .join(repo);
+    let git_pointer = fs::read_to_string(worktree.join(".git")).ok()?;
+    let gitdir = git_pointer.trim().strip_prefix("gitdir:")?.trim();
+    let gitdir = if Path::new(gitdir).is_absolute() {
+        Path::new(gitdir).to_path_buf()
+    } else {
+        worktree.join(gitdir)
+    };
+    let gitdir = gitdir.to_string_lossy();
+    gitdir
+        .find("/.git/worktrees/")
+        .and_then(|idx| (idx > 0).then(|| gitdir[..idx].to_string()))
+}

--- a/src/cli/setup/plugin_options_tests.rs
+++ b/src/cli/setup/plugin_options_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serial_test::serial;
 use std::sync::Mutex;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -74,6 +75,7 @@ fn reject_unsafe_value_errors_on_newline_and_cr() {
 }
 
 #[test]
+#[serial]
 fn prepare_plugin_hook_env_maps_server_options_without_client_probe() {
     let _lock = ENV_LOCK.lock().unwrap();
     let env = EnvGuard::new(&[
@@ -117,6 +119,7 @@ fn prepare_plugin_hook_env_maps_server_options_without_client_probe() {
 }
 
 #[test]
+#[serial]
 fn prepare_oauth_env_derives_public_url_and_redirects_once() {
     let _lock = ENV_LOCK.lock().unwrap();
     let env = EnvGuard::new(&[
@@ -169,6 +172,7 @@ fn prepare_oauth_env_derives_public_url_and_redirects_once() {
 }
 
 #[test]
+#[serial]
 fn prepare_plugin_hook_env_rejects_unsafe_api_token_before_mapping() {
     let _lock = ENV_LOCK.lock().unwrap();
     let env = EnvGuard::new(&[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod agent;
 pub mod agent_deploy;
+pub(crate) mod ai_project;
 pub mod ai_watch;
 pub mod api;
 pub mod app;

--- a/src/receiver/enrichment.rs
+++ b/src/receiver/enrichment.rs
@@ -282,6 +282,49 @@ pub(crate) fn project_from_transcript_path(path: &str) -> Option<String> {
     None
 }
 
+/// Normalize AI project paths that point at temporary worktrees back to the
+/// durable project root used by Cortex's session inventory.
+pub(crate) fn normalize_ai_project_path(project: &str) -> String {
+    let project = project.trim();
+    if project.is_empty() || project.contains("://") {
+        return project.to_string();
+    }
+    if let Some(root) = project_local_worktree_root(project) {
+        return root;
+    }
+    if let Some(root) = codex_app_worktree_project(project) {
+        return root;
+    }
+    project.to_string()
+}
+
+fn project_local_worktree_root(project: &str) -> Option<String> {
+    ["/.worktrees/", "/.claude/worktrees/"]
+        .into_iter()
+        .find_map(|marker| {
+            project
+                .find(marker)
+                .and_then(|idx| (idx > 0).then(|| project[..idx].to_string()))
+        })
+}
+
+fn codex_app_worktree_project(project: &str) -> Option<String> {
+    let marker = "/.codex/worktrees/";
+    let idx = project.find(marker)?;
+    let home = &project[..idx];
+    let rest = &project[idx + marker.len()..];
+    let mut segments = rest.split('/').filter(|segment| !segment.is_empty());
+    let _worktree_id = segments.next()?;
+    let repo = segments.next()?;
+    Some(
+        Path::new(home)
+            .join("workspace")
+            .join(repo)
+            .display()
+            .to_string(),
+    )
+}
+
 /// Decode a Claude project directory name back to a path.
 ///
 /// Claude encodes project paths by replacing `/` with `-` and prefixing with `-`.
@@ -315,7 +358,8 @@ fn project_from_sessions_index(path: &str) -> Option<String> {
                     .into_iter()
                     .find_map(|entry| entry.project_path)
             })
-        });
+        })
+        .map(|project| normalize_ai_project_path(&project));
 
     cache.insert(index_path, project.clone());
     project
@@ -336,7 +380,7 @@ fn fill_ai_metadata_from_json(entry: &mut LogBatchEntry, value: &serde_json::Val
             .get("cwd")
             .or_else(|| value.get("cwd"))
             .and_then(serde_json::Value::as_str)
-            .map(str::to_string);
+            .map(normalize_ai_project_path);
     }
     if entry.ai_project.is_none() {
         entry.ai_project = payload
@@ -346,7 +390,7 @@ fn fill_ai_metadata_from_json(entry: &mut LogBatchEntry, value: &serde_json::Val
             .and_then(|args| {
                 args.get("workdir")
                     .and_then(serde_json::Value::as_str)
-                    .map(str::to_string)
+                    .map(normalize_ai_project_path)
             });
     }
 }

--- a/src/receiver/enrichment.rs
+++ b/src/receiver/enrichment.rs
@@ -20,13 +20,16 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::{LazyLock, Mutex};
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use regex::Regex;
 use serde::Deserialize;
 
+use crate::ai_project::normalize_ai_project_path;
 use crate::db::LogBatchEntry;
 
 /// Configuration for the enrichment pipeline. Built from environment variables
@@ -277,52 +280,9 @@ pub(crate) fn project_from_transcript_path(path: &str) -> Option<String> {
     }
     if let Some(project_part) = path.split("/.claude/projects/").nth(1) {
         let encoded = project_part.split('/').next()?;
-        return decode_claude_project(encoded);
+        return decode_claude_project(encoded).map(|project| normalize_ai_project_path(&project));
     }
     None
-}
-
-/// Normalize AI project paths that point at temporary worktrees back to the
-/// durable project root used by Cortex's session inventory.
-pub(crate) fn normalize_ai_project_path(project: &str) -> String {
-    let project = project.trim();
-    if project.is_empty() || project.contains("://") {
-        return project.to_string();
-    }
-    if let Some(root) = project_local_worktree_root(project) {
-        return root;
-    }
-    if let Some(root) = codex_app_worktree_project(project) {
-        return root;
-    }
-    project.to_string()
-}
-
-fn project_local_worktree_root(project: &str) -> Option<String> {
-    ["/.worktrees/", "/.claude/worktrees/"]
-        .into_iter()
-        .find_map(|marker| {
-            project
-                .find(marker)
-                .and_then(|idx| (idx > 0).then(|| project[..idx].to_string()))
-        })
-}
-
-fn codex_app_worktree_project(project: &str) -> Option<String> {
-    let marker = "/.codex/worktrees/";
-    let idx = project.find(marker)?;
-    let home = &project[..idx];
-    let rest = &project[idx + marker.len()..];
-    let mut segments = rest.split('/').filter(|segment| !segment.is_empty());
-    let _worktree_id = segments.next()?;
-    let repo = segments.next()?;
-    Some(
-        Path::new(home)
-            .join("workspace")
-            .join(repo)
-            .display()
-            .to_string(),
-    )
 }
 
 /// Decode a Claude project directory name back to a path.

--- a/src/receiver/enrichment_tests.rs
+++ b/src/receiver/enrichment_tests.rs
@@ -317,6 +317,26 @@ fn enriches_codex_function_call_workdir_when_session_meta_absent() {
 }
 
 #[test]
+fn enriches_codex_workdir_normalizes_project_local_worktree() {
+    let cfg = EnrichmentConfig::default();
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("workspace/cortex");
+    let worktree = project.join(".worktrees/session-indexing");
+    let e = entry(
+        "codex-transcript",
+        &format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"type\":\"function_call\",\"arguments\":\"{{\\\"cmd\\\":\\\"cargo test\\\",\\\"workdir\\\":\\\"{}\\\"}}\"}}}}",
+            worktree.display()
+        ),
+        "10.0.0.1:1",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.ai_tool.as_deref(), Some("codex"));
+    assert_eq!(out.ai_project.as_deref(), Some(project.to_str().unwrap()));
+}
+
+#[test]
 fn enriches_claude_project_from_transcript_path_in_raw() {
     let cfg = EnrichmentConfig::default();
     let mut e = entry(

--- a/src/receiver/enrichment_tests.rs
+++ b/src/receiver/enrichment_tests.rs
@@ -337,6 +337,50 @@ fn enriches_codex_workdir_normalizes_project_local_worktree() {
 }
 
 #[test]
+fn enriches_codex_workdir_keeps_codex_app_worktree_even_when_workspace_project_exists() {
+    let cfg = EnrichmentConfig::default();
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("workspace/cortex");
+    fs::create_dir_all(&project).unwrap();
+    let worktree = tmp
+        .path()
+        .join(".codex/worktrees/ade935ee-48ec-49f4-8e89-ccb0294e73eb/cortex");
+    let e = entry(
+        "codex-transcript",
+        &format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"type\":\"function_call\",\"arguments\":\"{{\\\"cmd\\\":\\\"cargo test\\\",\\\"workdir\\\":\\\"{}\\\"}}\"}}}}",
+            worktree.display()
+        ),
+        "10.0.0.1:1",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.ai_tool.as_deref(), Some("codex"));
+    assert_eq!(out.ai_project.as_deref(), Some(worktree.to_str().unwrap()));
+}
+
+#[test]
+fn enriches_codex_workdir_keeps_codex_app_worktree_when_workspace_project_missing() {
+    let cfg = EnrichmentConfig::default();
+    let tmp = tempfile::tempdir().unwrap();
+    let worktree = tmp
+        .path()
+        .join(".codex/worktrees/ade935ee-48ec-49f4-8e89-ccb0294e73eb/cortex");
+    let e = entry(
+        "codex-transcript",
+        &format!(
+            "{{\"type\":\"response_item\",\"payload\":{{\"type\":\"function_call\",\"arguments\":\"{{\\\"cmd\\\":\\\"cargo test\\\",\\\"workdir\\\":\\\"{}\\\"}}\"}}}}",
+            worktree.display()
+        ),
+        "10.0.0.1:1",
+        "info",
+    );
+    let out = enrich_entry(e, &cfg);
+    assert_eq!(out.ai_tool.as_deref(), Some("codex"));
+    assert_eq!(out.ai_project.as_deref(), Some(worktree.to_str().unwrap()));
+}
+
+#[test]
 fn enriches_claude_project_from_transcript_path_in_raw() {
     let cfg = EnrichmentConfig::default();
     let mut e = entry(
@@ -385,5 +429,40 @@ fn project_from_transcript_path_prefers_sessions_index_original_path() {
     assert_eq!(
         project_from_transcript_path(transcript.to_str().unwrap()).as_deref(),
         Some(project.to_str().unwrap())
+    );
+}
+
+#[test]
+fn project_from_transcript_path_normalizes_sessions_index_worktree_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("workspace/cortex");
+    let worktree = project.join(".claude/worktrees/session-indexing");
+    fs::create_dir_all(&worktree).unwrap();
+
+    let transcript_dir = tmp.path().join(".claude/projects/-tmp-cortex");
+    fs::create_dir_all(&transcript_dir).unwrap();
+    fs::write(
+        transcript_dir.join("sessions-index.json"),
+        format!(
+            "{{\"version\":1,\"entries\":[{{\"projectPath\":\"{}\"}}]}}",
+            worktree.display()
+        ),
+    )
+    .unwrap();
+
+    let transcript = transcript_dir.join("session-123.jsonl");
+    assert_eq!(
+        project_from_transcript_path(transcript.to_str().unwrap()).as_deref(),
+        Some(project.to_str().unwrap())
+    );
+}
+
+#[test]
+fn project_from_transcript_path_normalizes_decoded_claude_worktree_fallback() {
+    let transcript = "/home/jmagar/.claude/projects/-home-jmagar-workspace-cortex-.claude-worktrees-session-indexing/session-123.jsonl";
+
+    assert_eq!(
+        project_from_transcript_path(transcript).as_deref(),
+        Some("/home/jmagar/workspace/cortex")
     );
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -6,12 +6,11 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 
+use crate::ai_project::normalize_local_ai_project_path;
 use crate::config::StorageConfig;
 use crate::db::{DbPool, LogBatchEntry, enforce_storage_budget, insert_logs_batch_in_tx};
 use crate::ingest_metadata::bounded_metadata_json;
-use crate::receiver::enrichment::{
-    normalize_ai_project_path, project_from_transcript_path, scrub_ai_message,
-};
+use crate::receiver::enrichment::{project_from_transcript_path, scrub_ai_message};
 
 mod checkpoint;
 mod claude;
@@ -287,6 +286,7 @@ fn is_known_transcript_root(path: &Path) -> bool {
     let allowed = [
         home.join(".claude/projects"),
         home.join(".codex/sessions"),
+        home.join(".codex/worktrees"),
         home.join(".gemini/tmp"),
     ];
     allowed
@@ -483,6 +483,7 @@ pub fn index_file_with_options(
     let mut imports = Vec::new();
     let mut batch = Vec::new();
     let mut chunk_bytes = 0usize;
+    let mut project_normalizer = ProjectNormalizer::default();
     let file = fs::File::open(&canonical_path)?;
     let mut reader = BufReader::new(file);
     let mut hasher = Sha256::new();
@@ -540,7 +541,7 @@ pub fn index_file_with_options(
                     .ai_project
                     .as_deref()
                     .or(fallback_project.as_deref())
-                    .map(normalize_ai_project_path);
+                    .map(|project| project_normalizer.normalize(project));
                 let project = accept_metadata_field(
                     project_candidate.as_deref(),
                     MAX_AI_PROJECT_CHARS,
@@ -927,7 +928,7 @@ fn looks_like_codex_record(line: &str) -> bool {
 
 fn detect_source_kind(path: &Path) -> SourceKind {
     let display = path.to_string_lossy();
-    if display.contains(".codex/sessions") {
+    if display.contains(".codex/sessions") || display.contains(".codex/worktrees") {
         SourceKind::CodexSession
     } else if display.contains(".gemini/tmp") {
         SourceKind::GeminiSession
@@ -985,7 +986,7 @@ fn project_for_file(source_kind: SourceKind, path: &Path) -> Option<String> {
         SourceKind::GeminiSession => None,
         SourceKind::ExplicitFile => std::env::current_dir()
             .ok()
-            .map(|path| normalize_ai_project_path(&path.to_string_lossy())),
+            .map(|path| normalize_local_ai_project_path(&path.to_string_lossy())),
     }
 }
 
@@ -999,10 +1000,26 @@ fn update_codex_fallbacks(
         return;
     }
     if let Some(project) = codex::project_from_line(line) {
-        *fallback_project = Some(normalize_ai_project_path(&project));
+        *fallback_project = Some(project);
     }
     if let Some(session_id) = codex::session_id_from_line(line) {
         *fallback_session_id = Some(session_id);
+    }
+}
+
+#[derive(Default)]
+struct ProjectNormalizer {
+    cache: HashMap<String, String>,
+}
+
+impl ProjectNormalizer {
+    fn normalize(&mut self, project: &str) -> String {
+        if let Some(normalized) = self.cache.get(project) {
+            return normalized.clone();
+        }
+        let normalized = normalize_local_ai_project_path(project);
+        self.cache.insert(project.to_string(), normalized.clone());
+        normalized
     }
 }
 
@@ -1048,6 +1065,7 @@ fn index_gemini_file(
     let mut chunk_bytes = 0usize;
     let host = local_hostname();
     let tool = SourceKind::GeminiSession.tool_name();
+    let mut project_normalizer = ProjectNormalizer::default();
     for (record_index, record) in parsed.records.into_iter().enumerate() {
         // A single malformed timestamp must not abort the whole file. Treat it
         // like the JSONL per-line path: record the error, skip the record, keep
@@ -1068,7 +1086,10 @@ fn index_gemini_file(
         };
         let record_key = record.record_key;
         let message = scrub_ai_message(&record.message, None);
-        let project_candidate = record.ai_project.as_deref().map(normalize_ai_project_path);
+        let project_candidate = record
+            .ai_project
+            .as_deref()
+            .map(|project| project_normalizer.normalize(project));
         let project = accept_metadata_field(
             project_candidate.as_deref(),
             MAX_AI_PROJECT_CHARS,
@@ -1388,6 +1409,7 @@ fn default_roots() -> Vec<PathBuf> {
             vec![
                 home.join(".claude/projects"),
                 home.join(".codex/sessions"),
+                home.join(".codex/worktrees"),
                 home.join(".gemini/tmp"),
             ]
         })

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -9,7 +9,9 @@ use sha2::{Digest, Sha256};
 use crate::config::StorageConfig;
 use crate::db::{DbPool, LogBatchEntry, enforce_storage_budget, insert_logs_batch_in_tx};
 use crate::ingest_metadata::bounded_metadata_json;
-use crate::receiver::enrichment::{project_from_transcript_path, scrub_ai_message};
+use crate::receiver::enrichment::{
+    normalize_ai_project_path, project_from_transcript_path, scrub_ai_message,
+};
 
 mod checkpoint;
 mod claude;
@@ -534,8 +536,13 @@ pub fn index_file_with_options(
             Ok(Some(parsed)) => {
                 let record_key = parsed.record_key;
                 let message = scrub_ai_message(&parsed.message, None);
+                let project_candidate = parsed
+                    .ai_project
+                    .as_deref()
+                    .or(fallback_project.as_deref())
+                    .map(normalize_ai_project_path);
                 let project = accept_metadata_field(
-                    parsed.ai_project.as_deref().or(fallback_project.as_deref()),
+                    project_candidate.as_deref(),
                     MAX_AI_PROJECT_CHARS,
                     "ai_project",
                     &canonical,
@@ -978,7 +985,7 @@ fn project_for_file(source_kind: SourceKind, path: &Path) -> Option<String> {
         SourceKind::GeminiSession => None,
         SourceKind::ExplicitFile => std::env::current_dir()
             .ok()
-            .map(|path| path.to_string_lossy().to_string()),
+            .map(|path| normalize_ai_project_path(&path.to_string_lossy())),
     }
 }
 
@@ -992,7 +999,7 @@ fn update_codex_fallbacks(
         return;
     }
     if let Some(project) = codex::project_from_line(line) {
-        *fallback_project = Some(project);
+        *fallback_project = Some(normalize_ai_project_path(&project));
     }
     if let Some(session_id) = codex::session_id_from_line(line) {
         *fallback_session_id = Some(session_id);
@@ -1061,8 +1068,9 @@ fn index_gemini_file(
         };
         let record_key = record.record_key;
         let message = scrub_ai_message(&record.message, None);
+        let project_candidate = record.ai_project.as_deref().map(normalize_ai_project_path);
         let project = accept_metadata_field(
-            record.ai_project.as_deref(),
+            project_candidate.as_deref(),
             MAX_AI_PROJECT_CHARS,
             "ai_project",
             canonical,

--- a/src/scanner_tests.rs
+++ b/src/scanner_tests.rs
@@ -839,6 +839,103 @@ fn index_file_uses_session_meta_for_codex_response_items() {
 }
 
 #[test]
+fn index_file_normalizes_codex_project_local_worktree_cwd() {
+    let (pool, dir) = test_pool();
+    let project = dir.path().join("workspace/cortex");
+    std::fs::create_dir_all(&project).unwrap();
+    let file = dir.path().join("rollout-worktree.jsonl");
+    let worktree = project.join(".worktrees/session-indexing");
+    std::fs::write(
+        &file,
+        format!(
+            "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"worktree-session\",\"cwd\":\"{}\"}}}}\n\
+             {{\"type\":\"response_item\",\"payload\":{{\"content\":[{{\"type\":\"output_text\",\"text\":\"worktree normalized\"}}]}},\"timestamp\":\"2026-05-11T00:00:00Z\"}}\n",
+            worktree.display()
+        ),
+    )
+    .unwrap();
+
+    let result = index_file(&pool, &file, "codex_session").unwrap();
+    assert_eq!(result.ingested, 1);
+    let search = search_ai_sessions(
+        &pool,
+        &SearchAiSessionsParams {
+            query: "normalized".into(),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(search.sessions[0].ai_project, project.to_string_lossy());
+}
+
+#[test]
+fn index_file_normalizes_claude_project_local_worktree_cwd() {
+    let (pool, dir) = test_pool();
+    let project = dir.path().join("workspace/cortex");
+    std::fs::create_dir_all(&project).unwrap();
+    let file = dir.path().join("claude-worktree.jsonl");
+    let worktree = project.join(".claude/worktrees/session-indexing");
+    std::fs::write(
+        &file,
+        format!(
+            "{{\"session_id\":\"claude-worktree\",\"cwd\":\"{}\",\"content\":\"claude worktree normalized\",\"timestamp\":\"2026-05-11T00:00:00Z\"}}\n",
+            worktree.display()
+        ),
+    )
+    .unwrap();
+
+    let result = index_file(&pool, &file, "claude_project").unwrap();
+    assert_eq!(result.ingested, 1);
+    let search = search_ai_sessions(
+        &pool,
+        &SearchAiSessionsParams {
+            query: "\"claude worktree\"".into(),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(search.sessions[0].ai_tool, "claude");
+    assert_eq!(search.sessions[0].ai_project, project.to_string_lossy());
+}
+
+#[test]
+#[serial]
+fn index_file_normalizes_codex_app_worktree_cwd_to_workspace_project() {
+    let (pool, dir) = test_pool();
+    let _home = HomeOverride::set(dir.path());
+    let project = dir.path().join("workspace/cortex");
+    std::fs::create_dir_all(&project).unwrap();
+    let file = dir.path().join("rollout-codex-app-worktree.jsonl");
+    let worktree = dir
+        .path()
+        .join(".codex/worktrees/ade935ee-48ec-49f4-8e89-ccb0294e73eb/cortex");
+    std::fs::write(
+        &file,
+        format!(
+            "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"codex-app-worktree\",\"cwd\":\"{}\"}}}}\n\
+             {{\"type\":\"response_item\",\"payload\":{{\"content\":[{{\"type\":\"output_text\",\"text\":\"codex app worktree normalized\"}}]}},\"timestamp\":\"2026-05-11T00:00:00Z\"}}\n",
+            worktree.display()
+        ),
+    )
+    .unwrap();
+
+    let result = index_file(&pool, &file, "codex_session").unwrap();
+    assert_eq!(result.ingested, 1);
+    let search = search_ai_sessions(
+        &pool,
+        &SearchAiSessionsParams {
+            query: "\"codex app worktree\"".into(),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(search.sessions[0].ai_project, project.to_string_lossy());
+}
+
+#[test]
 fn explicit_file_detects_codex_transcript_shape_outside_codex_root() {
     let (pool, dir) = test_pool();
     let file = dir.path().join("exported-codex.jsonl");

--- a/src/scanner_tests.rs
+++ b/src/scanner_tests.rs
@@ -13,6 +13,17 @@ fn test_pool() -> (crate::db::DbPool, tempfile::TempDir) {
     (pool, dir)
 }
 
+fn write_codex_app_worktree_git_pointer(worktree: &std::path::Path, project: &std::path::Path) {
+    std::fs::create_dir_all(worktree).unwrap();
+    let gitdir = project.join(".git/worktrees/codex-app");
+    std::fs::create_dir_all(&gitdir).unwrap();
+    std::fs::write(
+        worktree.join(".git"),
+        format!("gitdir: {}\n", gitdir.display()),
+    )
+    .unwrap();
+}
+
 #[test]
 fn index_file_is_idempotent() {
     let (pool, dir) = test_pool();
@@ -708,7 +719,7 @@ fn rewritten_file_falls_back_to_duplicate_safe_full_scan() {
 
 #[test]
 #[serial]
-fn index_roots_default_scans_claude_codex_and_gemini_roots() {
+fn index_roots_default_scans_claude_codex_codex_app_and_gemini_roots() {
     let (pool, dir) = test_pool();
     let _home = HomeOverride::set(dir.path());
 
@@ -736,6 +747,21 @@ fn index_roots_default_scans_claude_codex_and_gemini_roots() {
     )
     .unwrap();
 
+    let codex_app_project = dir.path().join("workspace/cortex");
+    let codex_app_root = dir
+        .path()
+        .join(".codex/worktrees/ade935ee-48ec-49f4-8e89-ccb0294e73eb/cortex");
+    write_codex_app_worktree_git_pointer(&codex_app_root, &codex_app_project);
+    std::fs::write(
+        codex_app_root.join("rollout-codex-app-default.jsonl"),
+        format!(
+            "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"codex-app-default\",\"cwd\":\"{}\"}}}}\n\
+             {{\"type\":\"response_item\",\"payload\":{{\"content\":[{{\"text\":\"default codex app worktree\"}}]}},\"timestamp\":\"2026-05-13T00:00:00Z\"}}\n",
+            codex_app_root.display()
+        ),
+    )
+    .unwrap();
+
     let gemini_root = dir.path().join(".gemini/tmp/hash/chats");
     std::fs::create_dir_all(&gemini_root).unwrap();
     std::fs::write(
@@ -758,8 +784,8 @@ fn index_roots_default_scans_claude_codex_and_gemini_roots() {
 
     let result = index_roots(&pool, None).unwrap();
 
-    assert_eq!(result.discovered_files, 3);
-    assert_eq!(result.ingested, 3);
+    assert_eq!(result.discovered_files, 4);
+    assert_eq!(result.ingested, 4);
     let claude = search_ai_sessions(
         &pool,
         &SearchAiSessionsParams {
@@ -775,7 +801,7 @@ fn index_roots_default_scans_claude_codex_and_gemini_roots() {
     let codex = search_ai_sessions(
         &pool,
         &SearchAiSessionsParams {
-            query: "codex".into(),
+            query: "\"default codex root\"".into(),
             limit: Some(10),
             ..Default::default()
         },
@@ -784,6 +810,22 @@ fn index_roots_default_scans_claude_codex_and_gemini_roots() {
     assert_eq!(codex.sessions[0].ai_tool, "codex");
     assert_eq!(codex.sessions[0].ai_project, "/tmp/default-codex");
     assert_eq!(codex.sessions[0].ai_session_id, "codex-default");
+
+    let codex_app = search_ai_sessions(
+        &pool,
+        &SearchAiSessionsParams {
+            query: "\"default codex app worktree\"".into(),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(codex_app.sessions[0].ai_tool, "codex");
+    assert_eq!(
+        codex_app.sessions[0].ai_project,
+        codex_app_project.to_string_lossy()
+    );
+    assert_eq!(codex_app.sessions[0].ai_session_id, "codex-app-default");
 
     let (gemini_tool, gemini_session): (String, String) = pool
         .get()
@@ -808,6 +850,18 @@ fn index_roots_default_scans_claude_codex_and_gemini_roots() {
     .unwrap();
     assert_eq!(gemini_sessions.len(), 1);
     assert_eq!(gemini_sessions[0].ai_session_id, "gemini-default");
+}
+
+#[test]
+#[serial]
+fn validate_transcript_scan_path_allows_codex_app_worktree_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let _home = HomeOverride::set(dir.path());
+    let worktrees = dir.path().join(".codex/worktrees");
+    std::fs::create_dir_all(&worktrees).unwrap();
+
+    let canonical = validate_transcript_scan_path(&worktrees).unwrap();
+    assert_eq!(canonical, worktrees.canonicalize().unwrap());
 }
 
 #[test]
@@ -911,6 +965,7 @@ fn index_file_normalizes_codex_app_worktree_cwd_to_workspace_project() {
     let worktree = dir
         .path()
         .join(".codex/worktrees/ade935ee-48ec-49f4-8e89-ccb0294e73eb/cortex");
+    write_codex_app_worktree_git_pointer(&worktree, &project);
     std::fs::write(
         &file,
         format!(
@@ -932,6 +987,111 @@ fn index_file_normalizes_codex_app_worktree_cwd_to_workspace_project() {
         },
     )
     .unwrap();
+    assert_eq!(search.sessions[0].ai_project, project.to_string_lossy());
+}
+
+#[test]
+#[serial]
+fn index_file_keeps_codex_app_worktree_when_workspace_project_missing() {
+    let (pool, dir) = test_pool();
+    let _home = HomeOverride::set(dir.path());
+    let file = dir.path().join("rollout-codex-app-worktree-missing.jsonl");
+    let worktree = dir
+        .path()
+        .join(".codex/worktrees/ade935ee-48ec-49f4-8e89-ccb0294e73eb/cortex");
+    std::fs::write(
+        &file,
+        format!(
+            "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"codex-app-worktree-missing\",\"cwd\":\"{}\"}}}}\n\
+             {{\"type\":\"response_item\",\"payload\":{{\"content\":[{{\"type\":\"output_text\",\"text\":\"codex app worktree fallback\"}}]}},\"timestamp\":\"2026-05-11T00:00:00Z\"}}\n",
+            worktree.display()
+        ),
+    )
+    .unwrap();
+
+    let result = index_file(&pool, &file, "codex_session").unwrap();
+    assert_eq!(result.ingested, 1);
+    let search = search_ai_sessions(
+        &pool,
+        &SearchAiSessionsParams {
+            query: "\"codex app worktree fallback\"".into(),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(search.sessions[0].ai_project, worktree.to_string_lossy());
+}
+
+#[test]
+#[serial]
+fn explicit_file_normalizes_current_dir_worktree_project() {
+    let (pool, dir) = test_pool();
+    let project = dir.path().join("workspace/cortex");
+    let worktree = project.join(".worktrees/session-indexing");
+    std::fs::create_dir_all(&worktree).unwrap();
+    let _cwd = CurrentDirGuard::set(&worktree);
+    let file = dir.path().join("explicit-claude.jsonl");
+    std::fs::write(
+        &file,
+        "{\"sessionId\":\"explicit-worktree\",\"content\":\"explicit worktree normalized\",\"timestamp\":\"2026-05-11T00:00:00Z\"}\n",
+    )
+    .unwrap();
+
+    let result = index_file(&pool, &file, "explicit_file").unwrap();
+    assert_eq!(result.ingested, 1);
+    let search = search_ai_sessions(
+        &pool,
+        &SearchAiSessionsParams {
+            query: "\"explicit worktree\"".into(),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(search.sessions[0].ai_project, project.to_string_lossy());
+}
+
+#[test]
+fn index_file_normalizes_gemini_cwd_worktree_project() {
+    let (pool, dir) = test_pool();
+    let project = dir.path().join("workspace/cortex");
+    let worktree = project.join(".worktrees/session-indexing");
+    std::fs::create_dir_all(&worktree).unwrap();
+    let file = dir.path().join("session-2026-04-02T22-02-da13.json");
+    std::fs::write(
+        &file,
+        format!(
+            r#"{{
+              "sessionId": "gemini-worktree",
+              "cwd": "{}",
+              "startTime": "2026-04-02T22:02:55.537Z",
+              "messages": [
+                {{
+                  "id": "gemini-worktree-message",
+                  "timestamp": "2026-04-02T22:03:29.818Z",
+                  "type": "gemini",
+                  "content": "gemini worktree normalized"
+                }}
+              ]
+            }}"#,
+            worktree.display()
+        ),
+    )
+    .unwrap();
+
+    let result = index_file(&pool, &file, "gemini_session").unwrap();
+    assert_eq!(result.ingested, 1);
+    let search = search_ai_sessions(
+        &pool,
+        &SearchAiSessionsParams {
+            query: "\"gemini worktree\"".into(),
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(search.sessions[0].ai_tool, "gemini");
     assert_eq!(search.sessions[0].ai_project, project.to_string_lossy());
 }
 
@@ -1128,6 +1288,22 @@ impl Drop for HomeOverride {
             // TODO: Audit that the environment access only happens in single-threaded code.
             unsafe { std::env::remove_var("HOME") };
         }
+    }
+}
+
+struct CurrentDirGuard(std::path::PathBuf);
+
+impl CurrentDirGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let previous = std::env::current_dir().unwrap();
+        std::env::set_current_dir(path).unwrap();
+        Self(previous)
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        std::env::set_current_dir(&self.0).unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary
- Normalize AI session project paths from repo-local `.worktrees` and `.claude/worktrees` directories back to the durable project root.
- Normalize Codex app worktrees under `~/.codex/worktrees/<id>/<repo>` to `~/workspace/<repo>`.
- Add regression coverage for Codex, Claude, and Codex app worktree transcript indexing.
- Stabilize env-mutating tests observed during full/pre-push runs.

## Verification
- `cargo build`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `cargo xtask check-version-sync`
- `cargo xtask check-release-versions`
- pre-push `cargo test --all-targets --all-features`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize worktree project paths so transcripts index under the correct repo root, and add default discovery for Codex app worktrees. Scanner resolves `~/.codex/worktrees/<id>/<repo>` to the workspace project (via `.git`) while live enrichment preserves worktree paths; adds tests and bumps to 1.33.4.

- **Bug Fixes**
  - Map repo-local `.worktrees/...` and `.claude/worktrees/...` to the project root across enrichment and scanning.
  - Discover and index `~/.codex/worktrees` by default; in the scanner, resolve these to the workspace project using the `.git` pointer and cache normalization per file, while live enrichment keeps the worktree path.
  - Normalize `ai_project` when reading session meta, function-call `workdir`, decoded Claude project paths, and `sessions-index.json`.
  - Add regression tests for Codex, Claude, and Codex app worktrees; serialize env‑mutating tests; update version refs to `1.33.4`.

- **Dependencies**
  - Update `crypto-bigint` to `0.7.5` in Cargo.lock.

<sup>Written for commit 9c982bbf26fcb290a70e3ae06ba2652221e0dbca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.33.4

* **Bug Fixes**
  * Improved AI project path normalization when working within temporary development worktrees. Project identification now consistently resolves to the root project path rather than temporary directory structures, enhancing accuracy across development tool integrations and ensuring reliable project tracking and metadata indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->