### PR TITLE
fix: harden fake-gemini test double against stdin broken-pipe race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.3] - 2026-07-02
+
+### Fixed
+
+- Fixed a flaky unit test: `ai_assess_writes_llm_invocation_audit_row_via_runner` intermittently failed under heavy parallel `cargo test --lib` load with `failed to write Gemini stdin: Broken pipe (os error 32)`. The test's fake-`gemini` script never read stdin before exiting, racing against `run_gemini_assessment`'s concurrent stdin-writer task under scheduler pressure. The script now drains stdin to EOF before responding, removing the race deterministically. Test-only change; no production code affected.
+
 ## [3.2.2] - 2026-07-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "3.2.2"
+version = "3.2.3"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.2.2}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.2.3}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "3.2.2",
+  "version": "3.2.3",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v3.2.2",
+      "identifier": "ghcr.io/jmagar/cortex:v3.2.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/app/service_tests.rs
+++ b/src/app/service_tests.rs
@@ -1660,13 +1660,21 @@ async fn ai_assess_writes_llm_invocation_audit_row_via_runner() {
     // run_gemini_assessment succeeds without needing a real Gemini CLI —
     // same fake-script-on-PATH pattern used by
     // src/assessment_tests.rs::gemini_assessment_timeout_kills_and_reaps_child.
+    //
+    // `cat >/dev/null` drains stdin before the script prints anything: the
+    // parent's stdin_task is writing the prompt concurrently, and under
+    // heavy parallel-test-suite scheduling pressure this script could
+    // otherwise exit (closing its stdin read end) before that write
+    // completed, surfacing a spurious "Broken pipe" from run_gemini_assessment.
+    // Reading stdin to EOF first makes the child block until the parent's
+    // write+shutdown finishes, removing the race deterministically.
     let source = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(source.path().join(".gemini")).unwrap();
     std::fs::write(source.path().join(".gemini").join("settings.json"), "{}").unwrap();
     let script = source.path().join("fake-gemini.sh");
     std::fs::write(
         &script,
-        "#!/usr/bin/env bash\necho '{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"ok\"}'\necho '{\"type\":\"result\",\"status\":\"success\"}'\n",
+        "#!/usr/bin/env bash\ncat >/dev/null\necho '{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"ok\"}'\necho '{\"type\":\"result\",\"status\":\"success\"}'\n",
     )
     .unwrap();
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- `ai_assess_writes_llm_invocation_audit_row_via_runner` intermittently failed under heavy parallel `cargo test --lib` load with `failed to write Gemini stdin: Broken pipe (os error 32)`.
- Root cause: the fake `gemini` script (`fake-gemini.sh`) in `src/app/service_tests.rs` exited without ever reading stdin, racing against `run_gemini_assessment`'s concurrent stdin-writer task — under scheduler pressure the child could exit and close its stdin read end before the parent finished writing, surfacing a spurious `Broken pipe` even though stdout already produced valid, complete output.
- Fix: the test double now drains stdin (`cat >/dev/null`) before responding, forcing it to block until the parent's write+shutdown completes. Test-only change — production code (`src/assessment.rs`) is untouched.
- Bumped version 3.2.2 → 3.2.3 (patch) per repo convention; CHANGELOG updated.

Closes syslog-mcp-sxx56.

## Test plan
- [x] Reproduced the original failure on unpatched code (single isolated test run failed with the exact reported `Broken pipe` error under current system load)
- [x] `cargo test --lib app::services::tests::ai_assess_writes_llm_invocation_audit_row_via_runner` — passed 6/6 consecutive runs after the fix
- [x] `cargo test --lib assessment::tests::` — all 12 tests pass, including the intentionally-racy `gemini_assessment_reports_child_stderr_before_stdin_pipe_error` (confirms the fix doesn't mask the exit-status-priority behavior that test depends on)
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo xtask check-release-versions`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky unit test by making the fake `gemini` test double read stdin to EOF (`cat >/dev/null`) before printing, removing the broken-pipe race under parallel runs. Test-only change; bumps `cortex` to 3.2.3 and updates Docker/manifest versions to match (addresses syslog-mcp-sxx56).

<sup>Written for commit e7d357289a20c0a597bfe0f0e2ddd8a7a0d8dcf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

