### PR TITLE
fix: Copilot review follow-ups from PR #106 (LLM invocation guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.2] - 2026-07-01
+
+### Fixed
+
+- GitHub Copilot PR review fixes for the `llm_invocations` retention/circuit-breaker/background-enrichment work (PR #106):
+  - `purge_old_llm_invocations` now formats its retention cutoff with millisecond fractional-second precision (matching `started_at`'s `strftime('%Y-%m-%dT%H:%M:%fZ','now')` format), instead of a coarser `%Y-%m-%dT%H:%M:%SZ` cutoff. The prior cutoff format could misorder rows within the same wall-clock second under lexicographic string comparison, since a shorter cutoff string does not compare consistently against a longer, fractional-seconds `started_at` value.
+  - `LlmRunnerError::CircuitOpen`'s `retry_after` field now reports the number of seconds remaining until the circuit closes (e.g. `"47s"`) instead of `Instant`'s opaque, platform-dependent Debug output, which was not actionable for a caller trying to know how long to wait.
+  - `LlmRunner::run`'s enablement check now gates `background_enrichment_enabled` on `spec.caller_surface == LlmCallerSurface::Background`, matching its documented contract, in addition to the existing `action == "background_enrich"` name check (kept as defense in depth). Previously a Background-surface call under a different action name could bypass the background-enrichment kill switch entirely.
+  - MCP schema: the `status` field description for `action=llm_invocations` now documents the `interrupted` terminal status (assigned by orphaned-row reconciliation in `init_pool` on restart), which was previously omitted from the enum.
+
 ## [3.2.1] - 2026-07-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "3.2.1"
+version = "3.2.2"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.2.1}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.2.2}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "3.2.1",
+  "version": "3.2.2",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v3.2.1",
+      "identifier": "ghcr.io/jmagar/cortex:v3.2.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/app/llm_runner.rs
+++ b/src/app/llm_runner.rs
@@ -182,8 +182,17 @@ impl LlmRunner {
         }
     }
 
-    fn action_enabled(&self, action: &str) -> bool {
-        if action == "background_enrich" && !self.config.background_enrichment_enabled {
+    /// `caller_surface` is required (not just `action`) because the
+    /// documented contract for `background_enrichment_enabled` is "checked
+    /// whenever `caller_surface == Background`" — the gate must trigger for
+    /// ANY action run with `LlmCallerSurface::Background`, not only the
+    /// literal action name `"background_enrich"`. The action-name check is
+    /// kept as defense in depth: it protects the well-known background
+    /// action even if a caller forgets to set `caller_surface` correctly.
+    fn action_enabled(&self, action: &str, caller_surface: LlmCallerSurface) -> bool {
+        if !self.config.background_enrichment_enabled
+            && (caller_surface == LlmCallerSurface::Background || action == "background_enrich")
+        {
             return false;
         }
         self.config
@@ -253,8 +262,10 @@ impl LlmRunner {
             return Err(LlmRunnerError::Disabled);
         }
 
-        // 2. Per-action enablement (covers background_enrichment_enabled too).
-        if !self.action_enabled(&action) {
+        // 2. Per-action enablement (covers background_enrichment_enabled too,
+        //    gated on caller_surface == Background per the documented
+        //    contract, not just the "background_enrich" action name).
+        if !self.action_enabled(&action, spec.caller_surface) {
             let id = new_invocation_id();
             self.write_start_row(&id, &spec, "disabled", prompt_bytes)
                 .await?;
@@ -287,9 +298,16 @@ impl LlmRunner {
                         .await?;
                     self.write_finish_row(&id, "circuit_open", Some("circuit_open"), 0)
                         .await?;
+                    // `Instant`'s Debug output is opaque/platform-dependent
+                    // (not a wall-clock time), so it's not actionable for a
+                    // caller trying to know how long to wait. Report the
+                    // remaining seconds until the circuit closes instead.
+                    let retry_after_secs = open_until
+                        .saturating_duration_since(Instant::now())
+                        .as_secs();
                     return Err(LlmRunnerError::CircuitOpen {
                         action: action.clone(),
-                        retry_after: format!("{open_until:?}"),
+                        retry_after: format!("{retry_after_secs}s"),
                     });
                 }
                 entry.circuit_open_until = None;

--- a/src/app/llm_runner.rs
+++ b/src/app/llm_runner.rs
@@ -134,7 +134,7 @@ pub enum LlmRunnerError {
     ActionConcurrencyLimited { action: String, limit: usize },
     #[error("rate limit exceeded for action '{action}': {detail}")]
     RateLimited { action: String, detail: String },
-    #[error("circuit open for action '{action}' until {retry_after}")]
+    #[error("circuit open for action '{action}', retry after {retry_after}")]
     CircuitOpen { action: String, retry_after: String },
     #[error("LLM invocation '{0}' timed out after {1}s")]
     Timeout(String, u64),

--- a/src/app/llm_runner.rs
+++ b/src/app/llm_runner.rs
@@ -302,9 +302,12 @@ impl LlmRunner {
                     // (not a wall-clock time), so it's not actionable for a
                     // caller trying to know how long to wait. Report the
                     // remaining seconds until the circuit closes instead.
+                    // Round UP (not truncate) so a sub-second remainder
+                    // never reports "0s" while the circuit is still open.
                     let retry_after_secs = open_until
                         .saturating_duration_since(Instant::now())
-                        .as_secs();
+                        .as_secs_f64()
+                        .ceil() as u64;
                     return Err(LlmRunnerError::CircuitOpen {
                         action: action.clone(),
                         retry_after: format!("{retry_after_secs}s"),

--- a/src/app/llm_runner_tests.rs
+++ b/src/app/llm_runner_tests.rs
@@ -71,6 +71,89 @@ async fn disabled_runner_denies_and_audits() {
 }
 
 #[tokio::test]
+async fn background_enrich_action_denied_when_background_enrichment_disabled() {
+    let (pool, _dir) = test_pool();
+    let cfg = LlmConfig {
+        background_enrichment_enabled: false,
+        ..LlmConfig::default()
+    };
+    let runner = LlmRunner::new(pool.clone(), cfg);
+
+    let result = runner
+        .run(base_spec("background_enrich"), |_prompt| async {
+            panic!("run_fn must not be called when background enrichment is disabled")
+        })
+        .await;
+
+    assert!(matches!(result, Err(LlmRunnerError::ActionDisabled(_))));
+}
+
+/// Regression test for the enforcement gap: the documented contract states
+/// `background_enrichment_enabled` is "checked whenever `caller_surface ==
+/// Background`" — not only when the action name happens to literally be
+/// `"background_enrich"`. Construct a spec with `caller_surface: Background`
+/// and a DIFFERENT action name, and confirm the call is denied even though
+/// no per-action config entry exists for it.
+#[tokio::test]
+async fn background_caller_surface_denied_regardless_of_action_name() {
+    let (pool, _dir) = test_pool();
+    let cfg = LlmConfig {
+        background_enrichment_enabled: false,
+        ..LlmConfig::default()
+    };
+    let runner = LlmRunner::new(pool.clone(), cfg);
+
+    let mut spec = base_spec("skill_assess");
+    spec.caller_surface = LlmCallerSurface::Background;
+
+    let result = runner
+        .run(spec, |_prompt| async {
+            panic!(
+                "run_fn must not be called: background_enrichment_enabled=false must gate \
+                 ANY action run with caller_surface=Background, not just \"background_enrich\""
+            )
+        })
+        .await;
+
+    assert!(
+        matches!(result, Err(LlmRunnerError::ActionDisabled(_))),
+        "expected ActionDisabled for a Background-surface call with enrichment disabled, got {result:?}"
+    );
+
+    let conn = pool.get().unwrap();
+    let status: String = conn
+        .query_row(
+            "SELECT status FROM llm_invocations WHERE action = 'skill_assess' ORDER BY started_at DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "disabled");
+}
+
+/// Sanity check on the flip side: once `background_enrichment_enabled` is
+/// true, a Background-surface call with a non-"background_enrich" action
+/// name is allowed through (assuming no other gate denies it).
+#[tokio::test]
+async fn background_caller_surface_allowed_when_enrichment_enabled() {
+    let (pool, _dir) = test_pool();
+    let cfg = LlmConfig {
+        background_enrichment_enabled: true,
+        ..LlmConfig::default()
+    };
+    let runner = LlmRunner::new(pool.clone(), cfg);
+
+    let mut spec = base_spec("skill_assess");
+    spec.caller_surface = LlmCallerSurface::Background;
+
+    let result = runner
+        .run(spec, |_prompt| async { Ok("ok".to_string()) })
+        .await;
+
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[tokio::test]
 async fn prompt_over_limit_is_rejected_before_spawn() {
     let (pool, _dir) = test_pool();
     let cfg = LlmConfig {
@@ -185,7 +268,29 @@ async fn circuit_opens_after_failure_threshold_and_audits_denial() {
             panic!("run_fn must not be called while circuit is open")
         })
         .await;
-    assert!(matches!(third, Err(LlmRunnerError::CircuitOpen { .. })));
+    match third {
+        Err(LlmRunnerError::CircuitOpen { retry_after, .. }) => {
+            // `retry_after` must be an actionable value (seconds remaining
+            // until the circuit closes), not `Instant`'s opaque Debug
+            // output (e.g. `Instant { tv_sec: ..., tv_nsec: ... }`).
+            assert!(!retry_after.is_empty(), "retry_after must not be empty");
+            assert!(
+                !retry_after.contains("Instant"),
+                "retry_after must not leak Instant Debug output: {retry_after}"
+            );
+            let seconds_str = retry_after.strip_suffix('s').unwrap_or_else(|| {
+                panic!("retry_after must be formatted as '<n>s': {retry_after}")
+            });
+            let seconds: u64 = seconds_str
+                .parse()
+                .unwrap_or_else(|_| panic!("retry_after seconds must parse as u64: {retry_after}"));
+            assert!(
+                seconds > 0,
+                "retry_after must report a positive number of remaining seconds, got {seconds}"
+            );
+        }
+        other => panic!("expected CircuitOpen, got {other:?}"),
+    }
 
     let conn = pool.get().unwrap();
     let denied_count: i64 = conn

--- a/src/app/llm_runner_tests.rs
+++ b/src/app/llm_runner_tests.rs
@@ -306,6 +306,51 @@ async fn circuit_opens_after_failure_threshold_and_audits_denial() {
     );
 }
 
+/// `retry_after` must round UP a sub-second remainder, never truncate it to
+/// "0s" — a caller reading "0s" would reasonably assume the circuit is
+/// already closed and retry immediately, when it's actually still open.
+/// `circuit_opens_after_failure_threshold_and_audits_denial` only asserts
+/// `seconds > 0`, which happens to hold with the default 300s cooldown but
+/// does not exercise the truncation-vs-rounding boundary; this test uses a
+/// 1s cooldown so the remaining time is checked well under a second after
+/// the circuit opens, which `.as_secs()` (truncate) would misreport as
+/// `"0s"` but `.as_secs_f64().ceil()` (round up) correctly reports as `"1s"`.
+#[tokio::test]
+async fn circuit_open_retry_after_rounds_up_sub_second_remainder() {
+    let (pool, _dir) = test_pool();
+    let cfg = LlmConfig {
+        failure_threshold: 1,
+        cooldown_secs: 1,
+        max_invocations_per_minute: 100,
+        max_invocations_per_hour: 100,
+        ..LlmConfig::default()
+    };
+    let runner = LlmRunner::new(pool.clone(), cfg);
+
+    let first = runner
+        .run(base_spec("ai_assess"), |_prompt| async {
+            Err(anyhow::anyhow!("simulated LLM failure"))
+        })
+        .await;
+    assert!(first.is_err());
+
+    let second = runner
+        .run(base_spec("ai_assess"), |_prompt| async {
+            panic!("run_fn must not be called while circuit is open")
+        })
+        .await;
+    match second {
+        Err(LlmRunnerError::CircuitOpen { retry_after, .. }) => {
+            assert_ne!(
+                retry_after, "0s",
+                "retry_after must round up a sub-second remainder, not truncate to 0s \
+                 while the circuit is still open"
+            );
+        }
+        other => panic!("expected CircuitOpen, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn dry_run_never_invokes_llm_and_reports_sizes() {
     let (pool, _dir) = test_pool();

--- a/src/db/maintenance.rs
+++ b/src/db/maintenance.rs
@@ -774,13 +774,23 @@ pub fn purge_old_llm_invocations(
         return Ok(0);
     }
 
+    // `llm_invocations.started_at` is written by SQLite as
+    // `strftime('%Y-%m-%dT%H:%M:%fZ','now')`, which includes millisecond
+    // fractional seconds (e.g. `2026-07-01T20:09:50.850Z`). The cutoff must
+    // carry the same precision: since the comparison is a lexicographic
+    // string compare (`started_at < cutoff`), a cutoff formatted without
+    // fractional seconds (e.g. `...:50Z`) does NOT sort the same as it would
+    // as a real timestamp comparison — `"...:50Z"` can compare greater OR
+    // less than `"...:50.850Z"` depending on the next byte (`Z` (0x5A) vs
+    // `.` (0x2E)), misordering rows within the same second. Use
+    // `SecondsFormat::Millis` (matches `%f`'s 3-digit precision) so the
+    // comparison is safe.
     let cutoff = Utc::now()
         .checked_sub_signed(chrono::TimeDelta::days(retention_days as i64))
         .ok_or_else(|| {
             anyhow::anyhow!("date arithmetic overflow for retention_days={retention_days}")
         })?
-        .format("%Y-%m-%dT%H:%M:%SZ")
-        .to_string();
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
     let mut total_deleted: usize = 0;
     loop {

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -1204,3 +1204,76 @@ fn test_purge_old_llm_invocations_chunked() {
     assert_eq!(deleted, 5);
     assert_eq!(count_llm_invocations(&pool), 1);
 }
+
+/// Regression test for the lexicographic-cutoff bug: a cutoff formatted
+/// without fractional seconds (e.g. `...:50Z`) does not sort consistently
+/// against `started_at` values that DO carry fractional seconds (SQLite
+/// writes `started_at` via `strftime('%Y-%m-%dT%H:%M:%fZ','now')`). Seed two
+/// rows one second apart that straddle a millisecond-precision cutoff, and
+/// confirm the purge honors true chronological order rather than string
+/// comparison.
+#[test]
+fn test_purge_old_llm_invocations_millisecond_precision_ordering() {
+    let (pool, _dir) = test_pool();
+
+    // Two rows within the same wall-clock second, one just after and one
+    // just before a cutoff that sits between them.
+    insert_llm_invocation(&pool, "just-before-cutoff", "2020-01-01T00:00:50.000001Z");
+    insert_llm_invocation(&pool, "just-after-cutoff", "2020-01-01T00:00:50.999999Z");
+
+    // Directly exercise the cutoff-comparison SQL with a hand-built cutoff
+    // straddling the two rows, to pin down true chronological behavior
+    // independent of `Utc::now()` in the production function.
+    let cutoff = "2020-01-01T00:00:50.500000Z";
+    let conn = pool.get().unwrap();
+    let deleted = conn
+        .execute(
+            "DELETE FROM llm_invocations WHERE id IN (
+                 SELECT id FROM llm_invocations
+                 WHERE started_at < ?1
+                 LIMIT 1000
+             )",
+            params![cutoff],
+        )
+        .unwrap();
+    drop(conn);
+
+    assert_eq!(
+        deleted, 1,
+        "exactly the row before the cutoff must be deleted"
+    );
+
+    let conn = pool.get().unwrap();
+    let remaining_id: String = conn
+        .query_row("SELECT id FROM llm_invocations", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        remaining_id, "just-after-cutoff",
+        "the row chronologically after the cutoff must survive"
+    );
+}
+
+/// End-to-end regression test through the real production function: the
+/// cutoff it formats must retain millisecond precision so that a row
+/// inserted a fraction of a second before `Utc::now() - retention_days` is
+/// correctly purged instead of surviving due to a lexicographic-comparison
+/// mismatch against a coarser cutoff string.
+#[test]
+fn test_purge_old_llm_invocations_cutoff_has_fractional_seconds() {
+    let (pool, _dir) = test_pool();
+
+    // A row exactly at the retention boundary, but 1ms before now-90days,
+    // formatted with the same precision SQLite uses for started_at.
+    let boundary =
+        (chrono::Utc::now() - chrono::TimeDelta::days(90) - chrono::TimeDelta::milliseconds(1))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    insert_llm_invocation(&pool, "at-boundary", &boundary);
+
+    let deleted = purge_old_llm_invocations(&pool, 90, 1000).unwrap();
+    assert_eq!(
+        deleted, 1,
+        "row just past the retention boundary must be purged; a cutoff \
+         missing fractional-second precision could misorder it"
+    );
+    assert_eq!(count_llm_invocations(&pool), 0);
+}

--- a/src/db/maintenance_tests.rs
+++ b/src/db/maintenance_tests.rs
@@ -1209,9 +1209,9 @@ fn test_purge_old_llm_invocations_chunked() {
 /// without fractional seconds (e.g. `...:50Z`) does not sort consistently
 /// against `started_at` values that DO carry fractional seconds (SQLite
 /// writes `started_at` via `strftime('%Y-%m-%dT%H:%M:%fZ','now')`). Seed two
-/// rows one second apart that straddle a millisecond-precision cutoff, and
-/// confirm the purge honors true chronological order rather than string
-/// comparison.
+/// rows within the same wall-clock second that straddle a
+/// millisecond-precision cutoff, and confirm the purge honors true
+/// chronological order rather than string comparison.
 #[test]
 fn test_purge_old_llm_invocations_millisecond_precision_ordering() {
     let (pool, _dir) = test_pool();
@@ -1262,10 +1262,12 @@ fn test_purge_old_llm_invocations_millisecond_precision_ordering() {
 fn test_purge_old_llm_invocations_cutoff_has_fractional_seconds() {
     let (pool, _dir) = test_pool();
 
-    // A row exactly at the retention boundary, but 1ms before now-90days,
-    // formatted with the same precision SQLite uses for started_at.
+    // A row just past the retention boundary, 1s before now-90days (a 1ms
+    // margin would be too tight here: both the stored timestamp and the
+    // cutoff are formatted at millisecond precision, so rounding/truncation
+    // could collapse a 1ms delta to zero and make this test flaky).
     let boundary =
-        (chrono::Utc::now() - chrono::TimeDelta::days(90) - chrono::TimeDelta::milliseconds(1))
+        (chrono::Utc::now() - chrono::TimeDelta::days(90) - chrono::TimeDelta::seconds(1))
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
     insert_llm_invocation(&pool, "at-boundary", &boundary);
 

--- a/src/mcp/schemas.rs
+++ b/src/mcp/schemas.rs
@@ -223,7 +223,7 @@ pub(super) fn tool_definitions() -> Vec<Value> {
                 },
                 "status": {
                     "type": "string",
-                    "description": "For action=llm_invocations: filter by invocation outcome status. One of: running, success, error, denied, rate_limited, circuit_open, disabled, dry_run, timeout."
+                    "description": "For action=llm_invocations: filter by invocation outcome status. One of: running, success, error, denied, rate_limited, circuit_open, disabled, dry_run, timeout, interrupted. 'interrupted' is a terminal status assigned by orphaned-row reconciliation at startup: init_pool rewrites any row still status='running' from a prior process into status='interrupted'."
                 },
                 "limit": {
                     "type": "integer",


### PR DESCRIPTION
## Summary

PR #106 (LLM Invocation Guard + Audit Infrastructure) picked up a real GitHub Copilot review after it was already open, and the fixes were pushed to that branch — but the PR got squash-merged (`bb28230`) before that last commit (`0d1fd82`) landed, so these 4 real fixes never made it into `main`. This PR cherry-picks that commit cleanly onto current `main`.

## Fixes

1. **Retention-cutoff timestamp comparison bug** (`src/db/maintenance.rs`) — `purge_old_llm_invocations` formatted its cutoff without fractional seconds while `llm_invocations.started_at` is written with millisecond precision. Lexicographic comparison of the two could misorder rows within the same second. Now uses `SecondsFormat::Millis`, matching the sibling `logs`/heartbeats purges.
2. **`CircuitOpen.retry_after` opaque debug output** (`src/app/llm_runner.rs`) — was `Instant`'s platform-dependent `Debug` format, not actionable for a caller. Now reports remaining seconds (e.g. `"47s"`).
3. **`background_enrichment_enabled` enforcement gap** (`src/app/llm_runner.rs`) — the gate only special-cased the literal action name `"background_enrich"`, not `caller_surface == Background` as documented. A different action run with `caller_surface: Background` could bypass it. Now checks `caller_surface` (keeping the action-name check as defense in depth).
4. **MCP schema doc gap** (`src/mcp/schemas.rs`) — the `llm_invocations` `status` filter description omitted `interrupted`, the terminal status assigned by orphaned-row reconciliation on restart.

All 4 have regression tests. Version bumped 3.2.0 → 3.2.1.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test` full suite green (one transient flake in an unrelated pre-existing test — `ai_assess_writes_llm_invocation_audit_row_via_runner`, a fake-subprocess-stdin race under heavy load, confirmed non-deterministic and unrelated to this diff; tracked as [syslog-mcp-jxbib])
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cherry-picks missed fixes from PR #106 and tightens the circuit-breaker’s `retry_after` behavior. Bumps the app to 3.2.2.

- **Bug Fixes**
  - Retention purge now formats the cutoff with millisecond precision to match `started_at`, preventing misordered deletions.
  - Circuit breaker now returns a clear duration (e.g., "47s"), rounds up sub-second remainders so it never reports "0s" while still open, and the error reads "retry after {retry_after}".
  - `background_enrichment_enabled` is enforced for any `caller_surface: Background` (keeps the `"background_enrich"` action check as defense in depth).
  - MCP schema documents the `interrupted` terminal status for `llm_invocations`.
  - Tests: added regressions for all fixes, including rounding-up of `retry_after`; widened cutoff test timing to avoid flakes and corrected a misleading comment.

<sup>Written for commit 6e457371f921abff3613ac807d6cbc4486c2cd8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retention cleanup so older records are removed consistently, even when entries share the same second.
  * Circuit-breaker errors now show a clearer remaining wait time, such as `47s`.
  * Background enrichment access is now enforced more reliably for the correct request type.
  * Status reporting now includes interrupted runs as a valid terminal outcome.

* **Chores**
  * Updated the release version to 3.2.2 across packaging and deployment metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->