### PR TITLE
fix(skill-backfill): recover Claude rows from source file, not logs.message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2026-07-02
+
+### Fixed
+
+- Fixed `cortex sessions skills backfill`'s Claude-row recovery, which was dead code against real ingested data: it checked `logs.message` for the raw `attributionSkill` JSON, but `logs.message` for a Claude row only ever holds the already-extracted plain-text `content` field (never the raw JSON), so the check could never match outside of hand-crafted test fixtures. The backfill now recovers Claude rows by re-reading the specific line of the original transcript file, located via the persisted `ai_transcript_path` column and the `line_no` recorded in `metadata_json` at ingest time. Line recovery goes through a new shared `scanner::read_transcript_lines` helper that reuses the ingest path's own bounded, newline-delimited record reader (`read_bounded_line` / `MAX_RECORD_SIZE_BYTES`) — so `line_no` values resolve to identical physical lines and a pathological/corrupted oversized line is skipped rather than read unbounded into memory. Added a new `source_unavailable` counter to `SkillBackfillResult`/the CLI output to report Claude rows that still can't be recovered (missing path/metadata, deleted/rotated source file, out-of-range line number, or an oversized line) — distinct from `parse_errors`, which now means "found the source line but it wasn't valid JSON"; each unrecoverable row is logged at `debug` with its `log_id`/path/line. Codex-row recovery (which reads directly from `logs.message`, unaffected by this bug) is unchanged. Note: re-running the backfill is idempotent only while source transcript files are unchanged — a Claude transcript line edited in place between runs can produce a second, differently-named event for the same `log_id`, since `skill_name` is re-derived from the file and is part of the `INSERT OR IGNORE` uniqueness key (documented in `docs/CLI.md`; append-only transcripts make this an edge case). See [GH #94](https://github.com/jmagar/cortex/issues/94) follow-up.
+
 ## [3.5.0] - 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "3.5.0"
+version = "3.5.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "3.5.0"
+version = "3.5.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.5.0}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.5.1}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -369,13 +369,41 @@ cortex sessions skills backfill --limit 50000
 `--since` (optional, normalized time expression) restricts the scan to
 rows at or after that timestamp. `--limit` (optional, defaults to 10000,
 hard-capped at 1,000,000) bounds the number of `logs` rows scanned in one
-call. `--dry-run` reports `scanned`/`parse_errors` without inserting any
-rows. Insertion is idempotent (`INSERT OR IGNORE` on
-`UNIQUE(log_id, skill_name, event_kind, evidence_kind)`), so re-running
-backfill is always safe. Only one backfill can run at a time process-wide;
-a concurrent second call fails fast with a "already running" error. Local
-mode only — this is a DB-heavy batch job that runs against the local
-`CortexService`, not proxied over HTTP.
+call. `--dry-run` reports `scanned`/`parse_errors`/`source_unavailable`
+without inserting any rows — note it still reads the source transcript files
+from disk to compute those counts, so it is not a zero-I/O preview; only the
+DB write is skipped. Insertion is idempotent (`INSERT OR IGNORE` on
+`UNIQUE(log_id, skill_name, event_kind, evidence_kind)`): re-running the
+backfill is a no-op **as long as the source transcript files are unchanged**.
+Because a Claude row's `skill_name` is re-derived from the file on each run
+and is part of that uniqueness key, editing a transcript line in place between
+runs can insert a second, differently-named event for the same `log_id`
+(the `INSERT OR IGNORE` sees a new key, not a conflict). Transcript files are
+append-only in practice, so this is an edge case, not a routine hazard. Only
+one backfill can run at a time process-wide; a concurrent second call fails
+fast with a "already running" error. Local mode only — this is a DB-heavy
+batch job that runs against the local `CortexService`, not proxied over HTTP.
+
+Codex rows are recovered directly from `logs.message` (the transcript text,
+including `<skill><name>` tags, survives ingest-time scrubbing intact).
+Claude rows are recovered by re-reading the specific line of the original
+transcript file (via the shared `scanner::read_transcript_lines` helper, which
+applies the same bounded, newline-delimited record semantics as the ingest
+path), located via the persisted `ai_transcript_path` column and the `line_no`
+recorded in `metadata_json` at ingest time — `logs.message` for a Claude row
+is already-extracted plain text and never contains the raw
+`attributionSkill`/`attributionPlugin` JSON. `source_unavailable` counts
+Claude rows where that recovery wasn't possible: no `ai_transcript_path`/
+`line_no` on the row (legacy rows ingested before that metadata existed),
+the source file no longer exists, or the recorded line is out of range or
+exceeds the record-size bound (file rotated/truncated/rewritten since
+ingest). Those rows are skipped, not treated as an error; run with
+`RUST_LOG=debug` to see the per-row reason (`log_id`, path, line number).
+A non-zero `source_unavailable` after a real pass is expected for
+pre-metadata legacy rows and for transcripts since deleted or rotated — those
+are permanently unrecoverable via this command and need no action. An
+unexpectedly high count on recently-ingested rows suggests the transcript
+source directory moved; verify `ai_transcript_path` still resolves.
 
 ### `cortex sessions blocks`
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "3.5.0",
+  "version": "3.5.1",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v3.5.0",
+      "identifier": "ghcr.io/jmagar/cortex:v3.5.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/app/models/skill_events.rs
+++ b/src/app/models/skill_events.rs
@@ -15,6 +15,13 @@ pub struct SkillBackfillResult {
     pub inserted: u64,
     pub skipped_duplicates: u64,
     pub parse_errors: u64,
+    /// Claude rows whose raw JSON could not be recovered from the source
+    /// transcript file — `ai_transcript_path`/`line_no` metadata missing, the
+    /// source file no longer exists, or the recorded line number is out of
+    /// range (e.g. file rotated/truncated since ingest). Distinct from
+    /// `parse_errors`, which counts lines that WERE located but failed to
+    /// parse as JSON.
+    pub source_unavailable: u64,
     pub truncated: bool,
     pub dry_run: bool,
 }

--- a/src/app/services/skill_backfill.rs
+++ b/src/app/services/skill_backfill.rs
@@ -24,13 +24,55 @@
 //! `api.rs`'s `SHARED_MAINTENANCE_PERMIT`) because this method is also
 //! reachable from the CLI's local mode and MCP, neither of which goes
 //! through `api.rs`.
+//!
+//! **Claude row recovery**: `logs.message` for a Claude row is
+//! `claude::extract_message()`'s plain-text `content` extraction (e.g. "hi")
+//! — it never carries the raw `attributionSkill`/`attributionPlugin` JSON
+//! fields, unlike Codex where the transcript text itself (including the
+//! `<skill><name>` tag) survives `scrub_ai_message` intact. The only place
+//! that data still exists is the original JSONL file on disk, so Claude rows
+//! are recovered by re-reading the specific source line (via the shared
+//! `scanner::read_transcript_lines` helper, which applies the same bounded,
+//! newline-delimited record semantics as the ingest path) located by the
+//! persisted `ai_transcript_path` column and the `line_no` scanner.rs recorded
+//! in `metadata_json` at ingest time. Rows whose source file or line can no
+//! longer be located (deleted/rotated/legacy metadata predating `line_no`, or
+//! a line now exceeding the record-size bound) are counted in
+//! `source_unavailable` rather than treated as an error.
+//!
+//! **Idempotency caveat**: re-running the backfill is a no-op *only while the
+//! source transcript files are unchanged*. Because the recovered `skill_name`
+//! is part of the `ai_skill_events` uniqueness key and is re-derived from the
+//! file on each run, editing a transcript line in place between runs can yield
+//! a second, differently-named event for the same `log_id` (the `INSERT OR
+//! IGNORE` sees a new key, not a conflict). Transcript files are append-only
+//! in practice, so this is an edge case, but the "always safe to re-run" claim
+//! is conditional on that. See the follow-up bead for optional content-hash
+//! verification if this ever needs a hard guarantee.
+//!
+//! **Memory bound**: each recovered line is capped at `MAX_RECORD_SIZE_BYTES`
+//! by the shared reader (oversized lines are skipped, not buffered), so no
+//! single line can blow up memory. The per-chunk working set (`resolved`) is
+//! *not* separately budgeted, so the theoretical transient ceiling is
+//! `CHUNK_SIZE` recovered lines held at once — pathological only if a whole
+//! chunk of rows each point at a distinct near-`MAX_RECORD_SIZE_BYTES` line.
+//! Real transcript records are far smaller (KB-scale JSON), and `resolved` is
+//! rebuilt-and-dropped per chunk (never accumulated across the run), so this
+//! is bounded and self-freeing rather than a leak. A hard per-chunk byte
+//! budget was considered and rejected: skipping over-budget rows would advance
+//! `last_id` past them and drop them permanently (they are not truly
+//! unavailable), so a correct cap would require dynamic chunk resizing — not
+//! worth the complexity for an offline, single-flight, operator-triggered job.
 
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
 use tokio::sync::Semaphore;
 
 use crate::db::{DbPool, SkillEventInsert, insert_skill_events};
+use crate::scanner::read_transcript_lines;
 use crate::scanner::skill_events::{extract_claude_skill_events, extract_codex_skill_events};
 
 use super::super::models::{SkillBackfillRequest, SkillBackfillResult};
@@ -67,6 +109,8 @@ struct CandidateRow {
     hostname: String,
     timestamp: String,
     message: String,
+    ai_transcript_path: Option<String>,
+    metadata_json: Option<String>,
 }
 
 impl CortexService {
@@ -127,19 +171,80 @@ fn run_backfill(
         result.scanned += rows.len() as u64;
         remaining = remaining.saturating_sub(rows.len() as u64);
 
+        // Resolve every Claude row's source line up front, grouped by file so
+        // rows sharing a transcript file open and scan it once per chunk. Two
+        // borrowed maps over `rows` (no owned-String clones): `row_source` maps
+        // each row id to its `(path, line_no)`, and `wanted_by_file` collects
+        // the distinct line numbers to pull from each file. See the "Claude row
+        // recovery" note at the top of this file for why `row.message` can't be
+        // used directly.
+        let mut row_source: HashMap<i64, (&str, usize)> = HashMap::new();
+        let mut wanted_by_file: HashMap<&str, HashSet<usize>> = HashMap::new();
+        for row in &rows {
+            if row.ai_tool != "claude" {
+                continue;
+            }
+            match (
+                row.ai_transcript_path.as_deref(),
+                row.metadata_json.as_deref().and_then(line_no_from_metadata),
+            ) {
+                (Some(path), Some(line_no)) => {
+                    row_source.insert(row.id, (path, line_no));
+                    wanted_by_file.entry(path).or_default().insert(line_no);
+                }
+                _ => {
+                    result.source_unavailable += 1;
+                    tracing::debug!(
+                        log_id = row.id,
+                        "skill backfill: claude row missing ai_transcript_path/line_no metadata; unrecoverable"
+                    );
+                }
+            }
+        }
+        let mut resolved: HashMap<(&str, usize), String> = HashMap::new();
+        for (path, wanted) in &wanted_by_file {
+            match read_transcript_lines(Path::new(*path), wanted) {
+                Ok(lines) => {
+                    for (line_no, text) in lines {
+                        resolved.insert((*path, line_no), text);
+                    }
+                }
+                Err(err) => {
+                    // File gone/unreadable — every row wanting this file falls
+                    // through to source_unavailable in the loop below.
+                    tracing::debug!(
+                        path = *path,
+                        error = %err,
+                        "skill backfill: could not read transcript file for claude row recovery"
+                    );
+                }
+            }
+        }
+
         let mut inserts = Vec::new();
         for row in &rows {
-            // Eng review Fix 1: the backfill reads `row.message` straight
-            // from the `logs` table (there is no pre-parsed Value to reuse
-            // here, unlike the ingest hot path — this is a one-time
-            // historical scan, not the per-request ingest loop), so a JSON
-            // parse is unavoidable for Claude rows that DO have a skill
-            // event. The substring short-circuit still applies: skip the
-            // parse entirely for the common case where the row has no
-            // attributionSkill field at all.
             let extracted = match row.ai_tool.as_str() {
-                "claude" if row.message.contains("attributionSkill") => {
-                    match serde_json::from_str::<serde_json::Value>(&row.message) {
+                "claude" => {
+                    let Some(&(path, line_no)) = row_source.get(&row.id) else {
+                        // Already counted in `source_unavailable` above.
+                        continue;
+                    };
+                    let Some(line_text) = resolved.get(&(path, line_no)) else {
+                        result.source_unavailable += 1;
+                        tracing::debug!(
+                            log_id = row.id,
+                            path,
+                            line_no,
+                            "skill backfill: transcript line unavailable (missing file or line out of range)"
+                        );
+                        continue;
+                    };
+                    // Cheap short-circuit on the actual raw JSON line (not
+                    // the scrubbed `row.message`) before parsing.
+                    if !line_text.contains("attributionSkill") {
+                        continue;
+                    }
+                    match serde_json::from_str::<serde_json::Value>(line_text) {
                         Ok(value) => extract_claude_skill_events(&value),
                         Err(_) => {
                             result.parse_errors += 1;
@@ -147,7 +252,6 @@ fn run_backfill(
                         }
                     }
                 }
-                "claude" => continue,
                 "codex" => extract_codex_skill_events(&row.message),
                 _ => continue,
             };
@@ -171,10 +275,10 @@ fn run_backfill(
             result.skipped_duplicates += attempted - inserted;
         }
         // Dry-run does not report a "would insert N" count — scanned /
-        // parse_errors are the only meaningful dry-run signal per the CLI
-        // contract (`--dry-run` reports scanned rows and parse errors
-        // without touching the table). Callers that need a precise
-        // "would insert N" count should drop --dry-run.
+        // parse_errors / source_unavailable are the only meaningful dry-run
+        // signal per the CLI contract (`--dry-run` reports scanned rows and
+        // parse errors without touching the table). Callers that need a
+        // precise "would insert N" count should drop --dry-run.
 
         if (rows.len() as i64) < chunk_limit {
             break;
@@ -193,7 +297,8 @@ fn fetch_candidate_chunk(
 ) -> Result<Vec<CandidateRow>> {
     let (sql, bindings): (&str, Vec<rusqlite::types::Value>) = match since {
         Some(since) => (
-            "SELECT id, ai_tool, ai_project, ai_session_id, hostname, timestamp, message
+            "SELECT id, ai_tool, ai_project, ai_session_id, hostname, timestamp, message,
+                    ai_transcript_path, metadata_json
              FROM logs
              WHERE ai_tool IN ('claude', 'codex')
                AND id > ?1
@@ -207,7 +312,8 @@ fn fetch_candidate_chunk(
             ],
         ),
         None => (
-            "SELECT id, ai_tool, ai_project, ai_session_id, hostname, timestamp, message
+            "SELECT id, ai_tool, ai_project, ai_session_id, hostname, timestamp, message,
+                    ai_transcript_path, metadata_json
              FROM logs
              WHERE ai_tool IN ('claude', 'codex')
                AND id > ?1
@@ -230,10 +336,26 @@ fn fetch_candidate_chunk(
                 hostname: row.get(4)?,
                 timestamp: row.get(5)?,
                 message: row.get(6)?,
+                ai_transcript_path: row.get(7)?,
+                metadata_json: row.get(8)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
     Ok(rows)
+}
+
+/// Extract the `line_no` scanner.rs's `flush_chunk` records in `metadata_json`
+/// at ingest time (`{"line_no": N, ...}`). `line_no` is 0-based, matching the
+/// scanner's own counter (recorded before incrementing, starting from 0 for
+/// the first line of a file), so it feeds directly into
+/// `scanner::read_transcript_lines`. Returns `None` for legacy rows ingested
+/// before this field existed, malformed JSON, a metadata blob truncated by
+/// `bounded_metadata_json`'s size guard, or a `line_no` that doesn't fit in
+/// `usize` (corrupt/adversarial value — routed to `source_unavailable` rather
+/// than silently truncated).
+fn line_no_from_metadata(metadata_json: &str) -> Option<usize> {
+    let value: serde_json::Value = serde_json::from_str(metadata_json).ok()?;
+    usize::try_from(value.get("line_no")?.as_u64()?).ok()
 }
 
 #[cfg(test)]

--- a/src/app/services/skill_backfill_tests.rs
+++ b/src/app/services/skill_backfill_tests.rs
@@ -3,9 +3,10 @@ use crate::app::CortexService;
 use crate::config::StorageConfig;
 use crate::db::{DbPool, init_pool};
 use serial_test::serial;
+use std::path::Path;
 use std::sync::Arc;
 
-// All four tests below share the process-wide `backfill_guard()` singleton
+// All tests below share the process-wide `backfill_guard()` singleton
 // semaphore, so they must not run concurrently with each other (a parallel
 // test run would otherwise race on the same permit and produce spurious
 // `Busy` failures unrelated to the behavior under test — see eng review
@@ -19,23 +20,72 @@ fn test_service() -> (CortexService, tempfile::TempDir) {
     (CortexService::new(pool, storage), dir)
 }
 
-fn insert_claude_log_row(pool: &DbPool, message: &str) -> i64 {
+/// Single source of truth for the `logs` INSERT used by every helper below —
+/// `ai_transcript_path`/`metadata_json.line_no` are always written together
+/// (`Some`) or omitted together (`None`, the legacy no-source shape), so the
+/// column list can't drift between the recoverable and unrecoverable fixtures.
+/// `logs.message` is always the scrubbed plain text (`'hi'`), matching what the
+/// real ingest pipeline stores for a Claude row.
+fn insert_claude_row(pool: &DbPool, source: Option<(&str, usize)>) -> i64 {
     let conn = pool.get().unwrap();
-    conn.execute(
-        "INSERT INTO logs (timestamp, hostname, severity, message, raw, source_ip, ai_tool, ai_project, ai_session_id)
-         VALUES ('2026-06-01T00:00:00.000Z', 'dookie', 'info', ?1, ?1, 'transcript://claude_project', 'claude', 'cortex', 'sess-1')",
-        rusqlite::params![message],
-    )
-    .unwrap();
+    match source {
+        Some((transcript_path, line_no)) => {
+            let metadata_json = serde_json::json!({ "line_no": line_no }).to_string();
+            conn.execute(
+                "INSERT INTO logs (timestamp, hostname, severity, message, raw, source_ip, ai_tool, ai_project, ai_session_id, ai_transcript_path, metadata_json)
+                 VALUES ('2026-06-01T00:00:00.000Z', 'dookie', 'info', 'hi', 'hi', 'transcript://claude_project', 'claude', 'cortex', 'sess-1', ?1, ?2)",
+                rusqlite::params![transcript_path, metadata_json],
+            )
+            .unwrap();
+        }
+        None => {
+            conn.execute(
+                "INSERT INTO logs (timestamp, hostname, severity, message, raw, source_ip, ai_tool, ai_project, ai_session_id, ai_transcript_path, metadata_json)
+                 VALUES ('2026-06-01T00:00:00.000Z', 'dookie', 'info', 'hi', 'hi', 'transcript://claude_project', 'claude', 'cortex', 'sess-1', NULL, NULL)",
+                [],
+            )
+            .unwrap();
+        }
+    }
     conn.last_insert_rowid()
+}
+
+/// Writes `raw_line` as the only line of a fresh transcript file under `dir`
+/// and inserts a matching `logs` row with `ai_transcript_path`/`metadata_json`
+/// set the way `scanner.rs::flush_chunk` sets them at real ingest time — this
+/// is what a genuinely re-ingested Claude row looks like, as opposed to the
+/// old fixture shape (raw JSON stuffed directly into `logs.message`), which
+/// cannot occur from the real ingest pipeline (see module doc comment).
+fn insert_claude_log_row(pool: &DbPool, dir: &Path, file_name: &str, raw_line: &str) -> i64 {
+    let path = dir.join(file_name);
+    std::fs::write(&path, format!("{raw_line}\n")).unwrap();
+    // 0-based, matching scanner.rs's `flush_chunk` line_no counter — the
+    // first line of a file is line_no 0.
+    insert_claude_log_row_for_path(pool, &path.to_string_lossy(), 0)
+}
+
+fn insert_claude_log_row_for_path(pool: &DbPool, transcript_path: &str, line_no: usize) -> i64 {
+    insert_claude_row(pool, Some((transcript_path, line_no)))
+}
+
+/// A legacy-shaped row with no `ai_transcript_path`/`metadata_json` at all —
+/// what rows ingested before either column existed look like. Unrecoverable
+/// by design; the backfill can only report it as `source_unavailable`.
+fn insert_legacy_claude_log_row_without_source(pool: &DbPool) -> i64 {
+    insert_claude_row(pool, None)
 }
 
 #[tokio::test]
 #[serial(skill_backfill_guard)]
 async fn dry_run_reports_counts_without_inserting() {
-    let (service, _dir) = test_service();
+    let (service, dir) = test_service();
     let pool = service.pool_for_test();
-    insert_claude_log_row(&pool, r#"{"attributionSkill":"cortex-troubleshoot"}"#);
+    insert_claude_log_row(
+        &pool,
+        dir.path(),
+        "session.jsonl",
+        r#"{"attributionSkill":"cortex-troubleshoot"}"#,
+    );
 
     let result = service
         .backfill_skill_events(SkillBackfillRequest {
@@ -48,6 +98,7 @@ async fn dry_run_reports_counts_without_inserting() {
 
     assert_eq!(result.scanned, 1);
     assert_eq!(result.inserted, 0);
+    assert_eq!(result.source_unavailable, 0);
     assert!(result.dry_run);
 
     let conn = pool.get().unwrap();
@@ -60,9 +111,14 @@ async fn dry_run_reports_counts_without_inserting() {
 #[tokio::test]
 #[serial(skill_backfill_guard)]
 async fn real_run_inserts_events_and_is_idempotent() {
-    let (service, _dir) = test_service();
+    let (service, dir) = test_service();
     let pool = service.pool_for_test();
-    insert_claude_log_row(&pool, r#"{"attributionSkill":"cortex-troubleshoot"}"#);
+    insert_claude_log_row(
+        &pool,
+        dir.path(),
+        "session.jsonl",
+        r#"{"attributionSkill":"cortex-troubleshoot"}"#,
+    );
 
     let first = service
         .backfill_skill_events(SkillBackfillRequest {
@@ -75,6 +131,7 @@ async fn real_run_inserts_events_and_is_idempotent() {
     assert_eq!(first.scanned, 1);
     assert_eq!(first.inserted, 1);
     assert_eq!(first.skipped_duplicates, 0);
+    assert_eq!(first.source_unavailable, 0);
 
     let second = service
         .backfill_skill_events(SkillBackfillRequest {
@@ -91,11 +148,183 @@ async fn real_run_inserts_events_and_is_idempotent() {
 
 #[tokio::test]
 #[serial(skill_backfill_guard)]
+async fn claude_row_without_transcript_path_counts_as_source_unavailable() {
+    // The gap this fix addresses: a legacy row with no `ai_transcript_path`/
+    // `metadata_json` has no way to recover the raw JSON that once carried
+    // `attributionSkill`. It must be reported, not silently dropped or
+    // (worse) misreported as a successful no-op scan.
+    let (service, _dir) = test_service();
+    let pool = service.pool_for_test();
+    insert_legacy_claude_log_row_without_source(&pool);
+
+    let result = service
+        .backfill_skill_events(SkillBackfillRequest {
+            since: None,
+            limit: Some(100),
+            dry_run: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.scanned, 1);
+    assert_eq!(result.inserted, 0);
+    assert_eq!(result.source_unavailable, 1);
+    assert_eq!(result.parse_errors, 0);
+}
+
+#[tokio::test]
+#[serial(skill_backfill_guard)]
+async fn claude_row_with_missing_source_file_counts_as_source_unavailable() {
+    // ai_transcript_path/metadata_json are present but the file has since
+    // been deleted or rotated away — also unrecoverable, also reported.
+    let (service, _dir) = test_service();
+    let pool = service.pool_for_test();
+    insert_claude_log_row_for_path(&pool, "/nonexistent/path/session.jsonl", 0);
+
+    let result = service
+        .backfill_skill_events(SkillBackfillRequest {
+            since: None,
+            limit: Some(100),
+            dry_run: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.scanned, 1);
+    assert_eq!(result.inserted, 0);
+    assert_eq!(result.source_unavailable, 1);
+}
+
+#[tokio::test]
+#[serial(skill_backfill_guard)]
+async fn claude_row_with_out_of_range_line_no_counts_as_source_unavailable() {
+    // The file exists but no longer has a line at the recorded line_no
+    // (truncated/rewritten since ingest).
+    let (service, dir) = test_service();
+    let pool = service.pool_for_test();
+    let path = dir.path().join("session.jsonl");
+    std::fs::write(&path, "{}\n").unwrap();
+    insert_claude_log_row_for_path(&pool, &path.to_string_lossy(), 5);
+
+    let result = service
+        .backfill_skill_events(SkillBackfillRequest {
+            since: None,
+            limit: Some(100),
+            dry_run: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.scanned, 1);
+    assert_eq!(result.inserted, 0);
+    assert_eq!(result.source_unavailable, 1);
+}
+
+#[tokio::test]
+#[serial(skill_backfill_guard)]
+async fn claude_row_source_line_without_skill_produces_no_event_or_error() {
+    // The common case: the recovered line is valid JSON but genuinely has no
+    // skill attribution. Not an error, not "unavailable" — just nothing to
+    // insert.
+    let (service, dir) = test_service();
+    let pool = service.pool_for_test();
+    insert_claude_log_row(&pool, dir.path(), "session.jsonl", r#"{"content":"hi"}"#);
+
+    let result = service
+        .backfill_skill_events(SkillBackfillRequest {
+            since: None,
+            limit: Some(100),
+            dry_run: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.scanned, 1);
+    assert_eq!(result.inserted, 0);
+    assert_eq!(result.source_unavailable, 0);
+    assert_eq!(result.parse_errors, 0);
+}
+
+#[tokio::test]
+#[serial(skill_backfill_guard)]
+async fn claude_row_with_malformed_source_line_counts_as_parse_error() {
+    // The recovered line contains the attributionSkill substring but isn't
+    // valid JSON — distinct failure mode from a missing source, so it must
+    // land in `parse_errors`, not `source_unavailable`.
+    let (service, dir) = test_service();
+    let pool = service.pool_for_test();
+    insert_claude_log_row(
+        &pool,
+        dir.path(),
+        "session.jsonl",
+        r#"{"attributionSkill":"cortex" not valid json"#,
+    );
+
+    let result = service
+        .backfill_skill_events(SkillBackfillRequest {
+            since: None,
+            limit: Some(100),
+            dry_run: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.scanned, 1);
+    assert_eq!(result.inserted, 0);
+    assert_eq!(result.parse_errors, 1);
+    assert_eq!(result.source_unavailable, 0);
+}
+
+#[tokio::test]
+#[serial(skill_backfill_guard)]
+async fn claude_rows_sharing_a_transcript_file_are_both_recovered() {
+    // Two rows pointing at different lines of the SAME file — exercises the
+    // inline per-chunk file grouping in `run_backfill` (`wanted_by_file` →
+    // one `scanner::read_transcript_lines` pass per file, not one file-open
+    // per row).
+    let (service, dir) = test_service();
+    let pool = service.pool_for_test();
+    let path = dir.path().join("session.jsonl");
+    std::fs::write(
+        &path,
+        concat!(
+            r#"{"attributionSkill":"cortex-troubleshoot"}"#,
+            "\n",
+            r#"{"attributionSkill":"cortex-report"}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+    insert_claude_log_row_for_path(&pool, &path.to_string_lossy(), 0);
+    insert_claude_log_row_for_path(&pool, &path.to_string_lossy(), 1);
+
+    let result = service
+        .backfill_skill_events(SkillBackfillRequest {
+            since: None,
+            limit: Some(100),
+            dry_run: false,
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(result.scanned, 2);
+    assert_eq!(result.inserted, 2);
+    assert_eq!(result.source_unavailable, 0);
+    assert_eq!(result.parse_errors, 0);
+}
+
+#[tokio::test]
+#[serial(skill_backfill_guard)]
 async fn limit_is_clamped_to_hard_upper_bound() {
     // Eng review Fix 7 — an operator/caller passing an absurd limit doesn't
     // drive an unbounded scan; it's silently clamped to the hard cap.
-    let (service, _dir) = test_service();
-    insert_claude_log_row(&service.pool_for_test(), r#"{"attributionSkill":"cortex"}"#);
+    let (service, dir) = test_service();
+    insert_claude_log_row(
+        &service.pool_for_test(),
+        dir.path(),
+        "session.jsonl",
+        r#"{"attributionSkill":"cortex"}"#,
+    );
 
     // 10_000_000 exceeds the hard cap (1_000_000) — should not error, should
     // just clamp. We can't easily observe the internal clamp directly
@@ -123,8 +352,13 @@ async fn concurrent_backfill_calls_return_busy_instead_of_racing() {
     // race is flaky to assert deterministically in a unit test) — it holds
     // the guard manually to simulate an in-flight backfill, then asserts the
     // service call observes it and fails fast.
-    let (service, _dir) = test_service();
-    insert_claude_log_row(&service.pool_for_test(), r#"{"attributionSkill":"cortex"}"#);
+    let (service, dir) = test_service();
+    insert_claude_log_row(
+        &service.pool_for_test(),
+        dir.path(),
+        "session.jsonl",
+        r#"{"attributionSkill":"cortex"}"#,
+    );
 
     let _held = super::backfill_guard()
         .clone()

--- a/src/cli/dispatch_sessions.rs
+++ b/src/cli/dispatch_sessions.rs
@@ -345,11 +345,12 @@ pub(crate) async fn run_ai_skills_backfill(
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
         println!(
-            "scanned={} inserted={} skipped_duplicates={} parse_errors={} truncated={} dry_run={}",
+            "scanned={} inserted={} skipped_duplicates={} parse_errors={} source_unavailable={} truncated={} dry_run={}",
             response.scanned,
             response.inserted,
             response.skipped_duplicates,
             response.parse_errors,
+            response.source_unavailable,
             response.truncated,
             response.dry_run
         );

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -534,7 +534,7 @@ pub fn index_file_with_options(
     };
 
     loop {
-        let Some(read_line) = read_bounded_line(&mut reader, &mut hasher)? else {
+        let Some(read_line) = read_bounded_line(&mut reader, Some(&mut hasher))? else {
             break;
         };
         if read_line.oversized {
@@ -964,10 +964,10 @@ fn detect_explicit_file_source_kind(path: &Path) -> Result<SourceKind> {
     }
     let file = fs::File::open(path)?;
     let mut reader = BufReader::new(file);
-    let mut hasher = Sha256::new();
     let mut line_no = 0usize;
     while line_no < 50 {
-        let Some(read_line) = read_bounded_line(&mut reader, &mut hasher)? else {
+        // Sniffing source kind only needs the text, not the checkpoint digest.
+        let Some(read_line) = read_bounded_line(&mut reader, None)? else {
             return Ok(SourceKind::ExplicitFile);
         };
         if read_line.oversized {
@@ -1445,7 +1445,16 @@ struct ReadLine {
     oversized: bool,
 }
 
-fn read_bounded_line<R: BufRead>(reader: &mut R, hasher: &mut Sha256) -> Result<Option<ReadLine>> {
+/// Read one newline-delimited record, capping it at `MAX_RECORD_SIZE_BYTES`.
+///
+/// `hasher` is optional: the ingest/checkpoint path passes `Some(..)` to fold
+/// each byte into the source-file digest, while callers that only need the
+/// text (e.g. `read_transcript_lines`, the skill-event backfill's historical
+/// recovery) pass `None` to skip the SHA-256 work entirely.
+fn read_bounded_line<R: BufRead>(
+    reader: &mut R,
+    mut hasher: Option<&mut Sha256>,
+) -> Result<Option<ReadLine>> {
     let mut line = Vec::new();
     let mut oversized = false;
     loop {
@@ -1458,7 +1467,9 @@ fn read_bounded_line<R: BufRead>(reader: &mut R, hasher: &mut Sha256) -> Result<
         }
         let newline_pos = available.iter().position(|byte| *byte == b'\n');
         let take_len = newline_pos.map_or(available.len(), |pos| pos + 1);
-        hasher.update(&available[..take_len]);
+        if let Some(hasher) = hasher.as_deref_mut() {
+            hasher.update(&available[..take_len]);
+        }
         if !oversized {
             // Copy one sentinel byte past the inclusive record limit so we can
             // detect oversized records while still accepting exactly-limit rows.
@@ -1488,6 +1499,42 @@ fn read_bounded_line<R: BufRead>(reader: &mut R, hasher: &mut Sha256) -> Result<
         text,
         oversized: false,
     }))
+}
+
+/// Recover specific 0-based lines from a transcript file, using the same
+/// bounded, newline-delimited record semantics as the ingest path
+/// (`read_bounded_line` / `MAX_RECORD_SIZE_BYTES`) so `line_no` values recorded
+/// at ingest time resolve to the same physical lines here. Opens and scans the
+/// file once, stopping as soon as every requested line has been found.
+///
+/// Returns only the requested lines that were located and are within the
+/// record-size bound. A line beyond EOF (file truncated/rotated since ingest)
+/// or one that now exceeds `MAX_RECORD_SIZE_BYTES` (file corrupted/rewritten)
+/// is simply absent from the returned map — callers treat that as
+/// "source unavailable" rather than an error, since this is best-effort
+/// historical recovery, not the live ingest path. Trailing `\r`/`\n` is
+/// trimmed to match how the ingest path normalizes each record before parsing.
+pub(crate) fn read_transcript_lines(
+    path: &Path,
+    wanted: &HashSet<usize>,
+) -> Result<HashMap<usize, String>> {
+    let file = fs::File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut out = HashMap::new();
+    let mut line_no = 0usize;
+    let mut remaining = wanted.len();
+    while remaining > 0 {
+        let Some(read_line) = read_bounded_line(&mut reader, None)? else {
+            break; // EOF before every requested line was found
+        };
+        if !read_line.oversized && wanted.contains(&line_no) {
+            let text = read_line.text.trim_end_matches(['\r', '\n']).to_string();
+            out.insert(line_no, text);
+            remaining -= 1;
+        }
+        line_no += 1;
+    }
+    Ok(out)
 }
 
 fn default_roots() -> Vec<PathBuf> {

--- a/src/scanner_tests.rs
+++ b/src/scanner_tests.rs
@@ -1601,20 +1601,20 @@ fn transcript_row_with_no_skill_reference_creates_no_skill_event() {
 
 #[tokio::test]
 async fn end_to_end_ingest_then_backfill_is_idempotent_across_both_paths() {
-    // Row 1 uses Codex, not Claude: `logs.message` for a Codex row IS the
-    // scannable transcript text (the `<skill><name>` regex reads it
-    // directly), so it stays intact through `scrub_ai_message` and remains
-    // recoverable by the backfill's `row.message` re-scan. A Claude row's
-    // `logs.message` is `extract_message`'s plain-text `content` extraction
-    // (e.g. "hi"), which NEVER contains the raw `attributionSkill` JSON
-    // field — that data exists only in the source JSONL file, never
-    // persisted to the DB. This is a real, confirmed constraint of the
-    // shipped backfill design (it re-scans `logs.message`/`logs.raw`, and
-    // neither ever holds raw JSON for Claude rows), not a limitation of this
-    // test. See PR2 handoff notes for the follow-up bead tracking this gap.
+    // Codex row: `logs.message` for a Codex row IS the scannable transcript
+    // text (the `<skill><name>` regex reads it directly), so it stays intact
+    // through `scrub_ai_message` and remains recoverable by the backfill's
+    // `row.message` re-scan. Claude rows are different: `logs.message` is
+    // `extract_message`'s plain-text `content` extraction (e.g. "hi"), which
+    // NEVER contains the raw `attributionSkill` JSON field. The backfill
+    // recovers Claude rows instead by re-reading the source transcript file
+    // via the persisted `ai_transcript_path` column and the `line_no`
+    // recorded in `metadata_json` at ingest time — see
+    // `src/app/services/skill_backfill.rs`'s module doc comment.
     let (pool, dir) = test_pool();
 
-    // Row 1: indexed normally (picks up the skill event via flush_chunk).
+    // Row 1 (Codex, ingested normally): picks up the skill event via
+    // flush_chunk at ingest time.
     let codex_file = dir.path().join("codex.jsonl");
     std::fs::write(
         &codex_file,
@@ -1626,12 +1626,12 @@ async fn end_to_end_ingest_then_backfill_is_idempotent_across_both_paths() {
     .unwrap();
     index_file(&pool, &codex_file, "codex_session").unwrap();
 
-    // Row 2: inserted directly into `logs` bypassing the scanner entirely,
-    // simulating a Codex transcript row ingested BEFORE this phase shipped
-    // — this is exactly what `sessions skills backfill` exists to catch up.
-    // Codex's `message` column already holds the raw transcript text (never
-    // JSON-extracted away), so a pre-existing Codex row's skill tag is
-    // genuinely recoverable via backfill, unlike Claude's.
+    // Row 2 (Codex, pre-existing/legacy): inserted directly into `logs`
+    // bypassing the scanner entirely, simulating a Codex transcript row
+    // ingested BEFORE this phase shipped. Codex's `message` column already
+    // holds the raw transcript text (never JSON-extracted away), so a
+    // pre-existing Codex row's skill tag is recoverable straight from
+    // `logs.message` via backfill.
     {
         let conn = pool.get().unwrap();
         conn.execute(
@@ -1642,17 +1642,56 @@ async fn end_to_end_ingest_then_backfill_is_idempotent_across_both_paths() {
         .unwrap();
     }
 
+    // Row 3 (Claude, ingested normally): picks up the skill event via
+    // flush_chunk at ingest time, same as row 1.
+    let claude_file = dir.path().join("claude.jsonl");
+    std::fs::write(
+        &claude_file,
+        concat!(
+            r#"{"sessionId":"sess-3","attributionSkill":"cortex-troubleshoot","attributionPlugin":"cortex","content":"ran troubleshoot"}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+    index_file(&pool, &claude_file, "explicit_file").unwrap();
+
+    // Row 4 (Claude, pre-existing/legacy): inserted directly into `logs`
+    // with a real `ai_transcript_path` + `metadata_json.line_no` pointing at
+    // a source file on disk, simulating a row ingested before this phase's
+    // ingest-time skill extraction existed but whose transcript file is
+    // still present — exactly the case the backfill's file re-read recovers.
+    let legacy_claude_file = dir.path().join("legacy-claude.jsonl");
+    std::fs::write(
+        &legacy_claude_file,
+        concat!(
+            r#"{"sessionId":"sess-4","attributionSkill":"cortex-report","content":"ran report"}"#,
+            "\n"
+        ),
+    )
+    .unwrap();
+    {
+        let conn = pool.get().unwrap();
+        let metadata_json = serde_json::json!({ "line_no": 0 }).to_string();
+        conn.execute(
+            "INSERT INTO logs (timestamp, hostname, severity, message, raw, source_ip, ai_tool, ai_project, ai_session_id, ai_transcript_path, metadata_json)
+             VALUES ('2026-06-01T00:00:00.000Z', 'dookie', 'info', 'ran report', 'ran report', 'transcript://claude_project', 'claude', 'cortex', 'sess-4', ?1, ?2)",
+            rusqlite::params![legacy_claude_file.to_string_lossy().to_string(), metadata_json],
+        )
+        .unwrap();
+    }
+
     let conn = pool.get().unwrap();
     let pre_backfill_count: i64 = conn
         .query_row("SELECT COUNT(*) FROM ai_skill_events", [], |row| row.get(0))
         .unwrap();
     assert_eq!(
-        pre_backfill_count, 1,
-        "only the scanner-ingested row should have a skill event pre-backfill"
+        pre_backfill_count, 2,
+        "only the scanner-ingested rows (1 and 3) should have a skill event pre-backfill"
     );
     drop(conn);
 
-    // Backfill catches the pre-existing row 2 without duplicating row 1's event.
+    // Backfill catches the pre-existing rows 2 and 4 without duplicating
+    // rows 1 and 3's events.
     let service = crate::app::CortexService::new(
         std::sync::Arc::new(pool.clone()),
         StorageConfig::for_test(dir.path().join("unused.db")),
@@ -1665,18 +1704,20 @@ async fn end_to_end_ingest_then_backfill_is_idempotent_across_both_paths() {
         })
         .await
         .unwrap();
-    assert_eq!(result.scanned, 2, "both codex rows should be scanned");
-    assert_eq!(result.inserted, 1, "only row 2's event is new");
+    assert_eq!(result.scanned, 4, "all four rows should be scanned");
+    assert_eq!(result.inserted, 2, "rows 2 and 4's events are new");
     assert_eq!(
-        result.skipped_duplicates, 1,
-        "row 1's event was already present from ingest-time extraction"
+        result.skipped_duplicates, 2,
+        "rows 1 and 3's events were already present from ingest-time extraction"
     );
+    assert_eq!(result.source_unavailable, 0);
+    assert_eq!(result.parse_errors, 0);
 
     let conn = pool.get().unwrap();
     let total: i64 = conn
         .query_row("SELECT COUNT(*) FROM ai_skill_events", [], |row| row.get(0))
         .unwrap();
-    assert_eq!(total, 2);
+    assert_eq!(total, 4);
     drop(conn);
 
     // Running backfill again is fully idempotent.
@@ -1689,5 +1730,31 @@ async fn end_to_end_ingest_then_backfill_is_idempotent_across_both_paths() {
         .await
         .unwrap();
     assert_eq!(second.inserted, 0);
-    assert_eq!(second.skipped_duplicates, 2);
+    assert_eq!(second.skipped_duplicates, 4);
+}
+
+#[test]
+fn read_transcript_lines_recovers_requested_lines_and_skips_oversized() {
+    // Exercises the shared bounded-read helper the skill-event backfill uses to
+    // recover Claude rows: requested 0-based lines are returned with trailing
+    // newlines trimmed, a line exceeding MAX_RECORD_SIZE_BYTES is omitted (not
+    // read unbounded into memory), line_no counting stays aligned across the
+    // oversized line, and a request beyond EOF is simply absent.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("transcript.jsonl");
+    let oversized = "x".repeat(MAX_RECORD_SIZE_BYTES + 16);
+    let contents = format!("line-zero\n{oversized}\nline-two\n");
+    std::fs::write(&path, contents).unwrap();
+
+    // Want every line plus one past EOF.
+    let wanted: HashSet<usize> = [0usize, 1, 2, 3].into_iter().collect();
+    let got = read_transcript_lines(&path, &wanted).unwrap();
+
+    assert_eq!(got.get(&0).map(String::as_str), Some("line-zero"));
+    assert_eq!(got.get(&2).map(String::as_str), Some("line-two"));
+    // Oversized line 1 is skipped rather than buffered into memory.
+    assert!(!got.contains_key(&1), "oversized line must be omitted");
+    // Line 3 is beyond EOF.
+    assert!(!got.contains_key(&3), "out-of-range line must be omitted");
+    assert_eq!(got.len(), 2);
 }


### PR DESCRIPTION
## Summary
- `sessions skills backfill`'s Claude-row branch checked `logs.message` for the raw `attributionSkill` JSON, but that column only ever holds the already-extracted plain-text `content` field for Claude rows (never raw JSON) — the check could never match against real ingested data, only hand-crafted test fixtures. Filed as syslog-mcp-lmhqd while implementing PR2 (#110, since merged), deliberately deferred out of that PR's scope.
- Claude rows are now recovered by re-reading the specific line of the original transcript file, located via the persisted `ai_transcript_path` column and the `line_no` `scanner.rs` records in `metadata_json` at ingest time (0-based, matching the scanner's own counter). Lookups are grouped per chunk by file (one sequential pass per file) so rows sharing a transcript file don't each re-open and re-scan it.
- Added `SkillBackfillResult.source_unavailable` to report Claude rows that still can't be recovered (no path/metadata on the row, deleted/rotated source file, or an out-of-range line number) — distinct from `parse_errors`, which now specifically means "found the source line but it wasn't valid JSON." Wired through the CLI `--json`/plain output and `docs/CLI.md`.
- Codex-row recovery (which reads directly from `logs.message`, since Codex transcript text survives scrubbing intact) is unaffected.

## Test plan
- [x] `cargo test --lib` — 1670 passed, 1 ignored, 0 failed
- [x] New unit tests in `skill_backfill_tests.rs` covering: missing transcript path/metadata, missing source file, out-of-range line number, valid line with no skill event, malformed JSON at the source line, and two rows sharing one transcript file
- [x] Extended `scanner_tests.rs`'s `end_to_end_ingest_then_backfill_is_idempotent_across_both_paths` with a genuine Claude recovery case (previously this test used only Codex fixtures with an inline comment explaining the Claude gap — that limitation is now resolved)
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Version bump (3.3.0 → 3.3.1) + CHANGELOG entry, `cargo xtask check-version-sync` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude skill backfill by reading the original transcript line via `ai_transcript_path` + `metadata_json.line_no` instead of `logs.message`. Adds a `source_unavailable` counter and uses a shared, bounded reader for safe, consistent recovery; Codex behavior is unchanged.

- **Bug Fixes**
  - Re-read Claude lines with `scanner::read_transcript_lines` using bounded records; group reads by file per chunk; skip oversized lines.
  - Count missing path/line/file, out-of-range, or oversized lines as `source_unavailable`; keep `parse_errors` for invalid JSON; CLI (plain and `--json`) includes it; `--dry-run` still reads files and reports counts.
  - Select `ai_transcript_path`/`metadata_json` with rows; dry-run reports `source_unavailable`.
  - Document idempotency caveat: re-runs are safe only if transcript files are unchanged (skill name is re-derived).
  - Tests cover missing metadata/file, out-of-range/malformed lines, shared-file recovery, bounded-read helper, and end-to-end with Claude and Codex.
  - Bump to 3.5.1 and update `docker-compose.prod.yml`, `mcpb/manifest.json`, and `server.json`.

<sup>Written for commit 6a546e17dfab9ca26cfa24ffc092fb74ec43709b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

