### PR TITLE
fix: incident_id top-100 cap and cross-host nearby_logs leak in AI incident evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.5] - 2026-07-04
+
+### Fixed
+
+- `skill_incident_evidence.rs`/`mcp_incident_evidence.rs`/`hook_incident_evidence.rs` all routed exact `incident_id` investigation lookups through their `search_ai_*_incidents` function with `limit: Some(100)`, then filtered the returned top-100-by-priority candidates client-side for the matching id — an incident ranked below the top 100 silently returned empty evidence even though it existed. Added an `incident_id` field to `Ai*IncidentParams` so the full computed incident set (bounded only by the event-candidate cap, not an incident-count cap) is filtered before priority-ranked truncation.
+- The same three modules' "nearby non-AI logs in the correlation window" query filtered only by `timestamp`, with no `hostname` scope, so an incident on one host could pull in unrelated log rows from a different host active in the same time window. Added `hostname = ?` to the query, bound to the incident's own host.
+- `HookIncidentEvidence` (app model) passed `hook_events` straight through as the db-layer `AiHookEventEntry` type instead of translating to the app-level `HookEventEntry`, unlike every other evidence vector on the same struct. `derive_hook_incident_findings` now takes `&[HookEventEntry]` to match.
+
 ## [3.6.4] - 2026-07-03
 
 ### Fixed (CodeRabbit review round)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cortex"
-version = "3.6.4"
+version = "3.6.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "cortex"
-version = "3.6.4"
+version = "3.6.5"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
     # Default tag is kept in sync by `cargo xtask bump-version` (version canon);
     # previously this was frozen at 1.0.0 while migrations moved forward —
     # a stale binary against a newer schema (full-review OH1).
-    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.6.4}
+    image: ghcr.io/jmagar/cortex:${CORTEX_VERSION:-3.6.5}
     container_name: cortex
     user: "${CORTEX_UID:-1000}:${CORTEX_GID:-1000}"
     env_file:

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "cortex",
   "display_name": "Cortex",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "Query local cortex SQLite logs through a bundled stdio MCP server.",
   "long_description": "cortex packages the existing cortex stdio entrypoint as a local MCP Bundle. It is query-only: it reads the configured SQLite database and does not start syslog listeners, HTTP servers, Docker Compose, REST, or deploy flows.",
   "author": {

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/jmagar/cortex",
     "source": "github"
   },
-  "version": "3.6.4",
+  "version": "3.6.5",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/jmagar/cortex:v3.6.4",
+      "identifier": "ghcr.io/jmagar/cortex:v3.6.5",
       "transport": {
         "type": "stdio"
       },

--- a/src/app/hook_incident_findings.rs
+++ b/src/app/hook_incident_findings.rs
@@ -12,7 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::models::{HookIncident, LogEntry};
+use super::models::{HookEventEntry, HookIncident, LogEntry};
 
 // ── Stable failure-mode categories (GH #105) ────────────────────────────────
 pub const HOOK_FAILED: &str = "hook_failed";
@@ -108,7 +108,7 @@ fn scannable<'a>(
 #[allow(clippy::too_many_arguments)]
 pub fn derive_hook_incident_findings(
     incident: &HookIncident,
-    hook_events: &[crate::db::AiHookEventEntry],
+    hook_events: &[HookEventEntry],
     signal_anchors: &[LogEntry],
     transcript_before: &[LogEntry],
     transcript_after: &[LogEntry],

--- a/src/app/hook_incident_findings_tests.rs
+++ b/src/app/hook_incident_findings_tests.rs
@@ -1,6 +1,5 @@
 use super::*;
-use crate::app::models::{HookIncident, HookSignalCounts, LogEntry};
-use crate::db::AiHookEventEntry;
+use crate::app::models::{HookEventEntry, HookIncident, HookSignalCounts, LogEntry};
 
 fn log(id: i64, message: &str) -> LogEntry {
     LogEntry {
@@ -22,8 +21,8 @@ fn log(id: i64, message: &str) -> LogEntry {
     }
 }
 
-fn hook_event_entry(id: i64) -> AiHookEventEntry {
-    AiHookEventEntry {
+fn hook_event_entry(id: i64) -> HookEventEntry {
+    HookEventEntry {
         id,
         log_id: Some(id),
         ai_tool: "claude".to_string(),

--- a/src/app/models/ai_hook_incidents.rs
+++ b/src/app/models/ai_hook_incidents.rs
@@ -124,7 +124,7 @@ pub struct AiHookInvestigateRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HookIncidentEvidence {
     pub incident: HookIncident,
-    pub hook_events: Vec<db::AiHookEventEntry>,
+    pub hook_events: Vec<HookEventEntry>,
     pub hook_events_truncated: bool,
     pub signal_anchors: Vec<LogEntry>,
     pub signal_anchors_truncated: bool,
@@ -155,10 +155,11 @@ impl From<db::HookIncidentEvidence> for HookIncidentEvidence {
             v.nearby_tool_calls.into_iter().map(Into::into).collect();
         let nearby_logs: Vec<LogEntry> = v.nearby_logs.into_iter().map(Into::into).collect();
         let nearby_errors: Vec<LogEntry> = v.nearby_errors.into_iter().map(Into::into).collect();
+        let hook_events: Vec<HookEventEntry> = v.hook_events.into_iter().map(Into::into).collect();
 
         let findings = hook_incident_findings::derive_hook_incident_findings(
             &incident,
-            &v.hook_events,
+            &hook_events,
             &signal_anchors,
             &transcript_before,
             &transcript_after,
@@ -169,7 +170,7 @@ impl From<db::HookIncidentEvidence> for HookIncidentEvidence {
 
         Self {
             incident,
-            hook_events: v.hook_events,
+            hook_events,
             hook_events_truncated: v.hook_events_truncated,
             signal_anchors,
             signal_anchors_truncated: v.signal_anchors_truncated,

--- a/src/app/services/hook_incidents.rs
+++ b/src/app/services/hook_incidents.rs
@@ -25,6 +25,7 @@ impl CortexService {
                         evidence_kind: req.evidence_kind,
                         since: from,
                         until: to,
+                        incident_id: None,
                         limit: req.limit,
                         window_minutes: req.window_minutes,
                         signals: req.signals,

--- a/src/app/services/mcp_incidents.rs
+++ b/src/app/services/mcp_incidents.rs
@@ -26,6 +26,7 @@ impl CortexService {
                         hostname: req.hostname,
                         since: from,
                         until: to,
+                        incident_id: None,
                         limit: req.limit,
                         window_minutes: req.window_minutes,
                         signals: req.signals,

--- a/src/app/services/skill_incidents.rs
+++ b/src/app/services/skill_incidents.rs
@@ -26,6 +26,7 @@ impl CortexService {
                         hostname: req.hostname,
                         since: from,
                         until: to,
+                        incident_id: None,
                         limit: req.limit,
                         window_minutes: req.window_minutes,
                         signals: req.signals,

--- a/src/db/hook_incident_evidence.rs
+++ b/src/db/hook_incident_evidence.rs
@@ -81,13 +81,16 @@ pub fn investigate_ai_hook_incidents(
     const NEARBY_SUBSET_CAP: usize = 25;
 
     let limit = params.limit.unwrap_or(3).clamp(1, 10) as usize;
-    let incident_lookup_limit = if params.incident_id.is_some() {
-        100
-    } else {
-        limit as u32
-    };
     let corr_mins = i64::from(params.correlation_window_minutes.unwrap_or(5).clamp(1, 120));
 
+    // `incident_id` is passed straight through to `AiHookIncidentParams`,
+    // which filters the full computed incident set (bounded only by
+    // `HOOK_INCIDENT_CANDIDATE_CAP` events, not an incident-count cap)
+    // before its own priority-ranked truncation. This guarantees an exact
+    // incident_id lookup finds its target regardless of priority rank —
+    // routing it through a fixed-size top-N candidate window (as a prior
+    // version of this code did) could silently miss incidents ranked
+    // below that window.
     let incident_result = search_ai_hook_incidents(
         pool,
         &AiHookIncidentParams {
@@ -101,7 +104,8 @@ pub fn investigate_ai_hook_incidents(
             evidence_kind: None,
             since: params.since.clone(),
             until: params.until.clone(),
-            limit: Some(incident_lookup_limit),
+            incident_id: params.incident_id.clone(),
+            limit: Some(limit as u32),
             window_minutes: params.window_minutes,
             signals: Vec::new(),
             min_score: None,
@@ -109,15 +113,7 @@ pub fn investigate_ai_hook_incidents(
     )?;
     let total_incidents = incident_result.total_incidents;
     let truncated = incident_result.truncated;
-    let mut incidents = if let Some(incident_id) = &params.incident_id {
-        incident_result
-            .incidents
-            .into_iter()
-            .filter(|inc| inc.incident_id == *incident_id)
-            .collect::<Vec<_>>()
-    } else {
-        incident_result.incidents
-    };
+    let mut incidents = incident_result.incidents;
     incidents.truncate(limit);
 
     let conn = pool.get()?;
@@ -269,12 +265,15 @@ pub fn investigate_ai_hook_incidents(
                         process_id, message, received_at, source_ip,
                         ai_tool, ai_project, ai_session_id, ai_transcript_path, metadata_json
                  FROM logs
-                 WHERE timestamp >= ?1 AND timestamp <= ?2
+                 WHERE timestamp >= ?1 AND timestamp <= ?2 AND hostname = ?3
                  ORDER BY timestamp ASC
                  LIMIT 51",
             )?;
             let rows = stmt
-                .query_map(rusqlite::params![win_from, win_to], map_row)?
+                .query_map(
+                    rusqlite::params![win_from, win_to, &incident.hostname],
+                    map_row,
+                )?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             let truncated = rows.len() > NEARBY_CAP;
             let mut out = rows;

--- a/src/db/hook_incident_evidence_tests.rs
+++ b/src/db/hook_incident_evidence_tests.rs
@@ -200,3 +200,173 @@ fn investigate_with_no_matching_hook_returns_empty_evidence() {
     assert!(result.evidence.is_empty());
     assert_eq!(result.total_incidents, 0);
 }
+
+/// Regression test for a bug where an exact `incident_id` lookup routed
+/// through `search_ai_hook_incidents` with `limit: Some(100)` and then
+/// filtered client-side for the matching id — if the target incident ranked
+/// below the top 100 by priority score, investigation silently returned
+/// empty evidence for an incident that actually existed. This constructs
+/// 100 higher-scored decoy incidents (failed hook status) plus one
+/// lower-scored target (successful hook status) so the target provably
+/// ranks outside any top-100 window, then asserts the exact lookup still
+/// finds it.
+#[test]
+fn investigate_ai_hook_incidents_exact_incident_id_beyond_top_100_candidates() {
+    let (pool, _dir) = test_pool();
+
+    for i in 0..100 {
+        insert_hook_event_row(
+            &pool,
+            None,
+            "claude",
+            "/tmp/project-g",
+            &format!("sess-decoy-{i:03}"),
+            "host-a",
+            "2026-01-01T00:00:00.000Z",
+            "PostToolUse",
+            "format-on-save",
+            "failed",
+            "runtime_transcript",
+        );
+    }
+
+    // Target group: successful status, no failure signal, guaranteeing it
+    // ranks last among the 101 total matching incidents.
+    let target_session_id = "sess-target";
+    insert_hook_event_row(
+        &pool,
+        None,
+        "claude",
+        "/tmp/project-g",
+        target_session_id,
+        "host-a",
+        "2026-01-01T00:00:00.000Z",
+        "PostToolUse",
+        "format-on-save",
+        "success",
+        "runtime_transcript",
+    );
+
+    let target_lookup = search_ai_hook_incidents(
+        &pool,
+        &AiHookIncidentParams {
+            hook_name: Some("format-on-save".to_string()),
+            ai_session_id: Some(target_session_id.to_string()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(target_lookup.incidents.len(), 1);
+    let target_id = target_lookup.incidents[0].incident_id.clone();
+
+    let top100 = search_ai_hook_incidents(
+        &pool,
+        &AiHookIncidentParams {
+            hook_name: Some("format-on-save".to_string()),
+            limit: Some(100),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(top100.total_incidents, 101, "100 decoys + 1 target");
+    assert_eq!(top100.incidents.len(), 100);
+    assert!(
+        !top100
+            .incidents
+            .iter()
+            .any(|inc| inc.incident_id == target_id),
+        "test setup invariant: target must rank outside the top 100"
+    );
+
+    // The regression check: an exact incident_id lookup must still find the
+    // target even though it ranks outside the top-100 candidate window.
+    let exact = investigate_ai_hook_incidents(
+        &pool,
+        &AiHookInvestigateParams {
+            incident_id: Some(target_id.clone()),
+            hook_name: Some("format-on-save".to_string()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        exact.evidence.len(),
+        1,
+        "exact incident_id lookup must find an incident ranked outside the top 100"
+    );
+    assert_eq!(exact.evidence[0].incident.incident_id, target_id);
+}
+
+/// Regression test for a bug where the `nearby_logs` query only filtered by
+/// timestamp range, with no hostname scope, so an incident on one host could
+/// pull in unrelated log rows from a different host in the same time window.
+#[test]
+fn investigate_ai_hook_incidents_nearby_logs_scoped_to_incident_hostname() {
+    let (pool, _dir) = test_pool();
+
+    insert_hook_event_row(
+        &pool,
+        None,
+        "claude",
+        "/tmp/project-h",
+        "sess-h",
+        "host-a",
+        "2026-01-01T00:00:00.000Z",
+        "PostToolUse",
+        "format-on-save",
+        "success",
+        "runtime_transcript",
+    );
+
+    // Unrelated non-AI log on a DIFFERENT host, within the correlation window.
+    let other_host_log = LogBatchEntry {
+        timestamp: "2026-01-01T00:01:00Z".to_string(),
+        hostname: "host-b".to_string(),
+        facility: Some("local0".to_string()),
+        severity: "error".to_string(),
+        app_name: Some("nginx".to_string()),
+        process_id: None,
+        message: "connection refused".to_string(),
+        raw: "connection refused".to_string(),
+        source_ip: "10.0.0.5:514".to_string(),
+        docker_checkpoint: None,
+        ai_tool: None,
+        ai_project: None,
+        ai_session_id: None,
+        ai_transcript_path: None,
+        metadata_json: None,
+        http_status: None,
+        auth_outcome: None,
+        dns_blocked: None,
+        event_action: None,
+        parse_error: None,
+    };
+    insert_logs_batch(&pool, &[other_host_log]).unwrap();
+
+    let result = investigate_ai_hook_incidents(
+        &pool,
+        &AiHookInvestigateParams {
+            hook_name: Some("format-on-save".to_string()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.evidence.len(), 1);
+    let bundle = &result.evidence[0];
+    assert!(
+        bundle.nearby_logs.iter().all(|e| e.hostname == "host-a"),
+        "nearby_logs leaked a cross-host row: {:?}",
+        bundle.nearby_logs
+    );
+    assert!(
+        !bundle
+            .nearby_logs
+            .iter()
+            .any(|e| e.message.contains("connection refused")),
+        "cross-host log should not appear in nearby_logs"
+    );
+}

--- a/src/db/hook_incidents.rs
+++ b/src/db/hook_incidents.rs
@@ -37,6 +37,11 @@ pub struct AiHookIncidentParams {
     pub evidence_kind: Option<String>,
     pub since: Option<String>,
     pub until: Option<String>,
+    /// Exact incident_id match. When set, filters the full computed incident
+    /// set (bounded only by `HOOK_INCIDENT_CANDIDATE_CAP`, not `limit`)
+    /// before the priority-ranked truncation, so a match ranked below
+    /// `limit` is still found.
+    pub incident_id: Option<String>,
     /// Max incidents to return. Default 20, clamp 1..=100.
     pub limit: Option<u32>,
     /// Grouping window in minutes. Default 10, clamp 1..=120.
@@ -430,6 +435,9 @@ pub fn search_ai_hook_incidents(
         });
     }
 
+    if let Some(incident_id) = &params.incident_id {
+        incidents.retain(|inc| &inc.incident_id == incident_id);
+    }
     if !params.signals.is_empty() {
         incidents.retain(|inc| {
             inc.signals_present

--- a/src/db/mcp_incident_evidence.rs
+++ b/src/db/mcp_incident_evidence.rs
@@ -109,13 +109,16 @@ pub fn investigate_ai_mcp_incidents(
     const NEARBY_SUBSET_CAP: usize = 25;
 
     let limit = params.limit.unwrap_or(3).clamp(1, 10) as usize;
-    let incident_lookup_limit = if params.incident_id.is_some() {
-        100
-    } else {
-        limit as u32
-    };
     let corr_mins = i64::from(params.correlation_window_minutes.unwrap_or(5).clamp(1, 120));
 
+    // `incident_id` is passed straight through to `AiMcpIncidentParams`,
+    // which filters the full computed incident set (bounded only by
+    // `MCP_INCIDENT_CANDIDATE_CAP` events, not an incident-count cap) before
+    // its own priority-ranked truncation. This guarantees an exact
+    // incident_id lookup finds its target regardless of priority rank —
+    // routing it through a fixed-size top-N candidate window (as a prior
+    // version of this code did) could silently miss incidents ranked below
+    // that window.
     let incident_result = search_ai_mcp_incidents(
         pool,
         &AiMcpIncidentParams {
@@ -128,7 +131,8 @@ pub fn investigate_ai_mcp_incidents(
             hostname: None,
             since: params.since.clone(),
             until: params.until.clone(),
-            limit: Some(incident_lookup_limit),
+            incident_id: params.incident_id.clone(),
+            limit: Some(limit as u32),
             window_minutes: params.window_minutes,
             signals: Vec::new(),
             min_score: None,
@@ -136,15 +140,7 @@ pub fn investigate_ai_mcp_incidents(
     )?;
     let total_incidents = incident_result.total_incidents;
     let truncated = incident_result.truncated;
-    let mut incidents = if let Some(incident_id) = &params.incident_id {
-        incident_result
-            .incidents
-            .into_iter()
-            .filter(|inc| inc.incident_id == *incident_id)
-            .collect::<Vec<_>>()
-    } else {
-        incident_result.incidents
-    };
+    let mut incidents = incident_result.incidents;
     incidents.truncate(limit);
 
     let conn = pool.get()?;
@@ -292,12 +288,15 @@ pub fn investigate_ai_mcp_incidents(
                         process_id, message, received_at, source_ip,
                         ai_tool, ai_project, ai_session_id, ai_transcript_path, metadata_json
                  FROM logs
-                 WHERE timestamp >= ?1 AND timestamp <= ?2
+                 WHERE timestamp >= ?1 AND timestamp <= ?2 AND hostname = ?3
                  ORDER BY timestamp ASC
                  LIMIT 51",
             )?;
             let rows = stmt
-                .query_map(rusqlite::params![win_from, win_to], map_row)?
+                .query_map(
+                    rusqlite::params![win_from, win_to, &incident.hostname],
+                    map_row,
+                )?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             let truncated = rows.len() > NEARBY_CAP;
             let mut out = rows;

--- a/src/db/mcp_incident_evidence_tests.rs
+++ b/src/db/mcp_incident_evidence_tests.rs
@@ -211,3 +211,232 @@ fn investigate_ai_mcp_incidents_filters_by_incident_id() {
     .unwrap();
     assert!(none_result.evidence.is_empty());
 }
+
+/// Regression test for a bug where an exact `incident_id` lookup routed
+/// through `search_ai_mcp_incidents` with `limit: Some(100)` and then
+/// filtered client-side for the matching id — if the target incident ranked
+/// below the top 100 by priority score, investigation silently returned
+/// empty evidence for an incident that actually existed. This constructs
+/// 100 higher-scored decoy incidents plus one lower-scored target so the
+/// target provably ranks outside any top-100 window, then asserts the exact
+/// lookup still finds it.
+#[test]
+fn investigate_ai_mcp_incidents_exact_incident_id_beyond_top_100_candidates() {
+    let (pool, _dir) = test_pool();
+
+    fn log_ids_for_session(pool: &DbPool, session_id: &str) -> Vec<i64> {
+        let conn = pool.get().unwrap();
+        let mut stmt = conn
+            .prepare("SELECT id FROM logs WHERE ai_session_id = ?1 ORDER BY timestamp ASC, id ASC")
+            .unwrap();
+        stmt.query_map([session_id], |row| row.get::<_, i64>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap()
+    }
+
+    // 100 decoy groups, each scored higher than baseline via a
+    // user_correction_after_tool_call anchor, so every decoy outranks the
+    // target.
+    for i in 0..100 {
+        let session_id = format!("sess-decoy-{i:03}");
+        let call_log = make_ai_entry(
+            "2026-01-01T00:00:00Z",
+            "host-a",
+            "codex",
+            "/tmp/project-g",
+            &session_id,
+            "called mcp__labby__search",
+        );
+        let correction_log = make_ai_entry(
+            "2026-01-01T00:00:30Z",
+            "host-a",
+            "codex",
+            "/tmp/project-g",
+            &session_id,
+            "no, that's the wrong tool",
+        );
+        insert_logs_batch(&pool, &[call_log, correction_log]).unwrap();
+        let ids = log_ids_for_session(&pool, &session_id);
+        insert_mcp_event(
+            &pool,
+            ids[0],
+            "codex",
+            "/tmp/project-g",
+            &session_id,
+            "host-a",
+            "2026-01-01T00:00:00Z",
+            &format!("call-decoy-{i:03}"),
+            "mcp__labby__search",
+            Some("labby"),
+            Some("search"),
+            Some(false),
+        );
+    }
+
+    // Target group: baseline score only (no anchor signal), guaranteeing it
+    // ranks last among the 101 total matching incidents.
+    let target_session_id = "sess-target".to_string();
+    let target_call_log = make_ai_entry(
+        "2026-01-01T00:00:00Z",
+        "host-a",
+        "codex",
+        "/tmp/project-g",
+        &target_session_id,
+        "called mcp__labby__search",
+    );
+    insert_logs_batch(&pool, &[target_call_log]).unwrap();
+    let target_log_ids = log_ids_for_session(&pool, &target_session_id);
+    insert_mcp_event(
+        &pool,
+        target_log_ids[0],
+        "codex",
+        "/tmp/project-g",
+        &target_session_id,
+        "host-a",
+        "2026-01-01T00:00:00Z",
+        "call-target",
+        "mcp__labby__search",
+        Some("labby"),
+        Some("search"),
+        Some(false),
+    );
+
+    let target_lookup = search_ai_mcp_incidents(
+        &pool,
+        &AiMcpIncidentParams {
+            mcp_server: Some("labby".into()),
+            ai_session_id: Some(target_session_id.clone()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(target_lookup.incidents.len(), 1);
+    let target_id = target_lookup.incidents[0].incident_id.clone();
+
+    let top100 = search_ai_mcp_incidents(
+        &pool,
+        &AiMcpIncidentParams {
+            mcp_server: Some("labby".into()),
+            limit: Some(100),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(top100.total_incidents, 101, "100 decoys + 1 target");
+    assert_eq!(top100.incidents.len(), 100);
+    assert!(
+        !top100
+            .incidents
+            .iter()
+            .any(|inc| inc.incident_id == target_id),
+        "test setup invariant: target must rank outside the top 100"
+    );
+
+    // The regression check: an exact incident_id lookup must still find the
+    // target even though it ranks outside the top-100 candidate window.
+    let exact = investigate_ai_mcp_incidents(
+        &pool,
+        &AiMcpInvestigateParams {
+            incident_id: Some(target_id.clone()),
+            mcp_server: Some("labby".into()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        exact.evidence.len(),
+        1,
+        "exact incident_id lookup must find an incident ranked outside the top 100"
+    );
+    assert_eq!(exact.evidence[0].incident.incident_id, target_id);
+}
+
+/// Regression test for a bug where the `nearby_logs` query only filtered by
+/// timestamp range, with no hostname scope, so an incident on one host could
+/// pull in unrelated log rows from a different host in the same time window.
+#[test]
+fn investigate_ai_mcp_incidents_nearby_logs_scoped_to_incident_hostname() {
+    let (pool, _dir) = test_pool();
+
+    let call_log = make_ai_entry(
+        "2026-01-01T00:00:00Z",
+        "host-a",
+        "codex",
+        "/tmp/project-h",
+        "sess-h",
+        "called mcp__labby__search",
+    );
+    insert_logs_batch(&pool, &[call_log]).unwrap();
+    let log_id: i64 = {
+        let conn = pool.get().unwrap();
+        conn.query_row("SELECT id FROM logs LIMIT 1", [], |row| row.get(0))
+            .unwrap()
+    };
+    insert_mcp_event(
+        &pool,
+        log_id,
+        "codex",
+        "/tmp/project-h",
+        "sess-h",
+        "host-a",
+        "2026-01-01T00:00:00Z",
+        "call-h",
+        "mcp__labby__search",
+        Some("labby"),
+        Some("search"),
+        Some(false),
+    );
+
+    // Unrelated non-AI log on a DIFFERENT host, within the correlation window.
+    let other_host_log = LogBatchEntry {
+        timestamp: "2026-01-01T00:01:00Z".to_string(),
+        hostname: "host-b".to_string(),
+        facility: Some("local0".to_string()),
+        severity: "error".to_string(),
+        app_name: Some("nginx".to_string()),
+        process_id: None,
+        message: "connection refused".to_string(),
+        raw: "connection refused".to_string(),
+        source_ip: "10.0.0.5:514".to_string(),
+        docker_checkpoint: None,
+        ai_tool: None,
+        ai_project: None,
+        ai_session_id: None,
+        ai_transcript_path: None,
+        metadata_json: None,
+        http_status: None,
+        auth_outcome: None,
+        dns_blocked: None,
+        event_action: None,
+        parse_error: None,
+    };
+    insert_logs_batch(&pool, &[other_host_log]).unwrap();
+
+    let result = investigate_ai_mcp_incidents(
+        &pool,
+        &AiMcpInvestigateParams {
+            mcp_server: Some("labby".into()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.evidence.len(), 1);
+    let bundle = &result.evidence[0];
+    assert!(
+        bundle.nearby_logs.iter().all(|e| e.hostname == "host-a"),
+        "nearby_logs leaked a cross-host row: {:?}",
+        bundle.nearby_logs
+    );
+    assert!(
+        !bundle
+            .nearby_logs
+            .iter()
+            .any(|e| e.message.contains("connection refused")),
+        "cross-host log should not appear in nearby_logs"
+    );
+}

--- a/src/db/mcp_incidents.rs
+++ b/src/db/mcp_incidents.rs
@@ -33,6 +33,11 @@ pub struct AiMcpIncidentParams {
     pub hostname: Option<String>,
     pub since: Option<String>,
     pub until: Option<String>,
+    /// Exact incident_id match. When set, filters the full computed incident
+    /// set (bounded only by `MCP_INCIDENT_CANDIDATE_CAP`, not `limit`) before
+    /// the priority-ranked truncation, so a match ranked below `limit` is
+    /// still found.
+    pub incident_id: Option<String>,
     /// Max incidents to return. Default 20, clamp 1..=100.
     pub limit: Option<u32>,
     /// Grouping window in minutes. Default 10, clamp 1..=120.
@@ -393,6 +398,9 @@ pub fn search_ai_mcp_incidents(
         });
     }
 
+    if let Some(incident_id) = &params.incident_id {
+        incidents.retain(|inc| &inc.incident_id == incident_id);
+    }
     if !params.signals.is_empty() {
         incidents.retain(|inc| {
             inc.signals_present

--- a/src/db/skill_incident_evidence.rs
+++ b/src/db/skill_incident_evidence.rs
@@ -102,13 +102,16 @@ pub fn investigate_ai_skill_incidents(
     const NEARBY_SUBSET_CAP: usize = 25;
 
     let limit = params.limit.unwrap_or(3).clamp(1, 10) as usize;
-    let incident_lookup_limit = if params.incident_id.is_some() {
-        100
-    } else {
-        limit as u32
-    };
     let corr_mins = i64::from(params.correlation_window_minutes.unwrap_or(5).clamp(1, 120));
 
+    // `incident_id` is passed straight through to `AiSkillIncidentParams`,
+    // which filters the full computed incident set (bounded only by
+    // `SKILL_INCIDENT_CANDIDATE_CAP` events, not an incident-count cap)
+    // before its own priority-ranked truncation. This guarantees an exact
+    // incident_id lookup finds its target regardless of priority rank —
+    // routing it through a fixed-size top-N candidate window (as a prior
+    // version of this code did) could silently miss incidents ranked
+    // below that window.
     let incident_result = search_ai_skill_incidents(
         pool,
         &AiSkillIncidentParams {
@@ -120,7 +123,8 @@ pub fn investigate_ai_skill_incidents(
             hostname: None,
             since: params.since.clone(),
             until: params.until.clone(),
-            limit: Some(incident_lookup_limit),
+            incident_id: params.incident_id.clone(),
+            limit: Some(limit as u32),
             window_minutes: params.window_minutes,
             signals: Vec::new(),
             min_score: None,
@@ -128,15 +132,7 @@ pub fn investigate_ai_skill_incidents(
     )?;
     let total_incidents = incident_result.total_incidents;
     let truncated = incident_result.truncated;
-    let mut incidents = if let Some(incident_id) = &params.incident_id {
-        incident_result
-            .incidents
-            .into_iter()
-            .filter(|inc| inc.incident_id == *incident_id)
-            .collect::<Vec<_>>()
-    } else {
-        incident_result.incidents
-    };
+    let mut incidents = incident_result.incidents;
     incidents.truncate(limit);
 
     let conn = pool.get()?;
@@ -286,12 +282,15 @@ pub fn investigate_ai_skill_incidents(
                         process_id, message, received_at, source_ip,
                         ai_tool, ai_project, ai_session_id, ai_transcript_path, metadata_json
                  FROM logs
-                 WHERE timestamp >= ?1 AND timestamp <= ?2
+                 WHERE timestamp >= ?1 AND timestamp <= ?2 AND hostname = ?3
                  ORDER BY timestamp ASC
                  LIMIT 51",
             )?;
             let rows = stmt
-                .query_map(rusqlite::params![win_from, win_to], map_row)?
+                .query_map(
+                    rusqlite::params![win_from, win_to, &incident.hostname],
+                    map_row,
+                )?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
             let truncated = rows.len() > NEARBY_CAP;
             let mut out = rows;

--- a/src/db/skill_incident_evidence_tests.rs
+++ b/src/db/skill_incident_evidence_tests.rs
@@ -261,3 +261,222 @@ fn investigate_ai_skill_incidents_exact_incident_id_can_target_outside_top_page(
     assert_eq!(exact.evidence.len(), 1);
     assert_eq!(exact.evidence[0].incident.incident_id, target_id);
 }
+
+/// Regression test for a bug where an exact `incident_id` lookup routed
+/// through `search_ai_skill_incidents` with `limit: Some(100)` and then
+/// filtered client-side for the matching id — if the target incident
+/// ranked below the top 100 by priority score, investigation silently
+/// returned empty evidence for an incident that actually existed. This
+/// constructs 100 higher-scored decoy incidents plus one lower-scored
+/// target so the target provably ranks outside any top-100 window, then
+/// asserts the exact lookup still finds it.
+#[test]
+fn investigate_ai_skill_incidents_exact_incident_id_beyond_top_100_candidates() {
+    let (pool, _dir) = test_pool();
+
+    fn log_ids_for_session(pool: &DbPool, session_id: &str) -> Vec<i64> {
+        let conn = pool.get().unwrap();
+        let mut stmt = conn
+            .prepare("SELECT id FROM logs WHERE ai_session_id = ?1 ORDER BY timestamp ASC, id ASC")
+            .unwrap();
+        stmt.query_map([session_id], |row| row.get::<_, i64>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap()
+    }
+
+    // 100 decoy groups, each scored higher than baseline via a
+    // user_correction_after_skill anchor, so every decoy outranks the target.
+    for i in 0..100 {
+        let session_id = format!("sess-decoy-{i:03}");
+        let skill_log = make_ai_entry(
+            "2026-01-01T00:00:00Z",
+            "host-a",
+            "codex",
+            "/tmp/project-g",
+            &session_id,
+            "loaded skill lavra:lavra-plan",
+        );
+        let correction_log = make_ai_entry(
+            "2026-01-01T00:00:30Z",
+            "host-a",
+            "codex",
+            "/tmp/project-g",
+            &session_id,
+            "that's not what I asked, wrong file",
+        );
+        insert_logs_batch(&pool, &[skill_log, correction_log]).unwrap();
+        let ids = log_ids_for_session(&pool, &session_id);
+        insert_skill_event(
+            &pool,
+            ids[0],
+            "codex",
+            "/tmp/project-g",
+            &session_id,
+            "host-a",
+            "2026-01-01T00:00:00Z",
+            "lavra:lavra-plan",
+            Some("lavra"),
+        );
+    }
+
+    // Target group: baseline score only (no anchor signal), guaranteeing it
+    // ranks last among the 101 total matching incidents.
+    let target_session_id = "sess-target".to_string();
+    let target_skill_log = make_ai_entry(
+        "2026-01-01T00:00:00Z",
+        "host-a",
+        "codex",
+        "/tmp/project-g",
+        &target_session_id,
+        "loaded skill lavra:lavra-plan",
+    );
+    insert_logs_batch(&pool, &[target_skill_log]).unwrap();
+    let target_log_ids = log_ids_for_session(&pool, &target_session_id);
+    insert_skill_event(
+        &pool,
+        target_log_ids[0],
+        "codex",
+        "/tmp/project-g",
+        &target_session_id,
+        "host-a",
+        "2026-01-01T00:00:00Z",
+        "lavra:lavra-plan",
+        Some("lavra"),
+    );
+
+    let target_lookup = search_ai_skill_incidents(
+        &pool,
+        &AiSkillIncidentParams {
+            skill: Some("lavra:lavra-plan".into()),
+            ai_session_id: Some(target_session_id.clone()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(target_lookup.incidents.len(), 1);
+    let target_id = target_lookup.incidents[0].incident_id.clone();
+
+    let top100 = search_ai_skill_incidents(
+        &pool,
+        &AiSkillIncidentParams {
+            skill: Some("lavra:lavra-plan".into()),
+            limit: Some(100),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(top100.total_incidents, 101, "100 decoys + 1 target");
+    assert_eq!(top100.incidents.len(), 100);
+    assert!(
+        !top100
+            .incidents
+            .iter()
+            .any(|inc| inc.incident_id == target_id),
+        "test setup invariant: target must rank outside the top 100"
+    );
+
+    // The regression check: an exact incident_id lookup must still find the
+    // target even though it ranks outside the top-100 candidate window.
+    let exact = investigate_ai_skill_incidents(
+        &pool,
+        &AiSkillInvestigateParams {
+            incident_id: Some(target_id.clone()),
+            skill: Some("lavra:lavra-plan".into()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        exact.evidence.len(),
+        1,
+        "exact incident_id lookup must find an incident ranked outside the top 100"
+    );
+    assert_eq!(exact.evidence[0].incident.incident_id, target_id);
+}
+
+/// Regression test for a bug where the `nearby_logs` query only filtered by
+/// timestamp range, with no hostname scope, so an incident on one host could
+/// pull in unrelated log rows from a different host in the same time window.
+#[test]
+fn investigate_ai_skill_incidents_nearby_logs_scoped_to_incident_hostname() {
+    let (pool, _dir) = test_pool();
+
+    let skill_log = make_ai_entry(
+        "2026-01-01T00:00:00Z",
+        "host-a",
+        "codex",
+        "/tmp/project-h",
+        "sess-h",
+        "loaded skill lavra:lavra-plan",
+    );
+    insert_logs_batch(&pool, &[skill_log]).unwrap();
+    let log_id: i64 = {
+        let conn = pool.get().unwrap();
+        conn.query_row("SELECT id FROM logs LIMIT 1", [], |row| row.get(0))
+            .unwrap()
+    };
+    insert_skill_event(
+        &pool,
+        log_id,
+        "codex",
+        "/tmp/project-h",
+        "sess-h",
+        "host-a",
+        "2026-01-01T00:00:00Z",
+        "lavra:lavra-plan",
+        Some("lavra"),
+    );
+
+    // Unrelated non-AI log on a DIFFERENT host, within the correlation window.
+    let other_host_log = LogBatchEntry {
+        timestamp: "2026-01-01T00:01:00Z".to_string(),
+        hostname: "host-b".to_string(),
+        facility: Some("local0".to_string()),
+        severity: "error".to_string(),
+        app_name: Some("nginx".to_string()),
+        process_id: None,
+        message: "connection refused".to_string(),
+        raw: "connection refused".to_string(),
+        source_ip: "10.0.0.5:514".to_string(),
+        docker_checkpoint: None,
+        ai_tool: None,
+        ai_project: None,
+        ai_session_id: None,
+        ai_transcript_path: None,
+        metadata_json: None,
+        http_status: None,
+        auth_outcome: None,
+        dns_blocked: None,
+        event_action: None,
+        parse_error: None,
+    };
+    insert_logs_batch(&pool, &[other_host_log]).unwrap();
+
+    let result = investigate_ai_skill_incidents(
+        &pool,
+        &AiSkillInvestigateParams {
+            skill: Some("lavra:lavra-plan".into()),
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.evidence.len(), 1);
+    let bundle = &result.evidence[0];
+    assert!(
+        bundle.nearby_logs.iter().all(|e| e.hostname == "host-a"),
+        "nearby_logs leaked a cross-host row: {:?}",
+        bundle.nearby_logs
+    );
+    assert!(
+        !bundle
+            .nearby_logs
+            .iter()
+            .any(|e| e.message.contains("connection refused")),
+        "cross-host log should not appear in nearby_logs"
+    );
+}

--- a/src/db/skill_incidents.rs
+++ b/src/db/skill_incidents.rs
@@ -34,6 +34,11 @@ pub struct AiSkillIncidentParams {
     pub hostname: Option<String>,
     pub since: Option<String>,
     pub until: Option<String>,
+    /// Exact incident_id match. When set, filters the full computed incident
+    /// set (bounded only by `SKILL_INCIDENT_CANDIDATE_CAP`, not `limit`)
+    /// before the priority-ranked truncation, so a match ranked below
+    /// `limit` is still found.
+    pub incident_id: Option<String>,
     /// Max incidents to return. Default 20, clamp 1..=100.
     pub limit: Option<u32>,
     /// Grouping window in minutes. Default 10, clamp 1..=120.
@@ -381,7 +386,10 @@ pub fn search_ai_skill_incidents(
         });
     }
 
-    // ── Post-grouping filters: signals, min_score ───────────────────────────
+    // ── Post-grouping filters: incident_id, signals, min_score ──────────────
+    if let Some(incident_id) = &params.incident_id {
+        incidents.retain(|inc| &inc.incident_id == incident_id);
+    }
     if !params.signals.is_empty() {
         incidents.retain(|inc| {
             inc.signals_present


### PR DESCRIPTION
## Summary
- `skill_incident_evidence.rs`/`mcp_incident_evidence.rs`/`hook_incident_evidence.rs` all routed exact `incident_id` investigation lookups through `search_ai_*_incidents` with `limit: Some(100)` and filtered client-side; an incident ranked below the top 100 by priority silently returned empty evidence. Added `incident_id` to `Ai*IncidentParams` so the full computed incident set is filtered before priority-ranked truncation, independent of `limit`.
- The "nearby non-AI logs" query in all three modules filtered only by `timestamp`, with no `hostname` scope, letting an incident on one host pull in unrelated logs from another host in the same window. Added `hostname = ?` bound to the incident's own host.
- Translated `HookIncidentEvidence.hook_events` (app model) to the app-level `HookEventEntry` type instead of passing the db-layer `AiHookEventEntry` straight through, matching every other evidence vector on the struct; `derive_hook_incident_findings` now takes `&[HookEventEntry]` to match.

This picks up a fix that was made on `feature/hook-event-tracking` after PR #121 had already auto-merged an earlier snapshot of that branch, so it landed on `main` still carrying the bug — this PR (cherry-picked cleanly from `feature/hook-event-tracking`) closes that gap.

bd: syslog-mcp-oqvn5

## Test plan
- [x] `cargo build`
- [x] `cargo test --lib` (full suite + targeted `incident_evidence`/`hook_incident_findings` reruns) — 6 new regression tests added (2 per module: incident ranked outside top 100, cross-host nearby_logs)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] version bump 3.6.4 → 3.6.5 + CHANGELOG entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incident evidence lookups that could return empty results and stops cross-host leakage in `nearby_logs`. Also aligns hook event types at the app layer for consistent findings.

- **Bug Fixes**
  - Exact `incident_id` investigations now filter the full computed incident set before priority truncation. Adds `incident_id` to `Ai*IncidentParams` for skill/MCP/hook flows, so incidents ranked beyond the top 100 are still found.
  - `nearby_logs` queries now include `hostname = ?` scoped to the incident’s host across skill/MCP/hook evidence, preventing unrelated logs from other hosts in the same time window.
  - `HookIncidentEvidence.hook_events` now uses `HookEventEntry` (app type). Updated `derive_hook_incident_findings` to take `&[HookEventEntry]`.

<sup>Written for commit ca89a5bd97630c301efe947cb85fa1ea08049834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

