### PR TITLE
fix: make agent self-update backups unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.3] - 2026-06-30
+
+### Fixed
+
+- Agent self-update now writes rollback backups to unique paths, so stale
+  backup filenames cannot wedge an otherwise valid retry.
+
 ## [3.1.2] - 2026-06-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "3.1.2"
+version = "3.1.3"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.1.2}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.1.3}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "3.1.2",
+  "version": "3.1.3",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v3.1.2",
+      "identifier": "ghcr.io/jmagar/cortex:v3.1.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/agent/self_update.rs
+++ b/src/agent/self_update.rs
@@ -153,11 +153,7 @@ pub async fn maybe_update(
     }
 
     // 5. Keep a rollback copy of the current binary, then atomically swap.
-    let bak = dir.join(format!("cortex.bak-{current}"));
-    let _ = std::fs::remove_file(&bak);
-    std::fs::hard_link(&exe, &bak)
-        .or_else(|_| std::fs::copy(&exe, &bak).map(|_| ()))
-        .with_context(|| format!("back up current binary to {bak:?}"))?;
+    let bak = backup_current_binary(&exe, &dir, current)?;
 
     // Record the in-flight update before the swap so a boot-crash is recoverable.
     write_marker(
@@ -177,6 +173,39 @@ pub async fn maybe_update(
         "agent binary updated; re-executing"
     );
     reexec(&exe)
+}
+
+fn backup_current_binary(exe: &Path, dir: &Path, current: &str) -> Result<PathBuf> {
+    let base = unique_backup_path_base(dir, current);
+    for attempt in 0..100 {
+        let bak = if attempt == 0 {
+            base.clone()
+        } else {
+            dir.join(format!(
+                "{}-{attempt}",
+                base.file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("cortex.bak")
+            ))
+        };
+        match std::fs::hard_link(exe, &bak).or_else(|_| std::fs::copy(exe, &bak).map(|_| ())) {
+            Ok(()) => return Ok(bak),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| format!("back up current binary to {bak:?}"));
+            }
+        }
+    }
+    bail!("could not allocate a unique backup path for agent self-update")
+}
+
+fn unique_backup_path_base(dir: &Path, current: &str) -> PathBuf {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id();
+    dir.join(format!("cortex.bak-{current}-{pid}-{now}"))
 }
 
 /// Confirm a just-installed update is healthy, or roll back if it never settled.

--- a/src/agent/self_update_tests.rs
+++ b/src/agent/self_update_tests.rs
@@ -78,6 +78,27 @@ fn read_marker_absent_returns_none() {
     assert!(read_marker(&dir.path().join("nope.json")).is_none());
 }
 
+#[test]
+fn backup_current_binary_uses_unique_backup_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let exe = dir.path().join("cortex");
+    std::fs::write(&exe, b"current").unwrap();
+    std::fs::write(dir.path().join("cortex.bak-3.1.0"), b"stale").unwrap();
+
+    let first = backup_current_binary(&exe, dir.path(), "3.1.0").unwrap();
+    let second = backup_current_binary(&exe, dir.path(), "3.1.0").unwrap();
+
+    assert_ne!(first, dir.path().join("cortex.bak-3.1.0"));
+    assert_ne!(second, dir.path().join("cortex.bak-3.1.0"));
+    assert_ne!(first, second);
+    assert_eq!(std::fs::read(first).unwrap(), b"current");
+    assert_eq!(std::fs::read(second).unwrap(), b"current");
+    assert_eq!(
+        std::fs::read(dir.path().join("cortex.bak-3.1.0")).unwrap(),
+        b"stale"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn validate_binary_accepts_matching_version_and_rejects_mismatch() {


### PR DESCRIPTION
## Summary
- make agent self-update rollback backups use unique paths instead of a fixed cortex.bak-<version> name
- add regression coverage for stale backup-name collisions
- bump Cortex to 3.1.3 with changelog entry

## Verification
- cargo xtask check-release-versions
- RUSTC_WRAPPER='' cargo test agent::self_update --config 'build.rustc-wrapper=""' --locked
- RUSTC_WRAPPER='' cargo fmt -- --check
- git diff --check
- pre-push: version-sync, module-size, clippy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make agent self-update write backups to unique paths to prevent stale filename collisions and failed rollbacks. Also bumps `cortex` to 3.1.3 and updates related manifests.

- **Bug Fixes**
  - Backups now use unique names (PID + timestamp) and retry allocation to avoid collisions.
  - Added a regression test to ensure stale `cortex.bak-<version>` files don’t block retries.

- **Dependencies**
  - Bump `cortex` to `3.1.3`; update Cargo files, Docker image tag, MCP bundle manifest, server manifest, and changelog.

<sup>Written for commit d80c9832a808cc299260cce1aacdf49bc72fd195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

