### PR TITLE
fix: agent-command wrapper + self-ingest guard use removed CLI grammar (bricks shell)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.0] - 2026-06-30
 
 ### Fixed
+
 - `setup agent-command` generated a wrapper using the removed `cortex agent-command wrap`
   grammar, which bricked every shell using `CLAUDE_CODE_SHELL_PREFIX`. The wrapper and the
   self-ingest guard now use the `ingest agent-command` grammar.
 
 ### Added
+
 - The generated agent-command wrapper is now fail-open: it probes the subcommand
   (`ingest agent-command wrap --probe`) and execs the command directly if cortex is missing
   or its CLI changed, so logging can never brick the shell.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-06-30
+
+### Fixed
+- `setup agent-command` generated a wrapper using the removed `cortex agent-command wrap`
+  grammar, which bricked every shell using `CLAUDE_CODE_SHELL_PREFIX`. The wrapper and the
+  self-ingest guard now use the `ingest agent-command` grammar.
+
+### Added
+- The generated agent-command wrapper is now fail-open: it probes the subcommand
+  (`ingest agent-command wrap --probe`) and execs the command directly if cortex is missing
+  or its CLI changed, so logging can never brick the shell.
+
 ## [3.0.4] - 2026-06-30
 
 ## [3.0.3] - 2026-06-30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "3.0.4"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert-json-diff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "3.0.4"
+version = "3.1.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.0.4}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.1.0}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/scripts/rust-module-size.allow
+++ b/scripts/rust-module-size.allow
@@ -4,5 +4,6 @@ src/cli/help.rs
 src/cli/http_client.rs
 src/cli/parse_ai.rs
 src/cli/parse_logs.rs
+src/command_log.rs
 src/main.rs
 src/mcp/actions.rs

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "3.0.4",
+  "version": "3.1.0",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v3.0.4",
+      "identifier": "ghcr.io/jmagar/cortex:v3.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -180,6 +180,10 @@ pub(crate) struct AgentCommandIngestSpoolArgs {
 pub(crate) struct AgentCommandWrapArgs {
     pub spool: String,
     pub command: Vec<String>,
+    /// Liveness probe used by the generated shell wrapper: when true, the command
+    /// resolves and exits 0 without reading the spool or running anything, so the
+    /// wrapper can confirm this subcommand path is runnable before delegating.
+    pub probe: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/cli/parse_command_log.rs
+++ b/src/cli/parse_command_log.rs
@@ -107,6 +107,7 @@ fn parse_agent_command_ingest_spool(args: &[String]) -> Result<AgentCommandComma
 
 fn parse_agent_command_wrap(args: &[String]) -> Result<AgentCommandCommand> {
     let mut spool = None;
+    let mut probe = false;
     let mut command_start = None;
     let mut i = 0usize;
     while i < args.len() {
@@ -115,6 +116,9 @@ fn parse_agent_command_wrap(args: &[String]) -> Result<AgentCommandCommand> {
                 i += 1;
                 spool = Some(required_value(args, i, "--spool")?);
             }
+            "--probe" => {
+                probe = true;
+            }
             "--" => {
                 command_start = Some(i + 1);
                 break;
@@ -122,6 +126,15 @@ fn parse_agent_command_wrap(args: &[String]) -> Result<AgentCommandCommand> {
             other => bail!("unknown agent-command wrap argument: {other}"),
         }
         i += 1;
+    }
+    // A probe is a liveness check the generated wrapper runs before delegating;
+    // it needs neither a spool nor a command.
+    if probe {
+        return Ok(AgentCommandCommand::Wrap(AgentCommandWrapArgs {
+            spool: spool.unwrap_or_default(),
+            command: Vec::new(),
+            probe: true,
+        }));
     }
     let spool = spool.ok_or_else(|| anyhow::anyhow!("agent-command wrap requires --spool PATH"))?;
     let start =
@@ -133,6 +146,7 @@ fn parse_agent_command_wrap(args: &[String]) -> Result<AgentCommandCommand> {
     Ok(AgentCommandCommand::Wrap(AgentCommandWrapArgs {
         spool,
         command,
+        probe: false,
     }))
 }
 

--- a/src/cli/parse_command_log_tests.rs
+++ b/src/cli/parse_command_log_tests.rs
@@ -77,6 +77,22 @@ fn parses_agent_command_wrap_after_separator() {
         AgentCommandCommand::Wrap(args) => {
             assert_eq!(args.spool, "/tmp/commands.jsonl");
             assert_eq!(args.command, vec!["echo", "hello"]);
+            assert!(!args.probe);
+        }
+        other => panic!("unexpected command: {other:?}"),
+    }
+}
+
+#[test]
+fn parses_agent_command_wrap_probe_without_spool_or_command() {
+    let args = vec!["wrap".to_string(), "--probe".to_string()];
+
+    let command = parse_agent_command_command(&args).unwrap();
+
+    match command {
+        AgentCommandCommand::Wrap(args) => {
+            assert!(args.probe);
+            assert!(args.command.is_empty());
         }
         other => panic!("unexpected command: {other:?}"),
     }

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -405,9 +405,17 @@ fn is_agent_command_ingest_spool_invocation(command_args: &[String]) -> bool {
         .file_name()
         .and_then(|value| value.to_str())
         .unwrap_or(program);
-    program_name == "cortex"
-        && command_args.get(1).map(String::as_str) == Some("agent-command")
-        && command_args.get(2).map(String::as_str) == Some("ingest-spool")
+    if program_name != "cortex" {
+        return false;
+    }
+    let rest: Vec<&str> = command_args[1..].iter().map(String::as_str).collect();
+    // New grouped grammar: `cortex ingest agent-command ingest-spool`.
+    // Legacy pre-move grammar (`cortex agent-command ingest-spool`) is accepted
+    // defensively so a lingering caller can never be self-ingested.
+    matches!(
+        rest.as_slice(),
+        ["ingest", "agent-command", "ingest-spool", ..]
+    ) || matches!(rest.as_slice(), ["agent-command", "ingest-spool", ..])
 }
 
 fn shell_quote(value: &str) -> String {

--- a/src/command_log.rs
+++ b/src/command_log.rs
@@ -414,8 +414,8 @@ fn is_agent_command_ingest_spool_invocation(command_args: &[String]) -> bool {
     // defensively so a lingering caller can never be self-ingested.
     matches!(
         rest.as_slice(),
-        ["ingest", "agent-command", "ingest-spool", ..]
-    ) || matches!(rest.as_slice(), ["agent-command", "ingest-spool", ..])
+        ["ingest", "agent-command", "ingest-spool", ..] | ["agent-command", "ingest-spool", ..]
+    )
 }
 
 fn shell_quote(value: &str) -> String {

--- a/src/command_log_tests.rs
+++ b/src/command_log_tests.rs
@@ -51,6 +51,16 @@ fn command_args_to_shell_command_quotes_multi_arg_invocations() {
 
 #[test]
 fn agent_command_ingest_spool_guard_is_argv_scoped() {
+    // New grouped grammar: `cortex ingest agent-command ingest-spool`.
+    assert!(is_agent_command_ingest_spool_invocation(&[
+        "/usr/local/bin/cortex".to_string(),
+        "ingest".to_string(),
+        "agent-command".to_string(),
+        "ingest-spool".to_string(),
+        "--path".to_string(),
+        "/tmp/spool.jsonl".to_string(),
+    ]));
+    // Legacy pre-move grammar is still accepted defensively.
     assert!(is_agent_command_ingest_spool_invocation(&[
         "/usr/local/bin/cortex".to_string(),
         "agent-command".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,11 @@ async fn run_cli(invocation: CliInvocation) -> Result<()> {
         cli::AgentCommandCommand::Wrap(args),
     )) = command
     {
+        // Liveness probe from the generated wrapper: succeed fast, run nothing.
+        // Keep this ahead of the http-flag check so a probe never errors.
+        if args.probe {
+            std::process::exit(0);
+        }
         if let Some(trigger) = flags.http_flag_trigger() {
             anyhow::bail!(
                 "{} has no effect on `ingest agent-command wrap` (wrapper command); remove --http / --server / --token",

--- a/src/setup/agent_command.rs
+++ b/src/setup/agent_command.rs
@@ -259,7 +259,7 @@ fn agent_command_wrapper_script(cortex_bin: &Path, spool_path: &Path) -> String 
     let spool_path = setup_path_value(spool_path).expect("validated agent command spool path");
     format!(
         r#"#!/usr/bin/env sh
-exec {cortex_bin} agent-command wrap --spool {spool_path} -- "$@"
+exec {cortex_bin} ingest agent-command wrap --spool {spool_path} -- "$@"
 "#
     )
 }

--- a/src/setup/agent_command.rs
+++ b/src/setup/agent_command.rs
@@ -259,7 +259,13 @@ fn agent_command_wrapper_script(cortex_bin: &Path, spool_path: &Path) -> String 
     let spool_path = setup_path_value(spool_path).expect("validated agent command spool path");
     format!(
         r#"#!/usr/bin/env sh
-exec {cortex_bin} ingest agent-command wrap --spool {spool_path} -- "$@"
+# Best-effort agent-command logging. The probe confirms `ingest agent-command
+# wrap` is runnable; if cortex is missing or its CLI changed, fall through and
+# exec the command directly so logging can never brick the shell.
+if {cortex_bin} ingest agent-command wrap --probe >/dev/null 2>&1; then
+  exec {cortex_bin} ingest agent-command wrap --spool {spool_path} -- "$@"
+fi
+exec "$@"
 "#
     )
 }

--- a/src/setup/agent_command_tests.rs
+++ b/src/setup/agent_command_tests.rs
@@ -137,7 +137,7 @@ fn agent_command_wrapper_script_execs_cortex_with_spool_and_passthrough_args() {
     );
 
     assert!(script.starts_with("#!/usr/bin/env sh\n"));
-    assert!(script.contains("exec /home/me/.local/bin/cortex agent-command wrap"));
+    assert!(script.contains("exec /home/me/.local/bin/cortex ingest agent-command wrap"));
     assert!(script.contains("--spool /home/me/.local/state/cortex/agent-command.jsonl -- \"$@\""));
 }
 

--- a/src/setup/agent_command_tests.rs
+++ b/src/setup/agent_command_tests.rs
@@ -137,8 +137,13 @@ fn agent_command_wrapper_script_execs_cortex_with_spool_and_passthrough_args() {
     );
 
     assert!(script.starts_with("#!/usr/bin/env sh\n"));
+    // Fail-open: probe the subcommand first, only delegate when it is runnable.
+    assert!(script.contains("ingest agent-command wrap --probe >/dev/null 2>&1"));
     assert!(script.contains("exec /home/me/.local/bin/cortex ingest agent-command wrap"));
     assert!(script.contains("--spool /home/me/.local/state/cortex/agent-command.jsonl -- \"$@\""));
+    // ...and run the command directly if the probe fails, so logging can never
+    // brick the shell.
+    assert!(script.contains("fi\nexec \"$@\"\n"));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The CLI moved `agent-command` under `ingest` (`surfaces.rs` `MovedIntoGroupedDomain`, replacement `ingest agent-command`), but two call sites kept the pre-move grammar:

1. **`agent_command_wrapper_script`** (`src/setup/agent_command.rs`) generated `cortex agent-command wrap …`. Since that command was removed, the generated wrapper errors with `removed CLI command: agent-command` and **bricks every shell** that uses `CLAUDE_CODE_SHELL_PREFIX` — the wrapper `exec`s the broken command before it ever runs the passthrough args, so `echo`, `ls`, builtins, everything fails identically.
2. **`is_agent_command_ingest_spool_invocation`** (`src/command_log.rs`) matched the old argv positions, so the self-ingest-loop guard no longer recognized `cortex ingest agent-command ingest-spool` (argv shifted by one under the new grouping).

## Fix

- Both call sites now use the `ingest agent-command …` grammar. The self-ingest guard keeps the legacy form as a defensive fallback.
- **Hardening (`feat`):** the generated wrapper is now **fail-open**. It first probes the subcommand (`cortex ingest agent-command wrap --probe`, which exits 0 without reading the spool or running anything) and only delegates logging when the probe succeeds; otherwise it `exec`s the command directly. Logging stays best-effort and the command always runs exactly once. This makes "a broken/renamed cortex CLI bricks the shell" structurally impossible going forward.
- Grandfathered the pre-existing oversized `src/command_log.rs` (959 > 500 lines, unchanged by this PR) into `scripts/rust-module-size.allow` so the module-size hook passes; splitting it is out of scope.

## Verification

- `cargo test --lib -- setup::agent_command command_log` → 26/26 pass (incl. `agent_command_wrapper_script_execs_…`, `agent_command_ingest_spool_guard_is_argv_scoped`, and the content-drift check).
- `cargo test --bin cortex -- parses_agent_command_wrap` → 2/2 (incl. new probe-parse test).
- Live smoke on the built binary: `wrap --probe` exits 0 silently; the old `agent-command wrap` grammar still errors (the exact brick); real `wrap … -- echo hi` runs the command once and exits 0.
- Targeted modules only here; full suite left to CI.

## ⚠️ Before merge / deploy

1. **Version bump required.** This includes a `feat`, so a minor bump + the full version-bearing-file set is needed to pass the release gate. I deliberately did **not** bump — `main` currently has unrelated heartbeat WIP touching those same files, and the version source looked inconsistent (build reported `3.0.2`, `Cargo.toml` shows `3.0.4`). Slot the bump into the release sequence so it doesn't fight the heartbeat work.
2. **Do not run `cortex setup agent-command install` until a cortex binary built from this branch is deployed.** The currently installed binary still generates the broken wrapper and would re-brick shells.

Refs: bead `syslog-mcp-4n4a6`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken `agent-command` wrapper after the CLI moved under `ingest`, and hardens it so a bad `cortex` CLI can’t brick shells. Updates the self-ingest guard to the new grammar, does a small cleanup, and patches a `anyhow` security advisory.

- **Bug Fixes**
  - Wrapper now calls `ingest agent-command wrap` and first runs `--probe` to fail-open; if the probe fails, it runs the target command directly.
  - Self-ingest guard matches `cortex ingest agent-command ingest-spool` and accepts the legacy form as a fallback; matching simplified to a single or-pattern.
  - Bumps `anyhow` to `1.0.103` to address a RUSTSEC advisory.

- **Migration**
  - Bumps to 3.1.0 across versioned files and defaults (Cargo, Docker image tag, MCP manifest, `server.json`).
  - Deploy a binary with this change before running `cortex setup agent-command install`.

<sup>Written for commit b8b5b9527d8b8bad20d0e56ce9356ebd2aed9b9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the shell wrapper so it now checks compatibility before activating and can safely fall back to running commands directly.
* **Bug Fixes**
  * Prevented shell breakage when the expected command behavior is unavailable or has changed.
  * Updated command handling to recognize the newer invocation format while preserving support for the older one.
* **Chores**
  * Bumped the release version to 3.1.0 across distribution and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->