### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-07-01-topic-correlate-docs-fix.md
+++ b/docs/sessions/2026-07-01-topic-correlate-docs-fix.md
@@ -101,7 +101,7 @@ No bead activity observed. This task was treated as a small, self-contained docu
 | `git push -u origin claude/quirky-euclid-37627e` | Pushed; pre-push hooks (version-sync, clippy) passed |
 | `gh pr create --title "docs: ..." --body "..."` | Created PR #107 |
 | `git rebase origin/main` | Conflicts in 9 files |
-| `git xtask bump-version patch` (second run, after fixing `Cargo.toml` to 3.2.0) | `Bumped cortex 3.2.0 → 3.2.1` |
+| `cargo xtask bump-version patch` (second run, after fixing `Cargo.toml` to 3.2.0) | `Bumped cortex 3.2.0 → 3.2.1` |
 | `cargo xtask check-release-versions` (second run) | `OK: 8 version-bearing file(s) in sync at 3.2.1.` |
 | `cargo test --lib public_action_references_cover_schema_registry` (second run) | `test result: ok. 1 passed` |
 | `git push --force-with-lease origin claude/quirky-euclid-37627e` | Forced update accepted; pre-push hooks passed |

--- a/docs/sessions/2026-07-01-topic-correlate-docs-fix.md
+++ b/docs/sessions/2026-07-01-topic-correlate-docs-fix.md
@@ -1,0 +1,151 @@
+```yaml
+date: 2026-07-01 23:41:04 EST
+repo: git@github.com:jmagar/cortex.git
+branch: claude/quirky-euclid-37627e
+head: 662b38943febb436ed415bceab9ae2cabb4a0ac3
+working directory: /home/jmagar/workspace/cortex/.claude/worktrees/quirky-euclid-37627e
+worktree: /home/jmagar/workspace/cortex/.claude/worktrees/quirky-euclid-37627e
+pr: #107 "docs: add missing topic_correlate row to action index docs" (https://github.com/jmagar/cortex/pull/107) — merged
+```
+
+## User Request
+
+Fix a documentation gap: the `topic_correlate` MCP action existed in `src/mcp/actions.rs::ACTION_SPECS` but was missing from the "Current Action Index" table in `docs/contracts/mcp-actions-current.md`, discovered while diffing the live action registry against that doc during work on GH #94 PR1. Add the missing row (matching its real scope/cost/description), bump the "N actions" count, check `docs/mcp/TOOLS.md`, `docs/mcp/SCHEMA.md`, `docs/INVENTORY.md`, `README.md`, and `CLAUDE.md` for the same gap, and verify with `cargo test --lib public_action_references_cover_schema_registry`. Follow-up requests in the same session: create a PR, merge it, and save the session log.
+
+## Session Overview
+
+Added the missing `topic_correlate` row and corrected stale action counts in `docs/contracts/mcp-actions-current.md`, `README.md`, and `docs/mcp/SCHEMA.md` (the latter needed only a count fix; `docs/mcp/TOOLS.md`, `docs/INVENTORY.md`, and `CLAUDE.md` already had the row). Bumped the patch version per repo convention, opened PR #107, triaged two bot review comments (both rate-limit notices with no actionable findings) and a no-op Copilot summary, rebased through a merge conflict caused by PR #106 (`LlmRunner`/`llm_invocations`) landing on `main` first — which required re-deriving the version bump on top of the new 3.2.0 baseline — and merged the PR into `main` as commit `75c2b0a` (squash).
+
+## Sequence of Events
+
+1. Located `topic_correlate`'s real spec (`Read`, `Moderate` cost, description) in `src/mcp/actions.rs:339-345`.
+2. Read `docs/contracts/mcp-actions-current.md`'s "Current Action Index" table and confirmed the row and the "46 actions" count were both missing/stale.
+3. Inserted the `topic_correlate` row in table order (immediately after `ai_correlate`, matching `ACTION_SPECS` order) and bumped the count to 47.
+4. Grepped `docs/mcp/TOOLS.md`, `docs/mcp/SCHEMA.md`, `docs/INVENTORY.md`, `README.md`, and `CLAUDE.md` for `topic_correlate` and `ai_correlate` context. Found `TOOLS.md`, `SCHEMA.md`'s table, `INVENTORY.md`, and `CLAUDE.md` already had the row; only `README.md` (inline action list + table) and `SCHEMA.md`'s stale "46 actions" count sentence needed fixing.
+5. Fixed `README.md` (added `topic_correlate` to the inline action-list sentence and the action table) and `docs/mcp/SCHEMA.md` (46 → 47).
+6. Ran `cargo test --lib public_action_references_cover_schema_registry` — passed.
+7. Per repo convention ("every feature branch push MUST bump the version"), ran `cargo xtask bump-version patch` (3.1.3 → 3.1.4), added a CHANGELOG entry, and verified with `cargo xtask check-release-versions`.
+8. Committed, pushed `claude/quirky-euclid-37627e`, and opened PR #107 via `gh pr create`.
+9. Received two automated review-comment notifications (Codex usage-limit notice, CodeRabbit rate-limit notice) — both contained no code findings, so no action was taken. A later Copilot review also produced a summary with zero comments — no action needed.
+10. Received a merge-conflict notification: `main` had advanced past the PR's base because PR #106 ("PR1/4: LLM Invocation Guard + Audit Infrastructure", GH #94) merged first, adding the `llm_invocations` action and bumping the version to 3.2.0.
+11. Rebased `claude/quirky-euclid-37627e` onto the new `main` tip (`bb28230`). Resolved conflicts in `CHANGELOG.md`, `Cargo.lock`, `Cargo.toml`, `README.md`, `docker-compose.prod.yml`, `docs/contracts/mcp-actions-current.md`, `docs/mcp/SCHEMA.md`, `mcpb/manifest.json`, `server.json` — keeping `main`'s `llm_invocations` additions and merging in this branch's `topic_correlate` fix.
+12. First conflict-resolution pass mistakenly used `git checkout --theirs` with reversed rebase semantics, which reverted the version-bearing files back to this branch's stale 3.1.4 instead of `main`'s 3.2.0. Caught this by re-grepping the resolved files, corrected `Cargo.toml` to `3.2.0`, restored `main`'s CHANGELOG content, and re-ran `cargo xtask bump-version patch` to cleanly derive `3.2.1` across all 8 version-bearing files.
+13. Re-ran `cargo xtask check-release-versions` (pass) and `cargo test --lib public_action_references_cover_schema_registry` (pass) against the rebased tree.
+14. Amended the rebased commit with the corrected version files and CHANGELOG entry, then force-pushed with `--force-with-lease`.
+15. Confirmed PR #107 was `MERGEABLE` again, waited for CI (`gh pr checks 107` — all green), and merged via `gh pr merge 107 --squash --delete-branch`.
+16. The `--delete-branch` local checkout step failed because `main` was already checked out in a sibling worktree (`/home/jmagar/workspace/cortex`); the squash merge itself succeeded (verified via `gh pr view 107 --json state,mergedAt`). Deleted the now-orphaned remote branch manually via `gh api -X DELETE repos/jmagar/cortex/git/refs/heads/claude/quirky-euclid-37627e`.
+17. Invoked `/vibin:save-to-md` to document the session.
+
+## Key Findings
+
+- `src/mcp/actions.rs:338-353` — `topic_correlate` action spec: `Read` scope, `Moderate` cost, description "Resolve a topic to graph entities and correlate all related logs into a unified timeline". Registered between `ai_correlate` and `usage_blocks` in `ACTION_SPECS`.
+- `docs/contracts/mcp-actions-current.md` and `README.md` were the only docs with the gap; `docs/mcp/TOOLS.md`, `docs/mcp/SCHEMA.md`'s table body, `docs/INVENTORY.md`, and `CLAUDE.md` already listed `topic_correlate` correctly (only `SCHEMA.md`'s prose count sentence was stale).
+- PR #106 (merged as `bb28230` while this PR was open) independently fixed `docs/contracts/mcp-actions-current.md`'s count language to "48 actions (this snapshot may lag ...)" but did **not** add the `topic_correlate` row to that file's table — so after PR #106 landed, the table still needed this PR's row even though the count sentence had already been touched by someone else.
+- `git checkout --theirs`/`--ours` semantics are reversed during `git rebase` versus `git merge`: during a rebase, `--theirs` is the commit being replayed (this branch), not the branch being rebased onto. Applying `--theirs` naively to resolve the version-file conflicts silently reverted `main`'s 3.2.0 bump back to this branch's stale 3.1.4 — caught only by re-grepping the resolved files before continuing the rebase.
+
+## Technical Decisions
+
+- Inserted `topic_correlate`'s doc row at the same position it holds in `ACTION_SPECS` (after `ai_correlate`) rather than alphabetically, to keep doc order mirroring the authoritative source.
+- After the rebase conflict, re-derived the version bump from `main`'s new 3.2.0 baseline via `cargo xtask bump-version patch` (yielding 3.2.1) rather than hand-editing each version-bearing file, so `release/components.toml`'s declarative rewrite logic stayed the single source of truth for every carrier file.
+- Restored `main`'s full CHANGELOG entry for 3.2.0 (rather than keeping this branch's now-incorrect 3.1.4 entry) and added a new, separate 3.2.1 entry for the docs fix — preserving PR #106's changelog history intact.
+- Did not create a beads issue for this task; treated it as a small, self-contained documentation fix rather than "non-trivial work" per the repo's `bd`-before-code convention.
+- Left the `claude/quirky-euclid-37627e` worktree in place after the branch's remote ref was deleted, rather than removing it mid-session, since it was the active working directory for this very session-log step.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+| --- | --- | --- | --- | --- |
+| modified | `docs/contracts/mcp-actions-current.md` | — | Added `topic_correlate` row to the action index table; count corrected to 48 after rebase | `git show 75c2b0a -- docs/contracts/mcp-actions-current.md` |
+| modified | `README.md` | — | Added `topic_correlate` to the inline action list and action table | `git show 75c2b0a -- README.md` |
+| modified | `docs/mcp/SCHEMA.md` | — | Corrected stale "46 actions" count sentence (settled at 48 post-rebase) | `git show 75c2b0a -- docs/mcp/SCHEMA.md` |
+| modified | `CHANGELOG.md` | — | Added 3.2.1 entry documenting the docs fix, on top of PR #106's 3.2.0 entry | `git show 75c2b0a -- CHANGELOG.md` |
+| modified | `Cargo.toml` | — | Version bump 3.2.0 → 3.2.1 (canonical source) | `cargo xtask bump-version patch` output |
+| modified | `Cargo.lock` | — | `cortex` package version synced to 3.2.1 | `cargo xtask check-release-versions` |
+| modified | `server.json` | — | MCP registry version + image tag synced to 3.2.1 | `cargo xtask check-release-versions` |
+| modified | `mcpb/manifest.json` | — | MCP bundle manifest version synced to 3.2.1 | `cargo xtask check-release-versions` |
+| modified | `docker-compose.prod.yml` | — | Default image tag synced to 3.2.1 | `cargo xtask check-release-versions` |
+| created | `docs/sessions/2026-07-01-topic-correlate-docs-fix.md` | — | This session log | this file |
+
+`docs/mcp/TOOLS.md`, `docs/INVENTORY.md`, and `CLAUDE.md` were inspected and confirmed already correct — no changes made to them.
+
+## Beads Activity
+
+No bead activity observed. This task was treated as a small, self-contained documentation fix rather than "non-trivial work" requiring a tracked issue.
+
+## Repository Maintenance
+
+- **Plans**: No plan files were touched or referenced by this session (`Active plan: none`); no completed-plan moves were needed or performed.
+- **Beads**: No beads created, claimed, or closed this session (see above). No beads read/searched either, since the task didn't reference tracked work.
+- **Worktrees and branches**:
+  - The feature branch `claude/quirky-euclid-37627e` was merged via squash (commit `75c2b0a` on `main`) and its remote ref was deleted (`gh api -X DELETE repos/jmagar/cortex/git/refs/heads/claude/quirky-euclid-37627e`) after `gh pr merge --delete-branch` failed to do so automatically (local `main` was checked out in the sibling worktree `/home/jmagar/workspace/cortex`, blocking the branch-deletion checkout step).
+  - The local worktree at `/home/jmagar/workspace/cortex/.claude/worktrees/quirky-euclid-37627e` (this session's working directory) still points at the now-merged, remote-deleted `claude/quirky-euclid-37627e` branch. It was **not** removed in this session because it is the active working directory for this very session-log write; removal is a safe follow-up once the session ends (`git worktree remove` from a different location, or normal harness cleanup).
+  - Sibling worktrees `cool-cerf-85abde` and `happy-kepler-2d8fa5` were inspected read-only (`git worktree list`, `git branch -vv`) but not touched — `cool-cerf-85abde` tracks `origin/main` (behind 3, docs-only session-log branch, unrelated to this session) and `happy-kepler-2d8fa5` tracks an already-merged PR #108 (Copilot follow-ups for PR #106, unrelated to this session). Neither was created or modified by this session, so no cleanup action was taken on them.
+  - `main` in the primary worktree (`/home/jmagar/workspace/cortex`) is behind `origin/main` by 2 commits (PR #107's squash commit `75c2b0a` and PR #108's `814d033`) as of this session; it was not fast-forwarded here since that worktree wasn't touched by this session directly. Flagged in Next Steps.
+- **Stale docs**: The specific stale-doc gap this session was scoped to fix (`topic_correlate` missing from action-index docs) is resolved. No other stale-doc issues were identified or investigated beyond the five files the user named plus `CLAUDE.md`.
+- **Transparency**: All version-file conflict resolutions during the rebase were re-verified by grep before continuing (`grep -n "topic_correlate" ...`, `grep '^version' Cargo.toml`, etc.); the one clerk error (reversed `--theirs`/`--ours` reverting the version bump) was caught this way and corrected before pushing.
+
+## Tools and Skills Used
+
+- **Shell commands (`Bash`)**: `git` (status/diff/log/show/rebase/commit/push/checkout/worktree/branch/merge-base/ls-remote/fetch), `cargo` (`test`, `xtask bump-version`, `xtask check-release-versions`), `grep`, `gh` (`pr create`, `pr view`, `pr checks`, `pr merge`, `api -X DELETE`, `repo view`). No failures beyond the two documented below.
+- **File tools (`Read`/`Edit`/`Write`)**: Used to inspect and patch `src/mcp/actions.rs`, `docs/contracts/mcp-actions-current.md`, `README.md`, `docs/mcp/SCHEMA.md`, `CHANGELOG.md`, `Cargo.toml`, and to write this session log. No issues.
+- **No subagents, MCP tools, browser tools, or external skills were used** for the docs/PR/merge work — it was small enough to do directly. The `/vibin:save-to-md` skill was invoked for this final step.
+
+## Commands Executed
+
+| Command | Result |
+| --- | --- |
+| `grep -n "topic_correlate" -r src/mcp/actions.rs -A 6 -B 2` | Found the action spec (Read, Moderate, description) |
+| `cargo test --lib public_action_references_cover_schema_registry` (first run) | `test result: ok. 1 passed` |
+| `cargo xtask bump-version patch` (first run) | `Bumped cortex 3.1.3 → 3.1.4` |
+| `cargo xtask check-release-versions` (first run) | `OK: 8 version-bearing file(s) in sync at 3.1.4.` |
+| `git push -u origin claude/quirky-euclid-37627e` | Pushed; pre-push hooks (version-sync, clippy) passed |
+| `gh pr create --title "docs: ..." --body "..."` | Created PR #107 |
+| `git rebase origin/main` | Conflicts in 9 files |
+| `git xtask bump-version patch` (second run, after fixing `Cargo.toml` to 3.2.0) | `Bumped cortex 3.2.0 → 3.2.1` |
+| `cargo xtask check-release-versions` (second run) | `OK: 8 version-bearing file(s) in sync at 3.2.1.` |
+| `cargo test --lib public_action_references_cover_schema_registry` (second run) | `test result: ok. 1 passed` |
+| `git push --force-with-lease origin claude/quirky-euclid-37627e` | Forced update accepted; pre-push hooks passed |
+| `gh pr checks 107` | All checks (CI Gate, Clippy, Coverage, Tests, Version Sync, etc.) passed |
+| `gh pr merge 107 --squash --delete-branch` | Merged (squash); local branch-delete step failed (worktree conflict) |
+| `gh api -X DELETE repos/jmagar/cortex/git/refs/heads/claude/quirky-euclid-37627e` | Remote branch deleted |
+
+## Errors Encountered
+
+- **Rebase conflict from a racing PR**: PR #106 merged into `main` while PR #107 was open, both touching `docs/contracts/mcp-actions-current.md`, `docs/mcp/SCHEMA.md`, `README.md`, `CHANGELOG.md`, and all version-bearing files. Root cause: two independent doc/version-touching PRs open concurrently. Resolved via `git rebase origin/main` with manual per-file conflict resolution, keeping `main`'s `llm_invocations` additions and this branch's `topic_correlate` fix.
+- **Reversed `git checkout --theirs`/`--ours` semantics during rebase**: Used `--theirs` intending to take `main`'s version, but during a rebase `--theirs` refers to the commit being replayed (this branch's stale 3.1.4), not the target branch. This silently downgraded `Cargo.toml`/`Cargo.lock`/`server.json`/`mcpb/manifest.json`/`docker-compose.prod.yml`/`CHANGELOG.md` back to 3.1.4. Caught by re-grepping the resolved files (`grep '^version' Cargo.toml`) after the rebase completed, before pushing. Fixed by manually setting `Cargo.toml` to `main`'s 3.2.0, restoring `main`'s CHANGELOG content, and re-running `cargo xtask bump-version patch` to derive a clean 3.2.1 across all carriers.
+- **`gh pr merge --delete-branch` partial failure**: `gh pr merge 107 --squash --delete-branch` squash-merged successfully but the branch-deletion step failed with `fatal: 'main' is already used by worktree at '/home/jmagar/workspace/cortex'`, because `gh` attempts a local checkout of the base branch as part of branch cleanup, and `main` was already checked out in a sibling worktree. Verified the merge succeeded independently (`gh pr view 107 --json state,mergedAt`) and deleted the orphaned remote branch manually via the GitHub API.
+
+## Behavior Changes (Before/After)
+
+| Area | Before | After |
+| --- | --- | --- |
+| `docs/contracts/mcp-actions-current.md` | Missing `topic_correlate` row; stale action count | `topic_correlate` row present; count accurate (48, reflecting PR #106's `llm_invocations` addition too) |
+| `README.md` | `topic_correlate` absent from both the inline action list and the action table | Present in both |
+| `docs/mcp/SCHEMA.md` | Table already had `topic_correlate`, but prose said "46 actions" | Prose corrected to "48 actions" |
+| Package version | 3.1.3 (pre-session) → briefly 3.1.4 → corrected to 3.2.1 post-rebase | 3.2.1 across all 8 version-bearing files, merged to `main` |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+| --- | --- | --- | --- |
+| `cargo test --lib public_action_references_cover_schema_registry` (pre-rebase) | pass | `1 passed; 0 failed` | pass |
+| `cargo test --lib public_action_references_cover_schema_registry` (post-rebase) | pass | `1 passed; 0 failed` | pass |
+| `cargo xtask check-release-versions` (post-rebase) | all 8 files in sync | `OK: 8 version-bearing file(s) in sync at 3.2.1.` | pass |
+| `gh pr checks 107` | all required checks green | CI Gate, Changes, Clippy, CodeRabbit, Coverage, Dependency Check, Formatting, GitGuardian, MCP Integration Tests, Pre-publish CI gate, Secret Scan, Tests, Version Sync, build-and-push — all `pass` | pass |
+| `gh pr view 107 --json state,mergedAt` | merged | `{"mergedAt":"2026-07-02T01:10:34Z","state":"MERGED"}` | pass |
+| `git merge-base --is-ancestor 662b389 origin/main` | not a direct ancestor (squash merge expected) | exit 1 (confirmed squash, not fast-forward) | pass (expected) |
+
+## Risks and Rollback
+
+Low risk: the change is documentation- and version-metadata-only, with no runtime code touched. If the version bump to 3.2.1 needs to be reverted, `git revert 75c2b0a` on `main` (or a follow-up `cargo xtask bump-version` adjustment) would restore prior state; no data migrations or running-service behavior are affected.
+
+## Decisions Not Taken
+
+- Considered leaving the merge-conflict resolution to `git rebase --abort` and instead re-basing PR #107 as a fresh branch off the new `main` tip; rejected in favor of an in-place rebase since the conflict surface (9 files, all previously-inspected content) was small and well-understood.
+- Considered filing a beads issue for this docs fix per the repo's general convention; decided against it since the task was small, fully scoped by the user's original request, and completed within a single session with no follow-up work implied.
+
+## Next Steps
+
+- Fast-forward `main` in the primary worktree (`/home/jmagar/workspace/cortex`) to `origin/main` — it is currently 2 commits behind (`75c2b0a` from this session's PR #107, and `814d033` from the unrelated, already-merged PR #108).
+- Consider removing the now-stale worktree at `/home/jmagar/workspace/cortex/.claude/worktrees/quirky-euclid-37627e` (its branch is merged and its remote ref deleted) once this session ends — not done here since it was this session's active working directory.
+- No other follow-up work is implied by this session; the doc gap named by the user is fully closed and merged.


### PR DESCRIPTION
Session log — docs only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a session log at docs/sessions/2026-07-01-topic-correlate-docs-fix.md documenting the `topic_correlate` docs fix and the rebase/version bump, and correct a typo in the session log command reference. Docs-only; no code or behavior changes.

<sup>Written for commit 4fae38beed3602e04b32c6220661d756d8499e3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

