### PR TITLE
fix: avoid tag conflicts in auto deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.2] - 2026-06-30
+
+### Fixed
+
+- Auto-deploy now fetches `origin/main` without fetching tags, so stale local
+  tag conflicts cannot block the server update path.
+
 ## [3.1.1] - 2026-06-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.1.1}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.1.2}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -25,7 +25,7 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-git fetch origin main --tags
+git fetch --no-tags origin main
 before="$(git rev-parse HEAD)"
 git pull --ff-only
 after="$(git rev-parse HEAD)"

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "3.1.1",
+  "version": "3.1.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v3.1.1",
+      "identifier": "ghcr.io/jmagar/cortex:v3.1.2",
       "transport": {
         "type": "stdio"
       },

--- a/tests/workflow_shapes.rs
+++ b/tests/workflow_shapes.rs
@@ -88,6 +88,7 @@ fn local_cortex_server_has_auto_deploy_timer_contract() {
         "auto-deploy timer must schedule the service"
     );
     for required in [
+        "git fetch --no-tags origin main",
         "git pull --ff-only",
         "docker compose build cortex",
         "docker compose up -d --no-deps --force-recreate cortex",
@@ -99,6 +100,10 @@ fn local_cortex_server_has_auto_deploy_timer_contract() {
             "auto-deploy script must contain {required:?}"
         );
     }
+    assert!(
+        !script.contains("--tags"),
+        "auto-deploy must not fetch tags; stale local tag conflicts must not block deploy"
+    );
 }
 
 fn workflow_job_block<'a>(workflow: &'a str, job_name: &str) -> &'a str {


### PR DESCRIPTION
## Summary
- make the auto-deploy script fetch origin/main without fetching tags, avoiding stale local tag conflicts
- add a workflow-shape regression assertion that auto-deploy remains decoupled from tag fetches
- bump Cortex to 3.1.2

## Verification
- RUSTC_WRAPPER='' cargo test --test workflow_shapes --config 'build.rustc-wrapper=""' --locked
- cargo xtask check-release-versions
- bash -n scripts/auto-deploy.sh
- git diff --check
- RUSTC_WRAPPER='' cargo fmt -- --check
- pre-push hook: version-sync, module-size, clippy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-deploy now fetches `origin/main` without tags to avoid stale tag conflicts that could block updates. Adds a regression test to enforce this behavior and updates `cortex` to 3.1.2.

- **Bug Fixes**
  - Changed `scripts/auto-deploy.sh` to run `git fetch --no-tags origin main`.
  - Added a workflow shape test to assert no `--tags` usage and require `--no-tags`.

- **Dependencies**
  - Bumped `cortex` to `3.1.2` and updated image/manifest/version references.

<sup>Written for commit 163ec3e5428ec1e823436725f0f2bbaac232655e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

