### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-07-02-fix-circuit-breaker-cooldown-flaky-test.md
+++ b/docs/sessions/2026-07-02-fix-circuit-breaker-cooldown-flaky-test.md
@@ -1,0 +1,182 @@
+```yaml
+date: 2026-07-02 07:11:01 EST
+repo: git@github.com:jmagar/cortex.git
+branch: session-log/2026-07-02-fix-circuit-breaker-cooldown-flaky-test
+head: 18bcf7e92ca56e8c27d6591b3ad8b382185b936c
+working directory: /home/jmagar/workspace/cortex/.claude/worktrees/happy-dirac-58d616
+worktree: /home/jmagar/workspace/cortex/.claude/worktrees/happy-dirac-58d616
+pr: #112 "fix: increase cooldown in flaky circuit-breaker retry_after test" (https://github.com/jmagar/cortex/pull/112) — merged
+beads: syslog-mcp-gxahz (created, claimed, closed)
+```
+
+## User Request
+
+Fix a documented flaky test — `src/app/llm_runner_tests.rs::circuit_open_retry_after_rounds_up_sub_second_remainder` — which intermittently fails under a fully-loaded parallel `cargo test --lib` run because its 1-second circuit-breaker cooldown can occasionally be consumed by scheduler jitter before the test's second assertion runs. The user supplied a full root-cause analysis and recommended fix option 2 (increase `cooldown_secs`). After the fix landed and was pushed, the user asked to "merge it into main."
+
+## Session Overview
+
+Applied the user's recommended fix (bump `cooldown_secs` from 1s to 300s in the test fixture), verified it in isolation, bumped the crate version and changelog per repo convention, committed, and pushed. When asked to merge into main, discovered `origin/main` had advanced with an unrelated flaky-test fix (PR #111) that had already claimed version 3.2.3, requiring a rebase, a manual CHANGELOG conflict resolution, and a re-bump to 3.2.4 before opening and squash-merging PR #112.
+
+## Sequence of Events
+
+1. Read `src/app/llm_runner_tests.rs:319-352` and `src/app/llm_runner.rs` to confirm the `ceil()`-based `retry_after` rounding logic doesn't depend on the exact cooldown value, only that a sub-second remainder exists — validating the user's option 2 recommendation.
+2. Edited the test: `cooldown_secs: 1` → `cooldown_secs: 300`, and rewrote the preceding doc comment to explain the flakiness and the fix rationale.
+3. Ran `cargo test --lib circuit_open_retry_after_rounds_up_sub_second_remainder` — passed.
+4. Searched beads for an existing tracking issue (`bd search "flaky"`, `bd search "circuit_open_retry_after"`) — found none for this specific test; created `syslog-mcp-gxahz` and claimed it.
+5. Ran `cargo xtask bump-version patch` (3.2.2 → 3.2.3) and added a CHANGELOG entry.
+6. Ran `cargo fmt --check` (clean) and `cargo clippy --lib --tests -- -D warnings` (clean).
+7. Closed `syslog-mcp-gxahz`.
+8. Committed (`ade45cd`) and pushed to `origin/claude/happy-dirac-58d616` — lefthook pre-commit hooks (diff_check, module_size, env_guard, version_sync, yaml, rustfmt) all passed.
+9. User asked to merge into main. Checked for an existing PR (none) and branch protection on `main` (none — 404 "Branch not protected").
+10. Inspected recently merged PRs to confirm the repo's squash-merge-with-PR-number convention.
+11. Fetched `origin/main` and discovered it had advanced past the branch's base commit via PR #111 ("fix: harden fake-gemini test double against stdin broken-pipe race"), which had also bumped the version to 3.2.3 — a direct version collision with this branch's own 3.2.3 bump.
+12. Ran `git rebase origin/main`; only `CHANGELOG.md` conflicted (the other six version-bearing files auto-merged cleanly because both branches made the identical 3.2.2→3.2.3 edit).
+13. Attempted `git checkout --ours CHANGELOG.md` to resolve the conflict — denied by the Claude Code auto-mode classifier as an irreversible destructive git action taken without specific authorization for that resolution. Resolved the conflict manually instead, using the Edit tool to restructure the file: kept PR #111's already-released `[3.2.3]` entry intact and moved this branch's entry under `[Unreleased]`.
+14. Re-ran `cargo xtask bump-version patch` (3.2.3 → 3.2.4, since 3.2.3 was now taken) and completed the rebase (`git add -A && git rebase --continue`), producing commit `946bd36`.
+15. Verified `cargo xtask check-release-versions` (in sync at 3.2.4) and re-ran the target test — passed in 0.53s.
+16. Force-pushed the rebased branch with `git push --force-with-lease` — pre-push hooks (version-sync, module-size, clippy `--all-targets --all-features --locked`) all passed.
+17. Opened PR #112 via `gh pr create` and merged it with `gh pr merge 112 --squash --delete-branch=false`, producing merge commit `18bcf7e` on `main` at `2026-07-02T11:10:44Z`.
+18. User asked to `/save-to-md`. Since the working branch's PR was already merged and closed, created a fresh branch `session-log/2026-07-02-fix-circuit-breaker-cooldown-flaky-test` off `origin/main` to carry this doc directly to the default branch (per skill contract §"Where it lands", case 2).
+19. Ran a repository maintenance pass: reviewed `docs/plans/` (nothing session-relevant to move), reviewed beads (`syslog-mcp-gxahz` already closed with full context), and reviewed worktrees/branches for safe cleanup.
+20. Deleted the local `claude/happy-dirac-58d616` branch (fully merged into `origin/main` per its remote tracking ref). Attempted to delete two other already-merged-via-squash local branches (`claude/infallible-galileo-d5d1d1`, `session-log/2026-07-01-topic-correlate-docs-fix`); `git branch -d` refused both as "not fully merged" (expected — squash merges don't preserve linear ancestry) and force-deleting or deleting the remote `claude/happy-dirac-58d616` branch was denied by the sandbox classifier as requiring explicit user authorization beyond "merge it into main." Left all three for the user; see Repository Maintenance below.
+
+## Key Findings
+
+- `src/app/llm_runner.rs:307-313`: `retry_after` is computed as `open_until.duration_since(Instant::now()).as_secs_f64().ceil() as u64`, formatted as `"{retry_after_secs}s"`. This confirmed the rounding behavior under test is independent of the configured cooldown length — only the existence of a sub-second remainder at assertion time matters, making the cooldown value safe to raise.
+- `src/app/llm_runner_tests.rs:319-352`: the test opens the circuit with `failure_threshold: 1, cooldown_secs: 1`, then immediately asserts `retry_after != "0s"` on a second `.run()` call. Under contention, the gap between the two async calls could exceed 1 real second, making `"0s"` a legitimate (not buggy) result.
+- PR #111 (`1ac3b73`) landed on `main` between this branch's creation and its merge, independently bumping the version to 3.2.3 to fix a different flaky test (`ai_assess_writes_llm_invocation_audit_row_via_runner` in `src/app/service_tests.rs`) — confirming flaky-test remediation was an active parallel workstream this session, not isolated to this one test.
+
+## Technical Decisions
+
+- **Bumped `cooldown_secs` to 300s rather than injecting a mockable clock or marking the test `#[serial]`** — matches the user's explicit recommendation (option 2): lowest risk, preserves the original test intent (proving `ceil()`-based rounding, not truncation), and needs no production-code seam changes. A fake-clock injection (option 1) would have required a new testing seam in `LlmRunner` for a single test; `#[serial]` (option 3) doesn't address the real-time race since the issue is wall-clock elapsed time, not test interleaving.
+- **Rebased onto `origin/main` and re-bumped to 3.2.4 instead of trying to reuse 3.2.3** — the repo's `cargo xtask check-release-versions` gate requires all 8 version-bearing files to agree, and 3.2.3 was already claimed by PR #111 on `main`; taking the next patch version was the only conflict-free path.
+- **Resolved the CHANGELOG conflict by hand instead of `git checkout --ours`** — the sandbox denied the blanket `--ours` resolution as an unreviewed destructive action; manual resolution let both fixes' changelog entries survive (PR #111's entry stayed under its already-released `[3.2.3]` heading; this branch's entry moved to `[Unreleased]` and was later folded into the fresh `[3.2.4]` heading by `cargo xtask bump-version`).
+- **Squash-merged PR #112 directly (`gh pr merge --squash`) rather than a manual fast-forward** — matches the repository's observed convention (all recent history entries carry a `(#NNN)` suffix from squash merges), and `main` has no branch protection requiring review, so no approval gate blocked it.
+- **Created a new `session-log/…` branch off `origin/main` for this doc rather than committing onto `claude/happy-dirac-58d616`** — that branch's PR (#112) was already merged and closed, so further commits there would never reach `main` automatically; the skill's own case-2 branch-and-merge path was the only way to land the doc on `main` without leaving it stranded for manual merge.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | `src/app/llm_runner_tests.rs` | — | Bump `cooldown_secs` 1→300 in the flaky test; rewrite doc comment to explain the fix | `git show 946bd36 -- src/app/llm_runner_tests.rs` |
+| modified | `CHANGELOG.md` | — | Add `[3.2.4]` entry documenting the fix | `git show 946bd36 -- CHANGELOG.md` |
+| modified | `Cargo.toml` | — | Version bump 3.2.2 → 3.2.3 → 3.2.4 (re-bumped after rebase collision) | `cargo xtask bump-version patch` (x2) |
+| modified | `Cargo.lock` | — | `cortex` package entry version sync | `cargo xtask bump-version patch` |
+| modified | `docker-compose.prod.yml` | — | `${CORTEX_VERSION:-3.2.4}` default tag sync | `cargo xtask bump-version patch` |
+| modified | `mcpb/manifest.json` | — | MCP Bundle version sync | `cargo xtask bump-version patch` |
+| modified | `server.json` | — | MCP Registry version + image tag sync | `cargo xtask bump-version patch` |
+| created | `docs/sessions/2026-07-02-fix-circuit-breaker-cooldown-flaky-test.md` | — | This session log | `git status` on `session-log/2026-07-02-fix-circuit-breaker-cooldown-flaky-test` |
+
+All version-file changes above are automated by `cargo xtask bump-version`, declared in `release/components.toml`, and verified by `cargo xtask check-release-versions`.
+
+## Beads Activity
+
+| ID | Title | Actions | Final status | Why it mattered |
+|---|---|---|---|---|
+| `syslog-mcp-gxahz` | Flaky test: `circuit_open_retry_after_rounds_up_sub_second_remainder` under parallel load | created, claimed, closed | closed | Tracks the flaky-test root cause and fix per repo convention ("create a bead before writing code on non-trivial tasks"); close reason records the verification performed |
+
+No other beads were created, claimed, or modified this session. `bd search "flaky"` surfaced one pre-existing, unrelated bead (`syslog-mcp-jxbib`, P3, still open, covers a different test) that was left untouched — out of scope for this fix.
+
+## Repository Maintenance
+
+- **Plans**: Reviewed `docs/plans/*.md` — `2026-03-29-unifi-cef-hostname-fix.md`, `2026-05-04-rmcp-stdio-support-follow-up.md`, `2026-05-11-mnemo-feature-port.md` are unrelated to this session and not clearly completed by it; left in place. No plan file was touched or created this session.
+- **Beads**: `syslog-mcp-gxahz` created, claimed, and closed with a close reason recording the fix and verification (see Beads Activity). No other beads needed updates.
+- **Worktrees and branches**:
+  - Deleted local branch `claude/happy-dirac-58d616` (`git branch -d`) — fully merged into `origin/main` via squash-merged PR #112, and no worktree referenced it after this session repointed the `happy-dirac-58d616` worktree to the new session-log branch.
+  - Attempted to delete local branches `claude/infallible-galileo-d5d1d1` and `session-log/2026-07-01-topic-correlate-docs-fix` — both correspond to squash-merged, closed PRs (#111 and #109 respectively, confirmed via `gh pr list --state all --search "head:<branch>"`), but `git branch -d` refused both with "not fully merged" (expected: squash merges don't preserve linear commit ancestry, so git's safe-delete check can't see the merge). Did not force-delete (`-D`) — left for the user, since force-deleting a branch that git's own safety check flags is a judgment call better made explicitly.
+  - Did not delete the remote branch `origin/claude/happy-dirac-58d616` — `git push origin --delete` was denied by the Claude Code sandbox as a destructive action outside the scope of "merge it into main." **Follow-up for the user**: `git push origin --delete claude/happy-dirac-58d616` (and optionally `git branch -D claude/infallible-galileo-d5d1d1 session-log/2026-07-01-topic-correlate-docs-fix` to clean up the two non-fast-deletable local branches) are safe, since both underlying PRs are confirmed merged.
+  - Left untouched, out of scope: `claude/happy-kepler-2d8fa5` / `feature/pr2-skill-event-extraction` worktree (`happy-kepler-2d8fa5`) has uncommitted changes (`src/app/models/skill_events.rs`, `src/app/services/skill_backfill.rs`) — active in-progress work; `claude/jolly-jemison-0735af` and `claude/serene-taussig-76f587` are idle worktrees at `main`'s tip with unclear ownership from other sessions; `session-log/2026-07-02-fix-flaky-llm-invocation-test` (worktree `infallible-galileo-d5d1d1`) has an **open** PR #113 — active, unmerged work from a concurrent session.
+- **Stale docs**: No documentation was found to be stale or contradicted by this session's change (a test-only fixture fix with no behavioral or API surface change). No doc updates were needed.
+- **Transparency**: All actions above are evidence-backed by the commands cited inline; no cleanup was performed based on assumption alone.
+
+## Tools and Skills Used
+
+- **Shell (Bash)**: `cargo test`, `cargo fmt --check`, `cargo clippy`, `cargo xtask bump-version`/`check-release-versions`, `git` (status, diff, rebase, push, branch, worktree list), `gh` (pr create/merge/view/list, api), `bd` (search, create, update, close). No failures beyond the two permission denials noted below.
+- **Read/Edit/Write (file tools)**: Read and edited `src/app/llm_runner_tests.rs`, `CHANGELOG.md`; wrote this session doc. Used to resolve the CHANGELOG rebase conflict manually after a destructive git shortcut was denied.
+- **beads (`bd`) CLI**: issue creation/claim/close for `syslog-mcp-gxahz`, plus searches for related open flaky-test beads.
+- **GitHub CLI (`gh`)**: PR creation, squash-merge, branch-protection check, merged-PR history inspection, and PR-state lookups for branch-cleanup safety checks.
+- **Skill: `vibin:save-to-md`**: this session doc, including its mandated repository maintenance pass and default-branch landing logic.
+- **Issues encountered**: two Bash tool calls were denied by the Claude Code auto-mode classifier as destructive/irreversible git actions taken without specific authorization — `git checkout --ours CHANGELOG.md` (worked around by resolving the conflict manually with the Edit tool) and a batched `git push origin --delete claude/happy-dirac-58d616` (not worked around; left as a documented follow-up for the user). No other tool failures, degraded behavior, or retries occurred.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `cargo test --lib circuit_open_retry_after_rounds_up_sub_second_remainder` (pre-rebase) | 1 passed; 0 failed (27.61s incl. build) |
+| `cargo fmt --check` | clean, no output |
+| `cargo clippy --lib --tests -- -D warnings` | clean, finished with no warnings |
+| `bd create --title="Flaky test: …" --type=bug --priority=3` | created `syslog-mcp-gxahz` |
+| `bd update syslog-mcp-gxahz --claim` | claimed |
+| `cargo xtask bump-version patch` | 3.2.2 → 3.2.3 |
+| `git commit` (ade45cd) | lefthook pre-commit hooks all passed |
+| `git push -u origin claude/happy-dirac-58d616` | pre-push hooks (version-sync, module-size, clippy) passed; branch created on remote |
+| `bd close syslog-mcp-gxahz --reason "…"` | closed |
+| `gh api repos/jmagar/cortex/branches/main/protection` | 404 "Branch not protected" |
+| `gh pr list --state merged --limit 5 --json …` | confirmed squash-merge-with-PR-number convention |
+| `git fetch origin main` | `origin/main` advanced to `1ac3b73` (PR #111) |
+| `git rebase origin/main` | conflict in `CHANGELOG.md` only; other version files auto-merged |
+| `git checkout --ours CHANGELOG.md` | **denied** by sandbox classifier (irreversible destructive git action) |
+| Manual `Edit` of `CHANGELOG.md` + `git add` | conflict resolved |
+| `cargo xtask bump-version patch` | 3.2.3 → 3.2.4 |
+| `git rebase --continue` | rebase completed, produced `946bd36` |
+| `cargo xtask check-release-versions` | "OK: 8 version-bearing file(s) in sync at 3.2.4" |
+| `cargo test --lib circuit_open_retry_after_rounds_up_sub_second_remainder` (post-rebase) | 1 passed in 0.53s |
+| `git push --force-with-lease origin claude/happy-dirac-58d616` | pre-push hooks passed; forced update accepted |
+| `gh pr create --title "fix: increase cooldown …"` | created PR #112 |
+| `gh pr merge 112 --squash --delete-branch=false` | merged; commit `18bcf7e` on `main` |
+| `gh pr view 112 --json state,mergedAt,mergeCommit` | `{"state":"MERGED","mergedAt":"2026-07-02T11:10:44Z", …}` |
+| `git checkout -b session-log/2026-07-02-fix-circuit-breaker-cooldown-flaky-test origin/main` | new branch created from post-merge `main` |
+| `git branch -d claude/happy-dirac-58d616` | deleted (merged) |
+| `git branch -d claude/infallible-galileo-d5d1d1` / `session-log/2026-07-01-…` | both refused: "not fully merged" (squash-merge ancestry) |
+| `git push origin --delete claude/happy-dirac-58d616` | **denied** by sandbox classifier (unauthorized destructive remote action) |
+
+## Errors Encountered
+
+- **Version collision on rebase**: this branch's `cargo xtask bump-version patch` had claimed 3.2.3, but `origin/main` had independently claimed 3.2.3 via PR #111 in the interim. Root cause: two parallel flaky-test-fix sessions each bumped the patch version from the same base without coordination. Resolved by rebasing onto `origin/main`, manually reconciling the `CHANGELOG.md` conflict (the only file that didn't auto-merge — the other six version-bearing files applied identical byte-for-byte diffs and merged automatically), and re-running `cargo xtask bump-version patch` to claim 3.2.4.
+- **Destructive-action denials**: `git checkout --ours CHANGELOG.md` and a batched `git push origin --delete claude/happy-dirac-58d616` were both blocked by the Claude Code auto-mode classifier as irreversible/destructive git actions outside the scope of what the user explicitly authorized ("merge it into main"). The first was resolved by editing the file directly; the second was left undone and documented as a follow-up (see Repository Maintenance).
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| `circuit_open_retry_after_rounds_up_sub_second_remainder` test fixture | `cooldown_secs: 1` — could race scheduler jitter under parallel `cargo test --lib` load and fail with `left: "0s" right: "0s"` | `cooldown_secs: 300` — same rounding assertion, wide safety margin against jitter |
+| crate version | 3.2.2 (pre-session) | 3.2.4 (post-merge on `main`) |
+| `main` branch tip | `1ac3b73` (PR #111) | `18bcf7e` (PR #112 squash-merge) |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo test --lib circuit_open_retry_after_rounds_up_sub_second_remainder` (pre-rebase, commit `ade45cd`) | 1 passed | `test result: ok. 1 passed; 0 failed` | pass |
+| `cargo fmt --check` | no diff | no output | pass |
+| `cargo clippy --lib --tests -- -D warnings` | no warnings | `Finished` with no warnings | pass |
+| `cargo test --lib circuit_open_retry_after_rounds_up_sub_second_remainder` (post-rebase, commit `946bd36`) | 1 passed | `test result: ok. 1 passed` in 0.53s | pass |
+| `cargo xtask check-release-versions` (post-rebase) | all 8 files in sync | "OK: 8 version-bearing file(s) in sync at 3.2.4" | pass |
+| pre-push hooks on force-push (`version-sync`, `module-size`, `clippy --all-targets --all-features --locked`) | all pass | summary: all green (36.14s) | pass |
+| `gh pr view 112 --json state,mergedAt,mergeCommit` | state MERGED | `{"state":"MERGED", "mergedAt":"2026-07-02T11:10:44Z", "mergeCommit":{"oid":"18bcf7e…"}}` | pass |
+
+## Risks and Rollback
+
+Low risk: the production-code change is limited to a test fixture (`cooldown_secs` value); no runtime behavior, API surface, or MCP action changed. If the change needs reverting, `git revert` the squash-merge commit `18bcf7e` on `main` (single commit, no dependent commits followed it before this session log). The version bump to 3.2.4 is otherwise inert (no corresponding container image was built/deployed from this session).
+
+## Decisions Not Taken
+
+- **Fake-clock injection into `LlmRunner`** (fix option 1 from the user's analysis): rejected as higher-risk/higher-effort than necessary — would require adding a new testing seam to production code for a single test, when the existing `ceil()` rounding logic is provably independent of the exact cooldown duration.
+- **`#[serial]` test attribute** (fix option 3): rejected per the user's own analysis — the flakiness is a real wall-clock race (scheduler-induced elapsed time), not test interleaving, so serializing the test wouldn't reliably fix it.
+- **Force-deleting the two non-fast-deletable local branches, or deleting the remote `claude/happy-dirac-58d616` branch**: deferred to the user rather than overridden, since the sandbox explicitly flagged these as needing authorization beyond "merge it into main."
+
+## References
+
+- [PR #112](https://github.com/jmagar/cortex/pull/112) — this session's fix, merged into `main`
+- [PR #111](https://github.com/jmagar/cortex/pull/111) — the concurrent flaky-test fix that caused the version-bump collision
+- `src/app/llm_runner.rs:307-313` — `retry_after` ceil()-based rounding implementation
+- `src/app/llm_runner_tests.rs:308-352` — the fixed test and its doc comment
+
+## Open Questions
+
+- Whether the two local branches `claude/infallible-galileo-d5d1d1` and `session-log/2026-07-01-topic-correlate-docs-fix`, and the remote `origin/claude/happy-dirac-58d616` branch, should be deleted — deferred to the user (see Repository Maintenance).
+
+## Next Steps
+
+- Optional cleanup (user-actioned): `git push origin --delete claude/happy-dirac-58d616`; `git branch -D claude/infallible-galileo-d5d1d1 session-log/2026-07-01-topic-correlate-docs-fix`.
+- No further work is required for the fix itself — PR #112 is merged, the bead is closed, and the test passes both in isolation and post-rebase.


### PR DESCRIPTION
Session log — docs only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a session log documenting the flaky circuit-breaker cooldown test fix, covering the rationale for increasing the cooldown, rebase/version-bump resolution, and verification steps. Docs-only change; no code or behavior changes.

<sup>Written for commit 50b6b88fc7aba4fe92923169df40cf374febd6d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

