### PR TITLE
style: cargo fmt src/cli/setup.rs

### DIFF
--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -362,7 +362,10 @@ fn systemd_backup_phase(mode: SetupMode) -> SetupPhase {
             return SetupPhase {
                 name: "systemd-backup",
                 status: SetupStatus::Skipped,
-                detail: format!("source {} not found (running from installed binary?)", service_src.display()),
+                detail: format!(
+                    "source {} not found (running from installed binary?)",
+                    service_src.display()
+                ),
             };
         }
 
@@ -387,13 +390,11 @@ fn systemd_backup_phase(mode: SetupMode) -> SetupPhase {
             .output();
 
         match (reload_result, enable_result) {
-            (Ok(_), Ok(output)) if output.status.success() => {
-                SetupPhase {
-                    name: "systemd-backup",
-                    status: SetupStatus::Ok,
-                    detail: "timer installed and enabled".to_string(),
-                }
-            }
+            (Ok(_), Ok(output)) if output.status.success() => SetupPhase {
+                name: "systemd-backup",
+                status: SetupStatus::Ok,
+                detail: "timer installed and enabled".to_string(),
+            },
             (Ok(reload), Ok(enable)) => {
                 let reload_err = if !reload.status.success() {
                     format!("reload failed: {}", String::from_utf8_lossy(&reload.stderr))
@@ -411,20 +412,16 @@ fn systemd_backup_phase(mode: SetupMode) -> SetupPhase {
                     detail: format!("{}{}", reload_err, enable_err),
                 }
             }
-            (Err(e), _) => {
-                SetupPhase {
-                    name: "systemd-backup",
-                    status: SetupStatus::Warn,
-                    detail: format!("systemctl not available: {}", e),
-                }
-            }
-            _ => {
-                SetupPhase {
-                    name: "systemd-backup",
-                    status: SetupStatus::Warn,
-                    detail: "units copied but timer enable failed".to_string(),
-                }
-            }
+            (Err(e), _) => SetupPhase {
+                name: "systemd-backup",
+                status: SetupStatus::Warn,
+                detail: format!("systemctl not available: {}", e),
+            },
+            _ => SetupPhase {
+                name: "systemd-backup",
+                status: SetupStatus::Warn,
+                detail: "units copied but timer enable failed".to_string(),
+            },
         }
     } else {
         // In Check mode, just report whether the timer is enabled
@@ -433,27 +430,21 @@ fn systemd_backup_phase(mode: SetupMode) -> SetupPhase {
             .output();
 
         match is_active {
-            Ok(output) if output.status.success() => {
-                SetupPhase {
-                    name: "systemd-backup",
-                    status: SetupStatus::Ok,
-                    detail: "timer is enabled".to_string(),
-                }
-            }
-            Ok(_) => {
-                SetupPhase {
-                    name: "systemd-backup",
-                    status: SetupStatus::Warn,
-                    detail: "timer not enabled (run 'cortex setup repair' to enable)".to_string(),
-                }
-            }
-            Err(e) => {
-                SetupPhase {
-                    name: "systemd-backup",
-                    status: SetupStatus::Skipped,
-                    detail: format!("systemctl not available: {}", e),
-                }
-            }
+            Ok(output) if output.status.success() => SetupPhase {
+                name: "systemd-backup",
+                status: SetupStatus::Ok,
+                detail: "timer is enabled".to_string(),
+            },
+            Ok(_) => SetupPhase {
+                name: "systemd-backup",
+                status: SetupStatus::Warn,
+                detail: "timer not enabled (run 'cortex setup repair' to enable)".to_string(),
+            },
+            Err(e) => SetupPhase {
+                name: "systemd-backup",
+                status: SetupStatus::Skipped,
+                detail: format!("systemctl not available: {}", e),
+            },
         }
     }
 }


### PR DESCRIPTION
Fixes a Formatting CI failure on main from afb068b — its systemd-backup phase match arms weren't run through rustfmt. No behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `cargo fmt` to the `systemd_backup_phase` match arms in `src/cli/setup.rs` to fix the formatting CI failure on `main`. Style-only change; no behavior changes.

<sup>Written for commit 488df9503f5fd9be56104c0223e9bf3a154ab520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the setup flow for backup phase status handling.
  * Kept the same user-facing results: missing sources are still reported as skipped, successful enables still return OK, and unavailable system tools still produce warnings or skips as before.
  * Improved the formatting of one error message for clearer reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->