### PR TITLE
fix: lock release and deploy automation

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Dispatch release.yml
         if: steps.tag_check.outputs.exists == 'false'
         run: |
-          gh workflow run release.yml --ref "v${{ steps.version.outputs.version }}"
+          gh workflow run release.yml --ref "v${{ steps.version.outputs.version }}" -f publish=true
           echo "Dispatched release.yml for v${{ steps.version.outputs.version }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@ name: release
 # Builds cortex for Linux + Windows, packages with SHA256 checksums, and
 # publishes a GitHub Release with all artifacts attached.
 #
-# Manual dry-run via workflow_dispatch builds everything but skips the Release
-# creation (artifacts are still uploaded to the workflow run for inspection).
+# Manual workflow_dispatch defaults to a dry-run that builds everything but skips
+# Release creation. Pass publish=true only when auto-tag dispatches a real tag
+# release or when intentionally publishing from a tagged ref.
 #
 # NOTE: cortex uses target-dir = ".cache/cargo" in .cargo/config.toml so all
 # artifact paths use .cache/cargo/release/ instead of target/release/.
@@ -13,6 +14,12 @@ on:
   push:
     tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish a GitHub Release for the tagged ref instead of dry-run only"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write   # required to create releases
@@ -93,8 +100,9 @@ jobs:
     name: publish github release
     needs: [cortex-linux, cortex-windows]
     runs-on: ubuntu-latest
-    # Only create a release on real tag pushes; workflow_dispatch is dry-run.
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Tag pushes publish automatically. workflow_dispatch stays dry-run unless
+    # auto-tag (or a human) explicitly passes publish=true on a tagged ref.
+    if: startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || github.event.inputs.publish == 'true')
     permissions:
       contents: write
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-06-30
+
+### Fixed
+
+- Release dispatch now publishes real GitHub Releases when `auto-tag` creates a
+  version tag, instead of running `release.yml` in dry-run mode.
+- Added a local systemd auto-deploy timer for the source-built Cortex Compose
+  stack so the server can fast-forward `main`, rebuild, recreate, and verify
+  itself instead of waiting for manual deploys.
+
 ## [3.1.0] - 2026-06-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "3.1.0"
+version = "3.1.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/config/systemd/cortex-auto-deploy.service
+++ b/config/systemd/cortex-auto-deploy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=cortex local server auto-deploy
+Documentation=https://github.com/jmagar/cortex
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/jmagar/workspace/cortex
+Environment=PATH=/home/jmagar/.local/bin:/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/home/jmagar/workspace/cortex/scripts/auto-deploy.sh

--- a/config/systemd/cortex-auto-deploy.timer
+++ b/config/systemd/cortex-auto-deploy.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run cortex local server auto-deploy
+
+[Timer]
+OnBootSec=2min
+OnCalendar=*:0/5
+RandomizedDelaySec=30s
+Persistent=true
+Unit=cortex-auto-deploy.service
+
+[Install]
+WantedBy=timers.target

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.1.0}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.1.1}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/docs/runbooks/deploy.md
+++ b/docs/runbooks/deploy.md
@@ -25,6 +25,27 @@ curl -sf http://localhost:3100/health
 cortex compose logs --tail 20
 ```
 
+## Automatic Local Deploy
+
+The active dookie deployment is the local source-built Compose stack
+(`docker-compose.yml`, image `cortex-cortex`). GitHub publishes GHCR images, but
+that does not update this local stack by itself. Install the user timer below to
+keep the server aligned with `origin/main`:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp config/systemd/cortex-auto-deploy.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now cortex-auto-deploy.timer
+systemctl --user start cortex-auto-deploy.service
+systemctl --user status cortex-auto-deploy.timer cortex-auto-deploy.service
+```
+
+The service runs `scripts/auto-deploy.sh`: it refuses dirty/non-`main`
+checkouts, fast-forwards from `origin/main`, rebuilds the local image, recreates
+the `cortex` service, waits for `/health`, and verifies the in-container
+`cortex --version` matches `Cargo.toml`.
+
 ## Rollback
 
 Which rollback path applies depends on the compose file in use:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_dir="${CORTEX_AUTO_DEPLOY_REPO:-/home/jmagar/workspace/cortex}"
+lock_file="${CORTEX_AUTO_DEPLOY_LOCK:-/tmp/cortex-auto-deploy.lock}"
+health_url="${CORTEX_AUTO_DEPLOY_HEALTH_URL:-http://localhost:3100/health}"
+
+exec 9>"$lock_file"
+if ! flock -n 9; then
+  echo "cortex auto-deploy: another deploy is already running"
+  exit 0
+fi
+
+cd "$repo_dir"
+
+branch="$(git branch --show-current)"
+if [[ "$branch" != "main" ]]; then
+  echo "cortex auto-deploy: refusing to deploy from branch '$branch' (expected main)"
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "cortex auto-deploy: refusing to deploy from a dirty checkout"
+  git status --short
+  exit 1
+fi
+
+git fetch origin main --tags
+before="$(git rev-parse HEAD)"
+git pull --ff-only
+after="$(git rev-parse HEAD)"
+
+expected_version="$(
+  awk -F'"' '/^version = / { print $2; exit }' Cargo.toml
+)"
+if [[ -z "$expected_version" ]]; then
+  echo "cortex auto-deploy: could not read Cargo.toml version" >&2
+  exit 1
+fi
+
+running_version="$(
+  docker exec cortex cortex --version 2>/dev/null | awk '{print $2}' || true
+)"
+if [[ "$before" == "$after" && "$running_version" == "$expected_version" ]]; then
+  echo "cortex auto-deploy: current at $expected_version"
+  exit 0
+fi
+
+echo "cortex auto-deploy: deploying $expected_version (running=${running_version:-unknown})"
+docker compose build cortex
+docker compose up -d --no-deps --force-recreate cortex
+
+for _ in $(seq 1 24); do
+  if curl -fsS "$health_url" >/dev/null; then
+    deployed="$(docker exec cortex cortex --version 2>/dev/null || true)"
+    if [[ "$deployed" == "cortex $expected_version" ]]; then
+      echo "cortex auto-deploy: deployed $deployed"
+      exit 0
+    fi
+    echo "cortex auto-deploy: health ok but version is '$deployed', expected cortex $expected_version"
+  fi
+  sleep 5
+done
+
+echo "cortex auto-deploy: deployment did not become healthy at $expected_version" >&2
+docker compose ps
+docker compose logs --tail 80 cortex
+exit 1

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "3.1.0",
+  "version": "3.1.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v3.1.0",
+      "identifier": "ghcr.io/jmagar/cortex:v3.1.1",
       "transport": {
         "type": "stdio"
       },

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -50,6 +50,57 @@ fn ci_uses_changed_path_classifier_and_stable_gate() {
     }
 }
 
+#[test]
+fn auto_tag_dispatches_release_as_publish_not_dry_run() {
+    let auto_tag = include_str!("../.github/workflows/auto-tag.yml");
+    let release = include_str!("../.github/workflows/release.yml");
+
+    assert!(
+        auto_tag.contains("gh workflow run release.yml --ref"),
+        "auto-tag must explicitly dispatch release.yml after pushing a tag"
+    );
+    assert!(
+        auto_tag.contains("-f publish=true"),
+        "auto-tag dispatch must request a real publish; workflow_dispatch defaults to dry-run"
+    );
+    assert!(
+        release.contains("publish:") && release.contains("type: boolean"),
+        "release workflow must expose an explicit publish input for workflow_dispatch"
+    );
+    assert!(
+        release.contains("github.event.inputs.publish == 'true'"),
+        "release publish job must run for tagged workflow_dispatch when publish=true"
+    );
+}
+
+#[test]
+fn local_cortex_server_has_auto_deploy_timer_contract() {
+    let service = include_str!("../config/systemd/cortex-auto-deploy.service");
+    let timer = include_str!("../config/systemd/cortex-auto-deploy.timer");
+    let script = include_str!("../scripts/auto-deploy.sh");
+
+    assert!(
+        service.contains("ExecStart=") && service.contains("scripts/auto-deploy.sh"),
+        "auto-deploy service must execute the repo-owned deploy script"
+    );
+    assert!(
+        timer.contains("OnCalendar=") && timer.contains("cortex-auto-deploy.service"),
+        "auto-deploy timer must schedule the service"
+    );
+    for required in [
+        "git pull --ff-only",
+        "docker compose build cortex",
+        "docker compose up -d --no-deps --force-recreate cortex",
+        "curl -fsS",
+        "docker exec cortex cortex --version",
+    ] {
+        assert!(
+            script.contains(required),
+            "auto-deploy script must contain {required:?}"
+        );
+    }
+}
+
 fn workflow_job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {
     let marker = format!("  {job_name}:");
     let start = workflow


### PR DESCRIPTION
## Summary
- make auto-tag dispatch release.yml with publish=true so tagged releases publish assets instead of dry-running
- add a local Cortex auto-deploy script plus user systemd service/timer for the active source-built Compose stack
- add workflow-shape tests that lock both automation contracts
- bump Cortex to 3.1.1

## Verification
- RUSTC_WRAPPER='' cargo test --test ci_changed_paths --test workflow_shapes --config 'build.rustc-wrapper=""' --locked
- cargo xtask check-release-versions
- actionlint .github/workflows/auto-tag.yml .github/workflows/release.yml .github/workflows/docker-publish.yml
- bash -n scripts/auto-deploy.sh
- systemd-analyze verify --user config/systemd/cortex-auto-deploy.service config/systemd/cortex-auto-deploy.timer
- RUSTC_WRAPPER='' cargo fmt -- --check
- pre-push hook: version-sync, module-size, clippy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release automation so tagged versions publish assets and adds a local auto-deploy to keep the source-built stack current. Bumps `cortex` to 3.1.1 and updates images/manifests.

- **Bug Fixes**
  - `auto-tag.yml` now dispatches `release.yml` with `publish=true` so real tags create GitHub Releases.
  - `release.yml` adds a `publish` input and guards: workflow_dispatch stays dry-run unless `publish=true` on a tagged ref.

- **New Features**
  - Local auto-deploy: adds `scripts/auto-deploy.sh` plus user `systemd` service/timer to fast-forward `main`, rebuild/recreate the Compose service, health-check, and verify version (with a lock to prevent overlap). Docs updated with install steps.
  - Tests lock the automation contracts: workflow dispatch behavior and the auto-deploy script/service/timer shape.

<sup>Written for commit 247d9dcd740e6410c15b5e384cab6378ddedbcd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic local deployment support so the app can refresh itself from the latest main branch on a schedule.
  * Added a new release workflow option for manual runs that supports an explicit publish mode.

* **Bug Fixes**
  * Fixed release tagging so version tags now create real published releases instead of dry runs.
  * Updated version references across build, deploy, and packaging configs to 3.1.1.

* **Documentation**
  * Added deployment runbook guidance for the new local auto-deploy setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->