### PR TITLE
Add cortex update operator workflow

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -823,6 +823,34 @@ the debug Compose override, transcript-root permissions, disabled legacy index
 timer state, active/enabled watcher state, and container freshness via
 `scripts/check-runtime-current.sh --allow-local-image`.
 
+### `cortex update`
+
+Update an already-configured Cortex deployment.
+
+```bash
+cortex update
+cortex update server --dry-run
+cortex update server
+cortex update clients
+cortex update agents
+```
+
+`cortex update` defaults to `all`: it updates the configured server first, then
+updates configured host-agent clients. `clients` and `agents` are aliases; both
+refer to the host-local Cortex agents that forward logs, heartbeats, sessions,
+shell history, and command events into the server.
+
+Configure the update profile once:
+
+```bash
+cortex update config server --host tootie --home /mnt/cache/appdata/cortex
+cortex update config clients --hosts dookie,shart,squirts --target https://cortex.tootie.tv --docker
+```
+
+The profile lives at `~/.cortex/deployments.toml` by default. A successful
+`cortex setup deploy remote --home PATH HOST` also records the server profile,
+so a one-off low-level deploy can seed future `cortex update server` runs.
+
 ### `cortex setup deploy`
 
 Run the Compose-backed deployment workflow using operator-facing names.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -825,24 +825,8 @@ timer state, active/enabled watcher state, and container freshness via
 
 ### `cortex update`
 
-Update an already-configured Cortex deployment.
-
-```bash
-cortex update server --dry-run
-cortex update server
-cortex update clients --dry-run
-cortex update clients
-cortex update agents
-cortex update
-```
-
-`cortex update` defaults to `all`: it updates the configured server first, then
-updates configured host-agent clients. `clients` and `agents` are aliases; both
-refer to the host-local Cortex agents that forward logs, heartbeats, sessions,
-shell history, and command events into the server. Client dry-runs resolve the
-local binary and probe each configured host over SSH without deploying.
-
-Configure the update profile once:
+Update an already-configured Cortex deployment. Configure the update profile
+once:
 
 ```bash
 cortex update config server --host tootie --home /mnt/cache/appdata/cortex
@@ -851,8 +835,23 @@ cortex update config clients --hosts dookie,shart,squirts --target https://corte
 
 The profile lives at `~/.cortex/deployments.toml` by default. A successful
 `cortex setup deploy remote --home PATH HOST` also records the server profile,
-so a one-off low-level deploy can seed future `cortex update server` runs. Run
-the dry-run form before the live update when operating a remote server.
+so a one-off low-level deploy can seed future `cortex update server` runs.
+
+After the profile exists, dry-run before live updates:
+
+```bash
+cortex update --dry-run
+cortex update
+cortex update server --dry-run
+cortex update clients --dry-run
+cortex update clients
+```
+
+`cortex update` defaults to `all`: it updates the configured server first, then
+updates configured host-agent clients. `clients` and `agents` are aliases; both
+refer to the host-local Cortex agents that forward logs, heartbeats, sessions,
+shell history, and command events into the server. Client dry-runs resolve the
+local binary and probe each configured host over SSH without deploying.
 
 ### `cortex setup deploy`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -836,6 +836,8 @@ cortex update config clients --hosts dookie,shart,squirts --target https://corte
 The profile lives at `~/.cortex/deployments.toml` by default. A successful
 `cortex setup deploy remote --home PATH HOST` also records the server profile,
 so a one-off low-level deploy can seed future `cortex update server` runs.
+Re-running `cortex update config clients` replaces the host list and preserves
+any omitted saved `--target`, `--docker`, or `--journald` choices.
 
 After the profile exists, dry-run before live updates:
 
@@ -852,6 +854,10 @@ updates configured host-agent clients. `clients` and `agents` are aliases; both
 refer to the host-local Cortex agents that forward logs, heartbeats, sessions,
 shell history, and command events into the server. Client dry-runs resolve the
 local binary and probe each configured host over SSH without deploying.
+Live client updates preserve the existing remote heartbeat-agent env before
+reinstalling. Because this is an update path for already configured agents, it
+fails if the remote agent token cannot be read/preserved; use
+`cortex setup deploy agent --heartbeat-token ...` to seed or repair a client.
 
 ### `cortex setup deploy`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -828,17 +828,19 @@ timer state, active/enabled watcher state, and container freshness via
 Update an already-configured Cortex deployment.
 
 ```bash
-cortex update
 cortex update server --dry-run
 cortex update server
+cortex update clients --dry-run
 cortex update clients
 cortex update agents
+cortex update
 ```
 
 `cortex update` defaults to `all`: it updates the configured server first, then
 updates configured host-agent clients. `clients` and `agents` are aliases; both
 refer to the host-local Cortex agents that forward logs, heartbeats, sessions,
-shell history, and command events into the server.
+shell history, and command events into the server. Client dry-runs resolve the
+local binary and probe each configured host over SSH without deploying.
 
 Configure the update profile once:
 
@@ -849,7 +851,8 @@ cortex update config clients --hosts dookie,shart,squirts --target https://corte
 
 The profile lives at `~/.cortex/deployments.toml` by default. A successful
 `cortex setup deploy remote --home PATH HOST` also records the server profile,
-so a one-off low-level deploy can seed future `cortex update server` runs.
+so a one-off low-level deploy can seed future `cortex update server` runs. Run
+the dry-run form before the live update when operating a remote server.
 
 ### `cortex setup deploy`
 

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -79,6 +79,11 @@ deploy records the server profile so later updates do not repeat host/home
 details; otherwise configure it with
 `cortex update config server --host HOST --home PATH`.
 
+Client-agent updates preserve the existing remote heartbeat-agent env and fail
+if the saved token cannot be read or preserved. Use
+`cortex setup deploy agent --heartbeat-token ...` for first-time client
+bootstrap or token repair, then return to `cortex update clients`.
+
 Use `--dry-run` first to verify SSH and Docker prerequisites. Non-dry-run remote
 deploy preserves existing remote env values from `<home>/.env` or the legacy
 `<home>/compose/.env` path, but it intentionally drops `CORTEX_VERSION` so the

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -65,18 +65,19 @@ automated deployment path is Docker Compose only.
 `cortex setup deploy remote <host>` writes/replaces `.env`, the managed Compose
 YAML, and `config/Dockerfile` under the selected remote home, then runs Docker
 Compose there. The default remote home is `~/.cortex`; pass `--home PATH` for
-hosts whose runtime lives elsewhere. The normal update workflow is:
+hosts whose runtime lives elsewhere. After the server profile exists, the normal
+update workflow is:
 
 ```bash
-cortex update server --dry-run
-cortex update server
+cortex update --dry-run
 cortex update
 ```
 
 `cortex setup deploy remote --home /mnt/cache/appdata/cortex tootie` remains the
 low-level primitive and a useful escape hatch. A successful low-level remote
 deploy records the server profile so later updates do not repeat host/home
-details.
+details; otherwise configure it with
+`cortex update config server --host HOST --home PATH`.
 
 Use `--dry-run` first to verify SSH and Docker prerequisites. Non-dry-run remote
 deploy preserves existing remote env values from `<home>/.env` or the legacy

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -65,11 +65,18 @@ automated deployment path is Docker Compose only.
 `cortex setup deploy remote <host>` writes/replaces `.env`, the managed Compose
 YAML, and `config/Dockerfile` under the selected remote home, then runs Docker
 Compose there. The default remote home is `~/.cortex`; pass `--home PATH` for
-hosts whose runtime lives elsewhere. Tootie's canonical update path is:
+hosts whose runtime lives elsewhere. The normal update workflow is:
 
 ```bash
-cortex setup deploy remote --home /mnt/cache/appdata/cortex tootie
+cortex update
+cortex update server --dry-run
+cortex update server
 ```
+
+`cortex setup deploy remote --home /mnt/cache/appdata/cortex tootie` remains the
+low-level primitive and a useful escape hatch. A successful low-level remote
+deploy records the server profile so later updates do not repeat host/home
+details.
 
 Use `--dry-run` first to verify SSH and Docker prerequisites. Non-dry-run remote
 deploy preserves existing remote env values from `<home>/.env` or the legacy

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -68,9 +68,9 @@ Compose there. The default remote home is `~/.cortex`; pass `--home PATH` for
 hosts whose runtime lives elsewhere. The normal update workflow is:
 
 ```bash
-cortex update
 cortex update server --dry-run
 cortex update server
+cortex update
 ```
 
 `cortex setup deploy remote --home /mnt/cache/appdata/cortex tootie` remains the

--- a/docs/sessions/2026-07-13-cortex-update-command.md
+++ b/docs/sessions/2026-07-13-cortex-update-command.md
@@ -1,0 +1,185 @@
+---
+date: 2026-07-13 11:00:41 EDT
+repo: git@github.com:jmagar/cortex.git
+branch: codex/cortex-update-command
+head: 31edc135
+plan: docs/superpowers/plans/2026-07-13-cortex-update-command.md
+working directory: /home/jmagar/.codex/worktrees/19fc2484-44b9-4def-9e72-c2265baaa081/cortex/.worktrees/cortex-update-command
+worktree: /home/jmagar/.codex/worktrees/19fc2484-44b9-4def-9e72-c2265baaa081/cortex/.worktrees/cortex-update-command
+pr: "#132 Add cortex update operator workflow (https://github.com/jmagar/cortex/pull/132)"
+beads: syslog-mcp-jlih1
+---
+
+# Cortex update command session
+
+## User Request
+
+The user wanted a canonical update path for an already configured Cortex server, preferring an operator command like `cortex update` over repeatedly spelling out `cortex setup deploy remote --home /mnt/cache/appdata/cortex tootie`. The user explicitly asked to use `superpowers:writing-plans` and then `vibin:work-it`.
+
+## Session Overview
+
+This session wrote and pushed an implementation plan, created an isolated `.worktrees/cortex-update-command` checkout, implemented the profile-backed `cortex update` workflow, opened PR #132, and ran several review/fix waves. The final review hardening was still dirty at the time this session artifact was saved, so this note records the state immediately before the final code commit.
+
+## Sequence of Events
+
+1. Wrote the plan at `docs/superpowers/plans/2026-07-13-cortex-update-command.md` and pushed it on `codex/restore-dookie-session-ingest`.
+2. Created the feature worktree `.worktrees/cortex-update-command` on branch `codex/cortex-update-command`.
+3. Implemented the update profile, update runner, `cortex update` CLI surface, docs, and tests across focused commits.
+4. Opened PR #132 against `codex/restore-dookie-session-ingest`.
+5. Ran review waves and follow-up simplification, then addressed findings around client profile preservation, dry-run validation, token handling, remote env read failures, and secret redaction.
+6. Ran focused and broad verification: formatting, update/deploy/setup test slices, full library tests, bin tests, integration targets, clippy, doc tests, version sync, and diff hygiene.
+7. Saved this session note before the final broad `git add .` step required by `vibin:work-it`.
+
+## Key Findings
+
+- `cortex setup deploy remote --home ... tootie` is a correct low-level primitive, but it is too setup-shaped for routine updates; the operator UX belongs behind `cortex update`.
+- Client agent updates originally risked dropping existing optional heartbeat/AI-transcript forwarding settings because the setup env writer did not preserve the full optional key vocabulary (`src/setup/heartbeat_agent.rs:110`, `src/heartbeat_agent.rs:25`).
+- Remote agent env reads could fail open because a missing or failed SSH capture was treated like an empty env, which could erase or omit a required heartbeat token (`src/agent_deploy.rs:330`, `src/agent_deploy.rs:396`).
+- Client dry-runs could report success for an explicit but nonexistent agent binary; saved profiles also needed validation when loaded, not only when written (`src/update.rs:165`, `src/update.rs:384`).
+- The first redaction pass only covered exact Cortex key names; deploy diagnostics needed to redact arbitrary secret-like env assignments (`src/agent_deploy.rs:799`).
+
+## Technical Decisions
+
+- Kept `cortex setup deploy remote` as the explicit install/deploy primitive and added `cortex update` as the repeatable operator path for already configured machines.
+- Made update configuration profile-backed so tootie's home path, host, docker command, and journald mode can be remembered once and reused.
+- Preserved omitted saved client profile values when rerunning `cortex update config clients`, rather than treating omitted flags as a reset.
+- Required existing client heartbeat tokens only for `cortex update clients`; normal `cortex setup deploy agent` remains the repair/install path where a token may be supplied explicitly.
+- Centralized optional heartbeat-agent env keys in `heartbeat_agent::OPTIONAL_ENV_KEYS` so setup and deploy update paths preserve the same knobs.
+
+## Files Changed
+
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| created | `docs/superpowers/plans/2026-07-13-cortex-update-command.md` | | Implementation plan for the workflow | Commit `2905944a` |
+| created | `docs/sessions/2026-07-13-cortex-update-command.md` | | This session artifact | Saved before final code commit |
+| modified | `docs/CLI.md` | | Documents `cortex update`, profile config, client token preservation, and dry-run behavior | Dirty at save time plus commits `bd2cb136`, `b358bcd5`, `31edc135` |
+| modified | `docs/mcp/DEPLOY.md` | | Documents remote deploy/update split and client agent update recovery | Dirty at save time plus commits `bd2cb136`, `b358bcd5`, `31edc135` |
+| modified | `src/lib.rs` | | Exported update module during initial implementation | Commit `de63601f` |
+| modified | `src/update.rs` | | Update profile, runner, report generation, client deploy flow, validation, and tests hooks | Dirty at save time plus commits `de63601f`, `12d4abed`, `3b78e90f`, `b358bcd5`, `31edc135` |
+| modified | `src/update_tests.rs` | | Unit coverage for profile config, runner behavior, reports, validation, and follow-up review fixes | Dirty at save time plus implementation commits |
+| modified | `src/agent_deploy.rs` | | Agent deploy env preservation, fail-closed SSH reads, token requirement, and secret redaction | Dirty at save time plus commits `12d4abed`, `b358bcd5` |
+| modified | `src/agent_deploy_tests.rs` | | Coverage for deploy profiles, remote env failures, token preservation, and redaction | Dirty at save time plus commits `b358bcd5`, `31edc135` |
+| modified | `src/heartbeat_agent.rs` | | Defines optional heartbeat-agent env keys shared by setup and deploy | Dirty at save time |
+| modified | `src/setup/heartbeat_agent.rs` | | Writes optional env keys and preserves ambient `RUST_LOG` when nonblank | Dirty at save time |
+| modified | `src/setup/heartbeat_agent_tests.rs` | | Coverage for default env writing and optional key preservation | Dirty at save time |
+| modified | `src/main.rs` | | CLI dispatch for update commands and setup deploy config construction | Dirty at save time plus commits `85e6d9c9`, `c2cce187`, `31edc135` |
+| modified | `src/main_tests.rs` | | CLI parsing tests for update command behavior | Commits `85e6d9c9`, `c2cce187`, `b358bcd5`, `31edc135` |
+| modified | `src/cli/help.rs` | | Help text for update/config subcommands | Commits `bd2cb136`, `31edc135` |
+| modified | `src/cli/help_tests.rs` | | Help text assertions | Commit `bd2cb136` |
+| modified | `tests/cli_help.rs` | | Integration coverage for CLI help surface | Commit `bd2cb136` |
+
+## Beads Activity
+
+| id | title | action(s) | final status at save time | why it mattered |
+|---|---|---|---|---|
+| `syslog-mcp-jlih1` | Add cortex update operator workflow | Created, claimed, worked | `in_progress` | Tracks the requested update workflow; intentionally left open until final code commit, push, and PR/comment checks complete |
+
+## Repository Maintenance
+
+### Plans
+
+Checked `docs/plans` and `docs/superpowers/plans`. The active plan `docs/superpowers/plans/2026-07-13-cortex-update-command.md` was left in place because the PR and final code commit were still active at save time. Older plan files were not moved because they were outside this session's scope and their completion state was not re-proven.
+
+### Beads
+
+Read `bd show syslog-mcp-jlih1 --json`; it was `in_progress` and assigned to Jacob Magar. It was not closed during this artifact commit because the code changes were still dirty.
+
+### Worktrees And Branches
+
+Checked `git worktree list --porcelain`, `git branch -vv`, and `git branch -r -vv`. The main worktree, base worktree, and feature worktree were all active and tied to live branches; no worktree or branch cleanup was safe.
+
+### Stale Docs
+
+Updated `docs/CLI.md` and `docs/mcp/DEPLOY.md` to reflect the new update workflow and the review-driven client token preservation behavior. Broader docs were not changed because the touched docs covered the operator workflow affected by this session.
+
+### Transparency
+
+This session note is committed alone by contract. Code and docs hardening changes remain dirty after this artifact is written and must be committed separately.
+
+## Tools and Skills Used
+
+- **Skills.** `superpowers:writing-plans` for the implementation plan, `vibin:work-it` for worktree/PR/review workflow, and `vibin:save-to-md` for this artifact.
+- **Shell and Git.** Used `git`, `cargo`, `gh`, `bd`, `find`, `test`, and standard shell inspection commands.
+- **Subagents.** Used implementation, review, silent-failure, PR-test, analyzer, and simplifier agents during the work-it loop; review findings drove the final hardening batch.
+- **External CLIs.** Used `gh` for PR state and `bd` for issue tracking.
+- **Browser/Web.** No browser or raw web tools were used.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `git status --short --branch` | Confirmed branch `codex/cortex-update-command` and 10 dirty files before session note |
+| `gh pr view --json number,title,url,headRefName,baseRefName,state,statusCheckRollup` | Confirmed PR #132 open against `codex/restore-dookie-session-ingest`; visible checks included CodeRabbit success, GitGuardian success, and cubic neutral |
+| `bd show syslog-mcp-jlih1 --json` | Confirmed bead is `in_progress` |
+| `find docs/plans docs/superpowers/plans -maxdepth 2 -type f` | Confirmed active plan file and existing plan inventory |
+| `git worktree list --porcelain` | Confirmed active main, base, and feature worktrees |
+| `git branch -vv` and `git branch -r -vv` | Confirmed branch tracking and no safe branch cleanup target |
+| `cargo fmt && cargo test update --lib && cargo test agent_deploy::tests --lib && cargo test setup::heartbeat_agent --lib` | Passed focused formatting and test chain |
+| `cargo xtask check-version-sync` | Passed; 8 version-bearing files in sync at 3.9.1 |
+| `cargo test --lib` | Passed; 1932 passed, 1 ignored |
+| `cargo test --bins` | Passed; 520 passed, 1 ignored |
+| `cargo clippy --all-targets --all-features -- -D warnings` | Passed |
+| `cargo test --doc` | Passed; 0 doc tests |
+| `cargo test --test auth_modes --test ci_changed_paths --test cli_help --test enrich_pipeline --test oauth_flow --test rmcp_compat --test spike_rmcp_extensions --test stdio_mcp --test workflow_shapes` | Passed all named integration targets |
+| `git diff --check` | Passed with no whitespace errors |
+
+## Errors Encountered
+
+- The setup heartbeat env default test failed after env writing started honoring ambient `RUST_LOG`; fixed by making the test serial and clearing relevant ambient variables.
+- `cargo test --tests` produced a truncated/lost final status while rerunning broad integration coverage, so it was not treated as a clean gate; named integration targets were rerun explicitly and passed.
+- Review agents identified several non-crashing correctness risks: optional env loss, fail-open remote env reads, insufficient dry-run validation, profile overwrite behavior, and narrow secret redaction. These were addressed in the dirty review-hardening batch.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Server updates | Operator had to repeat `cortex setup deploy remote --home ... tootie` | Operator can configure once and run `cortex update` |
+| Server profile | No remembered remote update profile | Profile stores host/home/docker/journald defaults |
+| Client profile config | Omitted flags could wipe saved values | Omitted target/docker/journald values preserve previous saved config |
+| Client dry-run | Explicit bad binary path could still appear successful | Explicit binary path is validated before deploy planning |
+| Client token handling | Remote env read failures could collapse into empty env | Update clients fail closed when required token cannot be preserved |
+| Env preservation | Optional heartbeat/AI transcript keys could be dropped | Shared optional key list is preserved through setup and update paths |
+| Secret redaction | Only exact Cortex secret keys were redacted | Arbitrary secret-like env assignments are redacted |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `cargo fmt && cargo test update --lib && cargo test agent_deploy::tests --lib && cargo test setup::heartbeat_agent --lib` | Formatting plus focused tests pass | Passed | pass |
+| `cargo xtask check-version-sync` | Version-bearing files agree | Passed at 3.9.1 | pass |
+| `cargo test --lib` | Library tests pass | 1932 passed, 1 ignored | pass |
+| `cargo test --bins` | Binary tests pass | 520 passed, 1 ignored | pass |
+| `cargo clippy --all-targets --all-features -- -D warnings` | No clippy warnings | Passed | pass |
+| `cargo test --doc` | Doc tests pass | 0 doc tests, command passed | pass |
+| Named integration target command | Listed integration targets pass | Passed | pass |
+| `git diff --check` | No whitespace errors | Passed | pass |
+
+## Risks and Rollback
+
+- The final hardening batch was not yet committed at this artifact save point; rollback before the code commit would be `git restore` on the dirty files, preserving the already pushed implementation commits.
+- The update-client token requirement may surface previously hidden misconfigured agents; the intended repair path is `cortex setup deploy agent --heartbeat-token ...`, not bypassing the update check.
+- The PR targets `codex/restore-dookie-session-ingest`, not `main`, because the current work builds on the earlier dookie session ingest branch.
+
+## Decisions Not Taken
+
+- Did not rename or remove `setup deploy remote`; it remains the low-level install/deploy primitive for explicit setup work.
+- Did not add a token flag directly to `cortex update clients`; update is for already configured agents, while setup deploy remains the repair path for installing or replacing secrets.
+- Did not move older plan files to `docs/plans/complete/`; their completion state was not proven during this session.
+
+## References
+
+- Plan: `docs/superpowers/plans/2026-07-13-cortex-update-command.md`
+- PR: https://github.com/jmagar/cortex/pull/132
+- Bead: `syslog-mcp-jlih1`
+- User-requested skills: `superpowers:writing-plans`, `vibin:work-it`, `vibin:save-to-md`
+
+## Open Questions
+
+- None blocking at save time. Remaining work is procedural closeout: final commit, push, PR comment check, bead close, and final clean-state verification.
+
+## Next Steps
+
+1. Commit and push this session artifact alone.
+2. Commit and push the remaining code/docs hardening changes.
+3. Fetch PR comments/check status after the push and address any new actionable items.
+4. Close `syslog-mcp-jlih1`, push bead state, and verify the worktree is clean/up to date.

--- a/src/agent_deploy.rs
+++ b/src/agent_deploy.rs
@@ -279,6 +279,14 @@ pub fn deploy_agent_to_host(
     config: &AgentDeployConfig,
 ) -> DeployResult {
     let started = Instant::now();
+    if let Err(error) = validate_ssh_host(host) {
+        return DeployResult {
+            host: host.to_string(),
+            ok: false,
+            detail: error.to_string(),
+            elapsed_ms: started.elapsed().as_millis(),
+        };
+    }
     match run_deploy(host, local_binary, config) {
         Ok(()) => DeployResult {
             host: host.to_string(),
@@ -296,6 +304,9 @@ pub fn deploy_agent_to_host(
 }
 
 fn is_unraid(host: &str) -> bool {
+    if validate_ssh_host(host).is_err() {
+        return false;
+    }
     let out = Command::new("ssh")
         .args([
             "-o",
@@ -304,6 +315,7 @@ fn is_unraid(host: &str) -> bool {
             "BatchMode=yes",
             "-o",
             "LogLevel=ERROR",
+            "--",
             host,
             "test -f /etc/unraid-version && echo yes || echo no",
         ])
@@ -312,6 +324,7 @@ fn is_unraid(host: &str) -> bool {
 }
 
 fn run_deploy(host: &str, local_binary: &Path, config: &AgentDeployConfig) -> io::Result<()> {
+    validate_ssh_host(host)?;
     if is_unraid(host) {
         return run_deploy_unraid(host, local_binary, config);
     }
@@ -325,29 +338,27 @@ fn run_deploy(host: &str, local_binary: &Path, config: &AgentDeployConfig) -> io
         "chmod +x ~/.local/bin/cortex.new && mv -f ~/.local/bin/cortex.new ~/.local/bin/cortex",
     )?;
 
-    let mut env_pairs: Vec<String> = Vec::new();
-    if let Some(t) = &config.target {
-        env_pairs.push(format!("CORTEX_HEARTBEAT_TARGET={}", shell_quote(t)));
-    }
-    if let Some(t) = &config.token {
-        env_pairs.push(format!("CORTEX_HEARTBEAT_TOKEN={}", shell_quote(t)));
-    }
-    if config.docker == Some(true) {
-        env_pairs.push("CORTEX_AGENT_DOCKER=true".to_string());
-    }
-    if config.journald == Some(true) {
-        env_pairs.push("CORTEX_AGENT_JOURNALD=true".to_string());
-    }
-    if let Some(syslog_target) = deploy_syslog_target(config.target.as_deref()) {
-        env_pairs.push(format!(
-            "CORTEX_SYSLOG_TARGET={}",
-            shell_quote(&syslog_target)
-        ));
-    }
+    let env_pairs = resolve_linux_agent_env(
+        &parse_env_file(
+            &ssh_capture(
+                host,
+                "cat ~/.cortex/heartbeat-agent.env 2>/dev/null || true",
+            )
+            .unwrap_or_default(),
+        ),
+        config,
+    );
     let prefix = if env_pairs.is_empty() {
         String::new()
     } else {
-        format!("{} ", env_pairs.join(" "))
+        format!(
+            "{} ",
+            env_pairs
+                .iter()
+                .map(|(key, value)| format!("{key}={}", shell_quote(value)))
+                .collect::<Vec<_>>()
+                .join(" ")
+        )
     };
     ssh_run(
         host,
@@ -482,6 +493,67 @@ fn parse_env_file(contents: &str) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Resolve the host-local systemd agent env for a Linux (non-Unraid) deploy.
+/// Only keys that the Linux setup writer consumes are carried forward. A fresh
+/// no-flag deploy stays minimal, while upgrades preserve auth and forwarding
+/// knobs unless the operator supplied an explicit override.
+fn resolve_linux_agent_env(
+    persisted: &[(String, String)],
+    config: &AgentDeployConfig,
+) -> Vec<(String, String)> {
+    use std::collections::HashMap;
+    let prev: HashMap<&str, &str> = persisted
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let prev_get = |k: &str| prev.get(k).map(|s| s.to_string());
+
+    let mut out = Vec::new();
+    let target = config
+        .target
+        .clone()
+        .or_else(|| prev_get("CORTEX_HEARTBEAT_TARGET"));
+    if let Some(target) = &target {
+        out.push(("CORTEX_HEARTBEAT_TARGET".to_string(), target.clone()));
+    }
+    if let Some(token) = config
+        .token
+        .clone()
+        .or_else(|| prev_get("CORTEX_HEARTBEAT_TOKEN"))
+    {
+        out.push(("CORTEX_HEARTBEAT_TOKEN".to_string(), token));
+    }
+    if let Some(docker) = config
+        .docker
+        .map(|value| value.to_string())
+        .or_else(|| prev_get("CORTEX_AGENT_DOCKER"))
+    {
+        out.push(("CORTEX_AGENT_DOCKER".to_string(), docker));
+    }
+    if let Some(journald) = config
+        .journald
+        .map(|value| value.to_string())
+        .or_else(|| prev_get("CORTEX_AGENT_JOURNALD"))
+    {
+        out.push(("CORTEX_AGENT_JOURNALD".to_string(), journald));
+    }
+    if let Some(docker_url) = prev_get("CORTEX_AGENT_DOCKER_URL") {
+        out.push(("CORTEX_AGENT_DOCKER_URL".to_string(), docker_url));
+    }
+    if let Some(syslog_file) = prev_get("CORTEX_AGENT_SYSLOG_FILE") {
+        out.push(("CORTEX_AGENT_SYSLOG_FILE".to_string(), syslog_file));
+    }
+    let syslog_target = if config.target.is_some() {
+        deploy_syslog_target(target.as_deref())
+    } else {
+        prev_get("CORTEX_SYSLOG_TARGET").or_else(|| deploy_syslog_target(target.as_deref()))
+    };
+    if let Some(syslog_target) = syslog_target {
+        out.push(("CORTEX_SYSLOG_TARGET".to_string(), syslog_target));
+    }
+    out
+}
+
 /// Resolve the agent container env for a (re)deploy using precedence
 /// **flag > persisted > default** for each managed key, then carry every other
 /// key from the persisted env through unchanged (e.g. `CORTEX_AGENT_FILE_TAILS`).
@@ -614,6 +686,7 @@ fn preserved_custom_mount_flags(inspect_mounts: &str) -> Vec<String> {
 /// (e.g. inspecting a not-yet-existing container) should append `|| true` so the
 /// ssh invocation itself succeeds and returns empty output.
 fn ssh_capture(host: &str, cmd: &str) -> io::Result<String> {
+    validate_ssh_host(host)?;
     let out = Command::new("ssh")
         .args([
             "-o",
@@ -622,6 +695,7 @@ fn ssh_capture(host: &str, cmd: &str) -> io::Result<String> {
             "StrictHostKeyChecking=accept-new",
             "-o",
             "LogLevel=ERROR",
+            "--",
             host,
             cmd,
         ])
@@ -630,6 +704,7 @@ fn ssh_capture(host: &str, cmd: &str) -> io::Result<String> {
 }
 
 fn ssh_run(host: &str, cmd: &str) -> io::Result<()> {
+    validate_ssh_host(host)?;
     let status = Command::new("ssh")
         .args([
             "-o",
@@ -638,19 +713,22 @@ fn ssh_run(host: &str, cmd: &str) -> io::Result<()> {
             "StrictHostKeyChecking=accept-new",
             "-o",
             "LogLevel=ERROR",
+            "--",
             host,
             cmd,
         ])
         .status()?;
     if !status.success() {
         return Err(io::Error::other(format!(
-            "ssh {host}: '{cmd}' exited non-zero"
+            "ssh {host}: '{}' exited non-zero",
+            redact_secret_envs(cmd)
         )));
     }
     Ok(())
 }
 
 fn scp_file(local: &Path, host: &str, remote_path: &str) -> io::Result<()> {
+    validate_ssh_host(host)?;
     let dest = format!("{host}:{remote_path}");
     let status = Command::new("scp")
         .args([
@@ -658,6 +736,7 @@ fn scp_file(local: &Path, host: &str, remote_path: &str) -> io::Result<()> {
             "BatchMode=yes",
             "-o",
             "StrictHostKeyChecking=accept-new",
+            "--",
         ])
         .arg(local)
         .arg(&dest)
@@ -669,6 +748,55 @@ fn scp_file(local: &Path, host: &str, remote_path: &str) -> io::Result<()> {
         )));
     }
     Ok(())
+}
+
+fn validate_ssh_host(host: &str) -> io::Result<()> {
+    if crate::inventory::ssh::is_safe_ssh_host(host) {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("unsafe ssh host: {host}"),
+        ))
+    }
+}
+
+fn redact_secret_envs(input: &str) -> String {
+    const SECRET_KEYS: &[&str] = &["CORTEX_HEARTBEAT_TOKEN", "CORTEX_TOKEN", "CORTEX_API_TOKEN"];
+    let mut redacted = input.to_string();
+    for key in SECRET_KEYS {
+        redacted = redact_env_assignment(&redacted, key);
+    }
+    redacted
+}
+
+fn redact_env_assignment(input: &str, key: &str) -> String {
+    let needle = format!("{key}=");
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0usize;
+    while let Some(relative) = input[cursor..].find(&needle) {
+        let start = cursor + relative;
+        output.push_str(&input[cursor..start]);
+        output.push_str(&needle);
+        output.push_str("<redacted>");
+        cursor = skip_shell_word(input, start + needle.len());
+    }
+    output.push_str(&input[cursor..]);
+    output
+}
+
+fn skip_shell_word(input: &str, start: usize) -> usize {
+    let mut quote: Option<char> = None;
+    for (relative, ch) in input[start..].char_indices() {
+        match quote {
+            Some(active) if ch == active => quote = None,
+            Some(_) => {}
+            None if ch == '\'' || ch == '"' => quote = Some(ch),
+            None if ch.is_ascii_whitespace() => return start + relative,
+            None => {}
+        }
+    }
+    input.len()
 }
 
 fn home_dir() -> Option<PathBuf> {

--- a/src/agent_deploy.rs
+++ b/src/agent_deploy.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use serde::Serialize;
 
 const PROBE_TIMEOUT_SECS: u64 = 5;
 const REMOTE_BIN_TMP: &str = ".local/bin/cortex.new";
@@ -47,7 +48,7 @@ pub struct AgentDeployConfig {
     pub journald: Option<bool>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct DeployResult {
     pub host: String,
     pub ok: bool,

--- a/src/agent_deploy.rs
+++ b/src/agent_deploy.rs
@@ -42,6 +42,10 @@ impl HostProbe {
 pub struct AgentDeployConfig {
     pub target: Option<String>,
     pub token: Option<String>,
+    /// Require an effective heartbeat token after flag/persisted-env resolution.
+    /// `cortex update clients` sets this because it updates already configured
+    /// agents and must not silently strip auth when a remote env read fails.
+    pub require_token: bool,
     /// `None` = not specified on the CLI → preserve the host's existing value on
     /// an upgrade (rather than reset to the default).
     pub docker: Option<bool>,
@@ -329,6 +333,15 @@ fn run_deploy(host: &str, local_binary: &Path, config: &AgentDeployConfig) -> io
         return run_deploy_unraid(host, local_binary, config);
     }
 
+    let env_pairs = resolve_linux_agent_env(
+        &parse_env_file(&read_optional_remote_file(
+            host,
+            "$HOME/.cortex/heartbeat-agent.env",
+        )?),
+        config,
+    );
+    require_token_if_requested(&env_pairs, config)?;
+
     ssh_run(host, "mkdir -p ~/.local/bin")?;
     // scp to a temp path then mv atomically — avoids ETXTBSY if the binary is
     // currently running as a service on the remote host.
@@ -337,17 +350,6 @@ fn run_deploy(host: &str, local_binary: &Path, config: &AgentDeployConfig) -> io
         host,
         "chmod +x ~/.local/bin/cortex.new && mv -f ~/.local/bin/cortex.new ~/.local/bin/cortex",
     )?;
-
-    let env_pairs = resolve_linux_agent_env(
-        &parse_env_file(
-            &ssh_capture(
-                host,
-                "cat ~/.cortex/heartbeat-agent.env 2>/dev/null || true",
-            )
-            .unwrap_or_default(),
-        ),
-        config,
-    );
     let prefix = if env_pairs.is_empty() {
         String::new()
     } else {
@@ -393,28 +395,25 @@ fn run_deploy_unraid(
     // update between republishes, but the image is the source of truth).
     let image = format!("{CORTEX_IMAGE_REPO}:{}", env!("CARGO_PKG_VERSION"));
     ssh_run(host, &format!("mkdir -p {UNRAID_APPDATA}"))?;
-    ssh_run(host, &format!("docker pull {image}"))?;
 
     // Config-preserving upgrade: resolve the container env from the host's
     // persisted heartbeat-agent.env (flag > persisted > default per key, custom
     // keys like CORTEX_AGENT_FILE_TAILS carried through), and carry forward any
     // non-standard mounts (e.g. the host log dir a file-tail reads) from the
-    // running container. Both reads are best-effort (`|| true`): a first-time
-    // deploy has neither, and resolve_agent_env falls back to flag defaults.
+    // running container.
     let env_pairs = resolve_agent_env(
-        &parse_env_file(
-            &ssh_capture(host, &format!("cat {UNRAID_ENV} 2>/dev/null || true"))
-                .unwrap_or_default(),
-        ),
+        &parse_env_file(&read_optional_remote_file(host, UNRAID_ENV)?),
         config,
     );
-    let custom_mounts: String = preserved_custom_mount_flags(
-        &ssh_capture(
-            host,
-            &format!("docker inspect {UNRAID_CONTAINER} --format '{MOUNT_INSPECT_TMPL}' 2>/dev/null || true"),
-        )
-        .unwrap_or_default(),
-    )
+    require_token_if_requested(&env_pairs, config)?;
+    ssh_run(host, &format!("docker pull {image}"))?;
+
+    let custom_mounts: String = preserved_custom_mount_flags(&ssh_capture(
+        host,
+        &format!(
+            "docker inspect {UNRAID_CONTAINER} --format '{MOUNT_INSPECT_TMPL}' 2>/dev/null || true"
+        ),
+    )?)
     .concat();
 
     // Persist the resolved env (reference / manual restarts), then chmod 600. The
@@ -489,7 +488,7 @@ fn parse_env_file(contents: &str) -> Vec<(String, String)> {
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .filter_map(|line| line.split_once('='))
         .map(|(k, v)| (k.trim().to_string(), v.to_string()))
-        .filter(|(k, _)| !k.is_empty())
+        .filter(|(k, _)| is_safe_env_key(k))
         .collect()
 }
 
@@ -543,6 +542,11 @@ fn resolve_linux_agent_env(
     if let Some(syslog_file) = prev_get("CORTEX_AGENT_SYSLOG_FILE") {
         out.push(("CORTEX_AGENT_SYSLOG_FILE".to_string(), syslog_file));
     }
+    for key in crate::heartbeat_agent::OPTIONAL_ENV_KEYS {
+        if let Some(value) = prev_get(key) {
+            out.push(((*key).to_string(), value));
+        }
+    }
     let syslog_target = if config.target.is_some() {
         deploy_syslog_target(target.as_deref())
     } else {
@@ -552,6 +556,24 @@ fn resolve_linux_agent_env(
         out.push(("CORTEX_SYSLOG_TARGET".to_string(), syslog_target));
     }
     out
+}
+
+fn require_token_if_requested(
+    env_pairs: &[(String, String)],
+    config: &AgentDeployConfig,
+) -> io::Result<()> {
+    if !config.require_token
+        || env_pairs
+            .iter()
+            .any(|(key, value)| key == "CORTEX_HEARTBEAT_TOKEN" && !value.trim().is_empty())
+    {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        "client update requires existing CORTEX_HEARTBEAT_TOKEN on the remote agent; repair the client with `cortex setup deploy agent --heartbeat-token ...`",
+    ))
 }
 
 /// Resolve the agent container env for a (re)deploy using precedence
@@ -700,7 +722,20 @@ fn ssh_capture(host: &str, cmd: &str) -> io::Result<String> {
             cmd,
         ])
         .output()?;
+    if !out.status.success() {
+        return Err(io::Error::other(format!(
+            "ssh {host}: '{}' exited non-zero",
+            redact_secret_envs(cmd)
+        )));
+    }
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+fn read_optional_remote_file(host: &str, remote_path_expr: &str) -> io::Result<String> {
+    ssh_capture(
+        host,
+        &format!("if [ -e {remote_path_expr} ]; then cat {remote_path_expr}; fi"),
+    )
 }
 
 fn ssh_run(host: &str, cmd: &str) -> io::Result<()> {
@@ -762,12 +797,65 @@ fn validate_ssh_host(host: &str) -> io::Result<()> {
 }
 
 fn redact_secret_envs(input: &str) -> String {
-    const SECRET_KEYS: &[&str] = &["CORTEX_HEARTBEAT_TOKEN", "CORTEX_TOKEN", "CORTEX_API_TOKEN"];
+    let mut keys: BTreeSet<String> = ["CORTEX_HEARTBEAT_TOKEN", "CORTEX_TOKEN", "CORTEX_API_TOKEN"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    collect_secret_env_assignment_keys(input, &mut keys);
+
     let mut redacted = input.to_string();
-    for key in SECRET_KEYS {
-        redacted = redact_env_assignment(&redacted, key);
+    for key in keys {
+        redacted = redact_env_assignment(&redacted, &key);
     }
     redacted
+}
+
+fn collect_secret_env_assignment_keys(input: &str, out: &mut BTreeSet<String>) {
+    for (equals, ch) in input.char_indices() {
+        if ch != '=' {
+            continue;
+        }
+        let start = input[..equals]
+            .char_indices()
+            .rev()
+            .find_map(|(idx, ch)| (!is_env_key_char(ch)).then_some(idx + ch.len_utf8()))
+            .unwrap_or(0);
+        let key = &input[start..equals];
+        if is_safe_env_key(key)
+            && is_env_assignment_boundary(input, start)
+            && is_secret_env_key(key)
+        {
+            out.insert(key.to_string());
+        }
+    }
+}
+
+fn is_env_assignment_boundary(input: &str, start: usize) -> bool {
+    start == 0
+        || input[..start]
+            .chars()
+            .last()
+            .is_none_or(|ch| ch.is_ascii_whitespace() || ch == '\'' || ch == '"')
+}
+
+fn is_secret_env_key(key: &str) -> bool {
+    let upper = key.to_ascii_uppercase();
+    upper.contains("TOKEN")
+        || upper.contains("SECRET")
+        || upper.contains("PASSWORD")
+        || upper.contains("API_KEY")
+        || upper == "KEY"
+        || upper.ends_with("_KEY")
+}
+
+fn is_safe_env_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    matches!(chars.next(), Some(first) if first == '_' || first.is_ascii_alphabetic())
+        && chars.all(is_env_key_char)
+}
+
+fn is_env_key_char(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
 }
 
 fn redact_env_assignment(input: &str, key: &str) -> String {

--- a/src/agent_deploy_tests.rs
+++ b/src/agent_deploy_tests.rs
@@ -48,6 +48,26 @@ fn prepend_path(dir: &Path) -> EnvGuard {
     EnvGuard::set("PATH", new_path)
 }
 
+fn write_local_binary(dir: &Path) -> PathBuf {
+    let local_binary = dir.join("cortex");
+    std::fs::write(&local_binary, "binary").unwrap();
+    local_binary
+}
+
+fn write_successful_scp(dir: &Path) {
+    write_executable(&dir.join("scp"), "#!/bin/sh\nexit 0\n");
+}
+
+fn write_logging_scp(dir: &Path) {
+    write_executable(
+        &dir.join("scp"),
+        r#"#!/bin/sh
+printf 'scp %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
+exit 0
+"#,
+    );
+}
+
 #[test]
 fn parse_ssh_config_skips_wildcards_and_github() {
     let config = "Host *\n  ServerAliveInterval 60\n\nHost dookie\n  HostName 100.88.16.79\n\nHost github.com\n  User git\n\nHost tootie squirts\n  User jmagar\n";
@@ -220,8 +240,7 @@ fn find_local_binary_prefers_installed_cortex_from_path() {
 fn deploy_agent_to_linux_host_runs_install_sequence_with_env_prefix() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("commands.log");
-    let local_binary = dir.path().join("cortex");
-    std::fs::write(&local_binary, "binary").unwrap();
+    let local_binary = write_local_binary(dir.path());
     write_executable(
         &dir.path().join("ssh"),
         r#"#!/bin/sh
@@ -232,13 +251,7 @@ case "$*" in
 esac
 "#,
     );
-    write_executable(
-        &dir.path().join("scp"),
-        r#"#!/bin/sh
-printf 'scp %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
-exit 0
-"#,
-    );
+    write_logging_scp(dir.path());
     let _path = prepend_path(dir.path());
     let _log = EnvGuard::set("CORTEX_TEST_AGENT_DEPLOY_LOG", &log);
     let _syslog = EnvGuard::remove("CORTEX_SYSLOG_TARGET");
@@ -273,8 +286,7 @@ exit 0
 fn deploy_agent_to_linux_host_preserves_persisted_env_without_token_profile() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("commands.log");
-    let local_binary = dir.path().join("cortex");
-    std::fs::write(&local_binary, "binary").unwrap();
+    let local_binary = write_local_binary(dir.path());
     write_executable(
         &dir.path().join("ssh"),
         r#"#!/bin/sh
@@ -293,13 +305,7 @@ case "$*" in
 esac
 "#,
     );
-    write_executable(
-        &dir.path().join("scp"),
-        r#"#!/bin/sh
-printf 'scp %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
-exit 0
-"#,
-    );
+    write_logging_scp(dir.path());
     let _path = prepend_path(dir.path());
     let _log = EnvGuard::set("CORTEX_TEST_AGENT_DEPLOY_LOG", &log);
 
@@ -319,8 +325,7 @@ exit 0
 fn deploy_agent_rejects_unsafe_host_before_ssh() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("commands.log");
-    let local_binary = dir.path().join("cortex");
-    std::fs::write(&local_binary, "binary").unwrap();
+    let local_binary = write_local_binary(dir.path());
     write_executable(
         &dir.path().join("ssh"),
         r#"#!/bin/sh
@@ -328,7 +333,7 @@ printf 'ssh %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
 exit 0
 "#,
     );
-    write_executable(&dir.path().join("scp"), "#!/bin/sh\nexit 0\n");
+    write_successful_scp(dir.path());
     let _path = prepend_path(dir.path());
     let _log = EnvGuard::set("CORTEX_TEST_AGENT_DEPLOY_LOG", &log);
 
@@ -347,8 +352,7 @@ exit 0
 #[serial]
 fn deploy_agent_reports_first_remote_failure() {
     let dir = tempfile::tempdir().unwrap();
-    let local_binary = dir.path().join("cortex");
-    std::fs::write(&local_binary, "binary").unwrap();
+    let local_binary = write_local_binary(dir.path());
     write_executable(
         &dir.path().join("ssh"),
         r#"#!/bin/sh
@@ -359,7 +363,7 @@ case "$*" in
 esac
 "#,
     );
-    write_executable(&dir.path().join("scp"), "#!/bin/sh\nexit 0\n");
+    write_successful_scp(dir.path());
     let _path = prepend_path(dir.path());
 
     let result = deploy_agent_to_host("linux-host", &local_binary, &AgentDeployConfig::default());
@@ -373,8 +377,7 @@ esac
 #[serial]
 fn deploy_agent_redacts_secret_envs_from_failure_detail() {
     let dir = tempfile::tempdir().unwrap();
-    let local_binary = dir.path().join("cortex");
-    std::fs::write(&local_binary, "binary").unwrap();
+    let local_binary = write_local_binary(dir.path());
     write_executable(
         &dir.path().join("ssh"),
         r#"#!/bin/sh
@@ -385,7 +388,7 @@ case "$*" in
 esac
 "#,
     );
-    write_executable(&dir.path().join("scp"), "#!/bin/sh\nexit 0\n");
+    write_successful_scp(dir.path());
     let _path = prepend_path(dir.path());
 
     let result = deploy_agent_to_host(
@@ -409,8 +412,7 @@ esac
 fn deploy_agent_to_unraid_writes_persistent_env_and_docker_container() {
     let dir = tempfile::tempdir().unwrap();
     let log = dir.path().join("commands.log");
-    let local_binary = dir.path().join("cortex");
-    std::fs::write(&local_binary, "binary").unwrap();
+    let local_binary = write_local_binary(dir.path());
     write_executable(
         &dir.path().join("ssh"),
         r#"#!/bin/sh
@@ -421,13 +423,7 @@ case "$*" in
 esac
 "#,
     );
-    write_executable(
-        &dir.path().join("scp"),
-        r#"#!/bin/sh
-printf 'scp %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
-exit 0
-"#,
-    );
+    write_logging_scp(dir.path());
     let _path = prepend_path(dir.path());
     let _log = EnvGuard::set("CORTEX_TEST_AGENT_DEPLOY_LOG", &log);
 

--- a/src/agent_deploy_tests.rs
+++ b/src/agent_deploy_tests.rs
@@ -262,10 +262,85 @@ exit 0
     assert!(log.contains("mv -f ~/.local/bin/cortex.new ~/.local/bin/cortex"));
     assert!(log.contains("CORTEX_HEARTBEAT_TARGET='https://cortex.example.test:3100'"));
     assert!(log.contains("CORTEX_HEARTBEAT_TOKEN='heartbeat token'"));
-    assert!(log.contains("CORTEX_AGENT_DOCKER=true"));
-    assert!(log.contains("CORTEX_AGENT_JOURNALD=true"));
+    assert!(log.contains("CORTEX_AGENT_DOCKER='true'"));
+    assert!(log.contains("CORTEX_AGENT_JOURNALD='true'"));
     assert!(log.contains("CORTEX_SYSLOG_TARGET='cortex.example.test:1514'"));
     assert!(log.contains("~/.local/bin/cortex setup heartbeat-agent install"));
+}
+
+#[test]
+#[serial]
+fn deploy_agent_to_linux_host_preserves_persisted_env_without_token_profile() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("commands.log");
+    let local_binary = dir.path().join("cortex");
+    std::fs::write(&local_binary, "binary").unwrap();
+    write_executable(
+        &dir.path().join("ssh"),
+        r#"#!/bin/sh
+printf 'ssh %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
+case "$*" in
+  *"/etc/unraid-version"*) printf 'no\n'; exit 0 ;;
+  *"cat ~/.cortex/heartbeat-agent.env"*)
+    printf 'CORTEX_HEARTBEAT_TARGET=https://old.example\n'
+    printf 'CORTEX_HEARTBEAT_TOKEN=preserved-token\n'
+    printf 'CORTEX_AGENT_DOCKER=true\n'
+    printf 'CORTEX_AGENT_JOURNALD=true\n'
+    printf 'CORTEX_SYSLOG_TARGET=old-syslog.example:1514\n'
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+"#,
+    );
+    write_executable(
+        &dir.path().join("scp"),
+        r#"#!/bin/sh
+printf 'scp %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
+exit 0
+"#,
+    );
+    let _path = prepend_path(dir.path());
+    let _log = EnvGuard::set("CORTEX_TEST_AGENT_DEPLOY_LOG", &log);
+
+    let result = deploy_agent_to_host("linux-host", &local_binary, &AgentDeployConfig::default());
+
+    assert!(result.ok, "{result:?}");
+    let log = std::fs::read_to_string(log).unwrap();
+    assert!(log.contains("CORTEX_HEARTBEAT_TARGET='https://old.example'"));
+    assert!(log.contains("CORTEX_HEARTBEAT_TOKEN='preserved-token'"));
+    assert!(log.contains("CORTEX_AGENT_DOCKER='true'"));
+    assert!(log.contains("CORTEX_AGENT_JOURNALD='true'"));
+    assert!(log.contains("CORTEX_SYSLOG_TARGET='old-syslog.example:1514'"));
+}
+
+#[test]
+#[serial]
+fn deploy_agent_rejects_unsafe_host_before_ssh() {
+    let dir = tempfile::tempdir().unwrap();
+    let log = dir.path().join("commands.log");
+    let local_binary = dir.path().join("cortex");
+    std::fs::write(&local_binary, "binary").unwrap();
+    write_executable(
+        &dir.path().join("ssh"),
+        r#"#!/bin/sh
+printf 'ssh %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
+exit 0
+"#,
+    );
+    write_executable(&dir.path().join("scp"), "#!/bin/sh\nexit 0\n");
+    let _path = prepend_path(dir.path());
+    let _log = EnvGuard::set("CORTEX_TEST_AGENT_DEPLOY_LOG", &log);
+
+    let result = deploy_agent_to_host(
+        "-oProxyCommand=touch /tmp/pwned",
+        &local_binary,
+        &AgentDeployConfig::default(),
+    );
+
+    assert!(!result.ok);
+    assert!(result.detail.contains("unsafe ssh host"));
+    assert!(!log.exists());
 }
 
 #[test]
@@ -292,6 +367,41 @@ esac
     assert!(!result.ok);
     assert!(result.detail.contains("mkdir -p ~/.local/bin"));
     assert!(result.detail.contains("exited non-zero"));
+}
+
+#[test]
+#[serial]
+fn deploy_agent_redacts_secret_envs_from_failure_detail() {
+    let dir = tempfile::tempdir().unwrap();
+    let local_binary = dir.path().join("cortex");
+    std::fs::write(&local_binary, "binary").unwrap();
+    write_executable(
+        &dir.path().join("ssh"),
+        r#"#!/bin/sh
+case "$*" in
+  *"/etc/unraid-version"*) printf 'no\n'; exit 0 ;;
+  *"setup heartbeat-agent install"*) exit 42 ;;
+  *) exit 0 ;;
+esac
+"#,
+    );
+    write_executable(&dir.path().join("scp"), "#!/bin/sh\nexit 0\n");
+    let _path = prepend_path(dir.path());
+
+    let result = deploy_agent_to_host(
+        "linux-host",
+        &local_binary,
+        &AgentDeployConfig {
+            target: Some("https://cortex.example.test".to_string()),
+            token: Some("super secret token".to_string()),
+            docker: None,
+            journald: None,
+        },
+    );
+
+    assert!(!result.ok);
+    assert!(!result.detail.contains("super secret token"));
+    assert!(result.detail.contains("CORTEX_HEARTBEAT_TOKEN=<redacted>"));
 }
 
 #[test]
@@ -434,6 +544,38 @@ fn resolve_agent_env_first_deploy_defaults_and_omits_absent_token() {
     assert_eq!(env_get(&env, "CORTEX_HEARTBEAT_TOKEN"), None);
     assert_eq!(env_get(&env, "CORTEX_AGENT_DOCKER"), Some("false"));
     assert_eq!(env_get(&env, "RUST_LOG"), Some("warn"));
+}
+
+#[test]
+fn resolve_linux_agent_env_preserves_auth_and_flags_without_defaults() {
+    let persisted = vec![
+        (
+            "CORTEX_HEARTBEAT_TARGET".into(),
+            "https://cortex.tootie.tv".into(),
+        ),
+        ("CORTEX_HEARTBEAT_TOKEN".into(), "the-secret".into()),
+        ("CORTEX_AGENT_DOCKER".into(), "true".into()),
+        ("CORTEX_AGENT_JOURNALD".into(), "true".into()),
+        ("CORTEX_SYSLOG_TARGET".into(), "100.88.16.79:1514".into()),
+    ];
+    let env = resolve_linux_agent_env(&persisted, &AgentDeployConfig::default());
+
+    assert_eq!(
+        env_get(&env, "CORTEX_HEARTBEAT_TARGET"),
+        Some("https://cortex.tootie.tv")
+    );
+    assert_eq!(env_get(&env, "CORTEX_HEARTBEAT_TOKEN"), Some("the-secret"));
+    assert_eq!(env_get(&env, "CORTEX_AGENT_DOCKER"), Some("true"));
+    assert_eq!(env_get(&env, "CORTEX_AGENT_JOURNALD"), Some("true"));
+    assert_eq!(
+        env_get(&env, "CORTEX_SYSLOG_TARGET"),
+        Some("100.88.16.79:1514")
+    );
+}
+
+#[test]
+fn resolve_linux_agent_env_stays_empty_for_first_flagless_deploy() {
+    assert!(resolve_linux_agent_env(&[], &AgentDeployConfig::default()).is_empty());
 }
 
 #[test]

--- a/src/agent_deploy_tests.rs
+++ b/src/agent_deploy_tests.rs
@@ -262,6 +262,7 @@ esac
         &AgentDeployConfig {
             target: Some("https://cortex.example.test:3100".to_string()),
             token: Some("heartbeat token".to_string()),
+            require_token: false,
             docker: Some(true),
             journald: Some(true),
         },
@@ -291,18 +292,23 @@ fn deploy_agent_to_linux_host_preserves_persisted_env_without_token_profile() {
         &dir.path().join("ssh"),
         r#"#!/bin/sh
 printf 'ssh %s\n' "$*" >> "$CORTEX_TEST_AGENT_DEPLOY_LOG"
-case "$*" in
-  *"/etc/unraid-version"*) printf 'no\n'; exit 0 ;;
-  *"cat ~/.cortex/heartbeat-agent.env"*)
-    printf 'CORTEX_HEARTBEAT_TARGET=https://old.example\n'
-    printf 'CORTEX_HEARTBEAT_TOKEN=preserved-token\n'
-    printf 'CORTEX_AGENT_DOCKER=true\n'
-    printf 'CORTEX_AGENT_JOURNALD=true\n'
-    printf 'CORTEX_SYSLOG_TARGET=old-syslog.example:1514\n'
-    exit 0
-    ;;
-  *) exit 0 ;;
-esac
+	case "$*" in
+	  *"/etc/unraid-version"*) printf 'no\n'; exit 0 ;;
+	  *"heartbeat-agent.env"*)
+	    printf 'CORTEX_HEARTBEAT_TARGET=https://old.example\n'
+	    printf 'CORTEX_HEARTBEAT_TOKEN=preserved-token\n'
+	    printf 'CORTEX_AGENT_DOCKER=true\n'
+	    printf 'CORTEX_AGENT_JOURNALD=true\n'
+	    printf 'CORTEX_SYSLOG_TARGET=old-syslog.example:1514\n'
+	    printf 'CORTEX_AGENT_FILE_TAILS=/var/log/app.log:app\n'
+	    printf 'CORTEX_AGENT_AI_TRANSCRIPTS=true\n'
+	    printf 'CORTEX_AGENT_COMMAND_FORWARD=true\n'
+	    printf 'CORTEX_AGENT_SHELL_HISTORY_FORWARD=true\n'
+	    printf 'CORTEX_AGENT_AUTO_UPDATE=false\n'
+	    exit 0
+	    ;;
+	  *) exit 0 ;;
+	esac
 "#,
     );
     write_logging_scp(dir.path());
@@ -318,6 +324,66 @@ esac
     assert!(log.contains("CORTEX_AGENT_DOCKER='true'"));
     assert!(log.contains("CORTEX_AGENT_JOURNALD='true'"));
     assert!(log.contains("CORTEX_SYSLOG_TARGET='old-syslog.example:1514'"));
+    assert!(log.contains("CORTEX_AGENT_FILE_TAILS='/var/log/app.log:app'"));
+    assert!(log.contains("CORTEX_AGENT_AI_TRANSCRIPTS='true'"));
+    assert!(log.contains("CORTEX_AGENT_COMMAND_FORWARD='true'"));
+    assert!(log.contains("CORTEX_AGENT_SHELL_HISTORY_FORWARD='true'"));
+    assert!(log.contains("CORTEX_AGENT_AUTO_UPDATE='false'"));
+}
+
+#[test]
+#[serial]
+fn deploy_agent_to_linux_host_fails_when_existing_env_read_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let local_binary = write_local_binary(dir.path());
+    write_executable(
+        &dir.path().join("ssh"),
+        r#"#!/bin/sh
+case "$*" in
+  *"/etc/unraid-version"*) printf 'no\n'; exit 0 ;;
+  *"heartbeat-agent.env"*) exit 13 ;;
+  *) exit 0 ;;
+esac
+"#,
+    );
+    write_successful_scp(dir.path());
+    let _path = prepend_path(dir.path());
+
+    let result = deploy_agent_to_host("linux-host", &local_binary, &AgentDeployConfig::default());
+
+    assert!(!result.ok);
+    assert!(result.detail.contains("heartbeat-agent.env"));
+    assert!(result.detail.contains("exited non-zero"));
+}
+
+#[test]
+#[serial]
+fn deploy_agent_requires_token_when_requested() {
+    let dir = tempfile::tempdir().unwrap();
+    let local_binary = write_local_binary(dir.path());
+    write_executable(
+        &dir.path().join("ssh"),
+        r#"#!/bin/sh
+case "$*" in
+  *"/etc/unraid-version"*) printf 'no\n'; exit 0 ;;
+  *) exit 0 ;;
+esac
+"#,
+    );
+    write_successful_scp(dir.path());
+    let _path = prepend_path(dir.path());
+
+    let result = deploy_agent_to_host(
+        "linux-host",
+        &local_binary,
+        &AgentDeployConfig {
+            require_token: true,
+            ..AgentDeployConfig::default()
+        },
+    );
+
+    assert!(!result.ok);
+    assert!(result.detail.contains("CORTEX_HEARTBEAT_TOKEN"));
 }
 
 #[test]
@@ -397,6 +463,7 @@ esac
         &AgentDeployConfig {
             target: Some("https://cortex.example.test".to_string()),
             token: Some("super secret token".to_string()),
+            require_token: false,
             docker: None,
             journald: None,
         },
@@ -405,6 +472,19 @@ esac
     assert!(!result.ok);
     assert!(!result.detail.contains("super secret token"));
     assert!(result.detail.contains("CORTEX_HEARTBEAT_TOKEN=<redacted>"));
+}
+
+#[test]
+fn redact_secret_envs_redacts_custom_secret_keys() {
+    let redacted =
+        redact_secret_envs("PLEX_TOKEN='plex secret' API_KEY=apikey OTHER_SECRET='secret value'");
+
+    assert!(!redacted.contains("plex secret"));
+    assert!(!redacted.contains("apikey"));
+    assert!(!redacted.contains("secret value"));
+    assert!(redacted.contains("PLEX_TOKEN=<redacted>"));
+    assert!(redacted.contains("API_KEY=<redacted>"));
+    assert!(redacted.contains("OTHER_SECRET=<redacted>"));
 }
 
 #[test]
@@ -433,6 +513,7 @@ esac
         &AgentDeployConfig {
             target: Some("https://cortex.example.test".to_string()),
             token: Some("secret".to_string()),
+            require_token: false,
             docker: Some(false),
             journald: Some(true),
         },
@@ -521,6 +602,7 @@ fn resolve_agent_env_flags_override_persisted() {
     let cfg = AgentDeployConfig {
         target: Some("https://new.example".into()),
         token: Some("new-token".into()),
+        require_token: false,
         docker: Some(false),
         journald: None,
     };
@@ -553,6 +635,14 @@ fn resolve_linux_agent_env_preserves_auth_and_flags_without_defaults() {
         ("CORTEX_AGENT_DOCKER".into(), "true".into()),
         ("CORTEX_AGENT_JOURNALD".into(), "true".into()),
         ("CORTEX_SYSLOG_TARGET".into(), "100.88.16.79:1514".into()),
+        (
+            "CORTEX_AGENT_FILE_TAILS".into(),
+            "/var/log/app.log:app".into(),
+        ),
+        ("CORTEX_AGENT_AI_TRANSCRIPTS".into(), "true".into()),
+        ("CORTEX_AGENT_COMMAND_FORWARD".into(), "true".into()),
+        ("CORTEX_AGENT_SHELL_HISTORY_FORWARD".into(), "true".into()),
+        ("CORTEX_AGENT_AUTO_UPDATE".into(), "false".into()),
     ];
     let env = resolve_linux_agent_env(&persisted, &AgentDeployConfig::default());
 
@@ -567,6 +657,17 @@ fn resolve_linux_agent_env_preserves_auth_and_flags_without_defaults() {
         env_get(&env, "CORTEX_SYSLOG_TARGET"),
         Some("100.88.16.79:1514")
     );
+    assert_eq!(
+        env_get(&env, "CORTEX_AGENT_FILE_TAILS"),
+        Some("/var/log/app.log:app")
+    );
+    assert_eq!(env_get(&env, "CORTEX_AGENT_AI_TRANSCRIPTS"), Some("true"));
+    assert_eq!(env_get(&env, "CORTEX_AGENT_COMMAND_FORWARD"), Some("true"));
+    assert_eq!(
+        env_get(&env, "CORTEX_AGENT_SHELL_HISTORY_FORWARD"),
+        Some("true")
+    );
+    assert_eq!(env_get(&env, "CORTEX_AGENT_AUTO_UPDATE"), Some("false"));
 }
 
 #[test]
@@ -576,7 +677,7 @@ fn resolve_linux_agent_env_stays_empty_for_first_flagless_deploy() {
 
 #[test]
 fn parse_env_file_splits_on_first_equals_and_skips_blanks_and_comments() {
-    let parsed = parse_env_file("A=1\n\n# comment\nB=x=y z\n");
+    let parsed = parse_env_file("A=1\n\n# comment\nB=x=y z\nBAD-KEY=nope\n9BAD=nope\n");
     assert_eq!(
         parsed,
         vec![

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -568,8 +568,8 @@ const NESTED_CATALOG: &[NestedCommandDoc] = &[
         usage: &[
             "cortex update [all|server|clients|agents] [--dry-run] [--json]",
             "cortex update server [--dry-run] [--json]",
-            "cortex update clients [--json] [--binary PATH]",
-            "cortex update agents [--json] [--binary PATH]",
+            "cortex update clients [--dry-run] [--json] [--binary PATH]",
+            "cortex update agents [--dry-run] [--json] [--binary PATH]",
             "cortex update config server --host HOST --home PATH [--json]",
             "cortex update config clients --hosts h1,h2 [--target URL] [--docker] [--journald] [--json]",
         ],

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -61,6 +61,7 @@ const SECTIONS: &[(&str, &[&str])] = &[
             "db",
             "compose",
             "setup",
+            "update",
             "config",
             "completions",
         ],
@@ -305,6 +306,11 @@ const CATALOG: &[CommandDoc] = &[
             "cortex setup plugin-hook [--no-repair] [--json]",
             "cortex setup doctor [--json]",
         ],
+    },
+    CommandDoc {
+        name: "update",
+        summary: "Update the configured Cortex server and host-agent clients",
+        usage: &["cortex update [all|server|clients|agents] [--dry-run] [--json]"],
     },
     CommandDoc {
         name: "config",
@@ -554,6 +560,18 @@ const NESTED_CATALOG: &[NestedCommandDoc] = &[
             "cortex setup deploy local [--dry-run] [--json]",
             "cortex setup deploy remote [--home PATH] HOST [--dry-run] [--json]",
             "cortex setup deploy agent [--hosts h1,h2] [--target URL] [--heartbeat-token TOKEN] [--docker] [--journald] [--binary PATH]",
+        ],
+    },
+    NestedCommandDoc {
+        path: "update",
+        summary: "Update the configured server and host-agent clients",
+        usage: &[
+            "cortex update [all|server|clients|agents] [--dry-run] [--json]",
+            "cortex update server [--dry-run] [--json]",
+            "cortex update clients [--json] [--binary PATH]",
+            "cortex update agents [--json] [--binary PATH]",
+            "cortex update config server --host HOST --home PATH [--json]",
+            "cortex update config clients --hosts h1,h2 [--target URL] [--docker] [--journald] [--json]",
         ],
     },
     NestedCommandDoc {

--- a/src/cli/help_tests.rs
+++ b/src/cli/help_tests.rs
@@ -31,6 +31,7 @@ const PARSER_TOKENS: &[&str] = &[
     "serve",
     "mcp",
     "doctor",
+    "update",
 ];
 
 #[test]

--- a/src/heartbeat_agent.rs
+++ b/src/heartbeat_agent.rs
@@ -22,6 +22,16 @@ pub const DEFAULT_COLLECTION_DEADLINE_MS: u64 = 5_000;
 pub const DEFAULT_RETRY_BUFFER_LIMIT: usize = 32;
 pub const DEFAULT_TARGET: &str = "http://127.0.0.1:3100";
 pub const DEFAULT_DOCKER_URL: &str = "unix:///var/run/docker.sock";
+pub const OPTIONAL_ENV_KEYS: &[&str] = &[
+    "CORTEX_AGENT_FILE_TAILS",
+    "CORTEX_AGENT_AI_TRANSCRIPTS",
+    "CORTEX_AGENT_AI_TRANSCRIPT_CHECKPOINT",
+    "CORTEX_AGENT_COMMAND_FORWARD",
+    "CORTEX_AGENT_COMMAND_SPOOL",
+    "CORTEX_AGENT_SHELL_HISTORY_FORWARD",
+    "CORTEX_AGENT_SHELL_HISTORY_CHECKPOINT",
+    "CORTEX_AGENT_AUTO_UPDATE",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeartbeatAgentConfig {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod scanner;
 pub mod setup;
 pub mod shell_history_ingest;
 pub mod surfaces;
+pub mod update;
 pub mod web_app;
 
 pub(crate) mod db;

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,6 +335,7 @@ fn run_deploy_agent(
     let config = AgentDeployConfig {
         target,
         token,
+        require_token: false,
         docker,
         journald,
     };
@@ -406,9 +407,10 @@ async fn run_update(command: UpdateCommand) -> Result<()> {
             journald,
             profile,
         } => {
+            let hosts_label = hosts.join(",");
             let profile = cortex::update::configure_clients_profile(
                 profile.as_deref().map(std::path::Path::new),
-                hosts.clone(),
+                hosts,
                 target,
                 docker,
                 journald,
@@ -417,7 +419,7 @@ async fn run_update(command: UpdateCommand) -> Result<()> {
                 println!("{}", serde_json::to_string_pretty(&profile)?);
             } else {
                 println!("cortex update config clients");
-                println!("hosts: {}", hosts.join(","));
+                println!("hosts: {hosts_label}");
             }
         }
     }
@@ -1127,7 +1129,6 @@ fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
 fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
     let mut json = false;
     let mut dry_run = false;
-    let mut saw_dry_run = false;
     let mut profile: Option<String> = None;
     let mut binary: Option<String> = None;
     let mut rest = Vec::new();
@@ -1137,7 +1138,6 @@ fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
             "--json" => json = true,
             "--dry-run" => {
                 dry_run = true;
-                saw_dry_run = true;
             }
             "--profile" => {
                 i += 1;
@@ -1157,7 +1157,7 @@ fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
     }
 
     if rest.first().map(String::as_str) == Some("config") {
-        if saw_dry_run {
+        if dry_run {
             anyhow::bail!("--dry-run is only valid for `cortex update` run scopes");
         }
         if binary.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ async fn run() -> Result<()> {
         Mode::Cli(invocation) => run_cli(*invocation).await,
         Mode::Setup(command) => run_setup(command).await,
         Mode::Deploy(command) => run_deploy(command).await,
+        Mode::Update(command) => run_update(command).await,
         Mode::DoctorBinary(command) => doctor::run_binary_doctor(command.json).await,
         Mode::DoctorFull(command) => {
             doctor::run_full_doctor(command.json, command.fix, command.yes).await
@@ -352,6 +353,103 @@ fn run_deploy_agent(
     Ok(())
 }
 
+async fn run_update(command: UpdateCommand) -> Result<()> {
+    match command.kind {
+        UpdateCommandKind::Run {
+            scope,
+            dry_run,
+            profile,
+            binary,
+        } => {
+            let report = cortex::update::run_update(
+                scope,
+                cortex::update::UpdateOptions {
+                    dry_run,
+                    profile_path: profile.map(std::path::PathBuf::from),
+                    binary: binary.map(std::path::PathBuf::from),
+                },
+            )?;
+            if command.json {
+                println!("{}", serde_json::to_string_pretty(&report)?);
+            } else {
+                print_update_report(&report);
+            }
+            if report.has_errors {
+                anyhow::bail!("cortex update {} completed with failed phases", report.mode);
+            }
+        }
+        UpdateCommandKind::ConfigServer {
+            host,
+            home,
+            profile,
+        } => {
+            let profile = cortex::update::configure_server_profile(
+                profile.as_deref().map(std::path::Path::new),
+                &host,
+                &home,
+            )?;
+            if command.json {
+                println!("{}", serde_json::to_string_pretty(&profile)?);
+            } else {
+                println!("cortex update config server");
+                println!("host: {host}");
+                println!("home: {home}");
+            }
+        }
+        UpdateCommandKind::ConfigClients {
+            hosts,
+            target,
+            docker,
+            journald,
+            profile,
+        } => {
+            let profile = cortex::update::configure_clients_profile(
+                profile.as_deref().map(std::path::Path::new),
+                hosts.clone(),
+                target,
+                docker,
+                journald,
+            )?;
+            if command.json {
+                println!("{}", serde_json::to_string_pretty(&profile)?);
+            } else {
+                println!("cortex update config clients");
+                println!("hosts: {}", hosts.join(","));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_update_report(report: &cortex::update::UpdateReport) {
+    println!("cortex update {}", report.mode);
+    println!("profile: {}", report.profile_path.display());
+    if let Some(server) = &report.server {
+        println!("server: {} {}", server.host, server.home);
+        for phase in &server.phases {
+            println!(
+                "server\t{:?}\t{}\t{}ms\t{}",
+                phase.status, phase.name, phase.elapsed_ms, phase.detail
+            );
+        }
+    }
+    for client in &report.clients {
+        println!(
+            "client\t{}\t{}\t{}ms\t{}",
+            if client.ok { "ok" } else { "error" },
+            client.host,
+            client.elapsed_ms,
+            client.detail
+        );
+    }
+    for phase in &report.skipped {
+        println!(
+            "skip\t{:?}\t{}\t{}ms\t{}",
+            phase.status, phase.name, phase.elapsed_ms, phase.detail
+        );
+    }
+}
+
 async fn run_setup(command: SetupCommand) -> Result<()> {
     let report = match command.kind {
         SetupCommandKind::Main(mode) => cortex::setup::run_setup(mode).await?,
@@ -544,6 +642,7 @@ enum Mode {
     Cli(Box<CliInvocation>),
     Setup(SetupCommand),
     Deploy(DeployCommand),
+    Update(UpdateCommand),
     DoctorBinary(DoctorBinaryCommand),
     DoctorFull(DoctorFullCommand),
     Help,
@@ -578,6 +677,34 @@ struct SetupCommand {
 struct DeployCommand {
     kind: DeployCommandKind,
     json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UpdateCommand {
+    kind: UpdateCommandKind,
+    json: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum UpdateCommandKind {
+    Run {
+        scope: cortex::update::UpdateScope,
+        dry_run: bool,
+        profile: Option<String>,
+        binary: Option<String>,
+    },
+    ConfigServer {
+        host: String,
+        home: String,
+        profile: Option<String>,
+    },
+    ConfigClients {
+        hosts: Vec<String>,
+        target: Option<String>,
+        docker: Option<bool>,
+        journald: Option<bool>,
+        profile: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -668,6 +795,11 @@ impl Mode {
                 Ok(Self::Deploy(parse_deploy_command(rest)?))
             }
             [command, rest @ ..]
+                if command == "update" && global == cli::GlobalFlags::default() =>
+            {
+                Ok(Self::Update(parse_update_command(rest)?))
+            }
+            [command, rest @ ..]
                 if command == "setup"
                     && rest.first().map(String::as_str) != Some("plugin-hook")
                     && global == cli::GlobalFlags::default() =>
@@ -722,6 +854,7 @@ impl Mode {
             Self::Cli(_) => "error",
             Self::Setup(_) => "warn",
             Self::Deploy(_) => "warn",
+            Self::Update(_) => "warn",
             Self::DoctorBinary(_) => "warn",
             Self::DoctorFull(_) => "warn",
             Self::Help => "info",
@@ -1010,6 +1143,159 @@ fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
         other => anyhow::bail!("unknown deploy subcommand: {other}"),
     };
     Ok(DeployCommand { kind, json })
+}
+
+fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
+    let mut json = false;
+    let mut dry_run = false;
+    let mut profile: Option<String> = None;
+    let mut binary: Option<String> = None;
+    let mut rest = Vec::new();
+    let mut i = 0usize;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => json = true,
+            "--dry-run" => dry_run = true,
+            "--profile" => {
+                i += 1;
+                profile = Some(
+                    args.get(i)
+                        .ok_or_else(|| anyhow::anyhow!("--profile requires a value"))?
+                        .clone(),
+                );
+            }
+            "--binary" => {
+                i += 1;
+                binary = Some(
+                    args.get(i)
+                        .ok_or_else(|| anyhow::anyhow!("--binary requires a value"))?
+                        .clone(),
+                );
+            }
+            "--help" | "-h" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other => rest.push(other.to_string()),
+        }
+        i += 1;
+    }
+
+    if rest.first().map(String::as_str) == Some("config") {
+        return parse_update_config_command(&rest[1..], json, profile);
+    }
+
+    let scope = match rest.as_slice() {
+        [] => cortex::update::UpdateScope::All,
+        [scope] if scope == "all" => cortex::update::UpdateScope::All,
+        [scope] if scope == "server" => cortex::update::UpdateScope::Server,
+        [scope] if scope == "clients" || scope == "agents" => cortex::update::UpdateScope::Clients,
+        [other] => anyhow::bail!("unknown update scope: {other}"),
+        _ => anyhow::bail!("update accepts at most one scope"),
+    };
+    Ok(UpdateCommand {
+        kind: UpdateCommandKind::Run {
+            scope,
+            dry_run,
+            profile,
+            binary,
+        },
+        json,
+    })
+}
+
+fn parse_update_config_command(
+    args: &[String],
+    json: bool,
+    profile: Option<String>,
+) -> Result<UpdateCommand> {
+    let (target, rest) = args
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("update config requires server or clients"))?;
+    match target.as_str() {
+        "server" => {
+            let mut host = None;
+            let mut home = None;
+            let mut i = 0usize;
+            while i < rest.len() {
+                match rest[i].as_str() {
+                    "--host" => {
+                        i += 1;
+                        host = Some(
+                            rest.get(i)
+                                .ok_or_else(|| anyhow::anyhow!("--host requires a value"))?
+                                .clone(),
+                        );
+                    }
+                    "--home" => {
+                        i += 1;
+                        home = Some(
+                            rest.get(i)
+                                .ok_or_else(|| anyhow::anyhow!("--home requires a value"))?
+                                .clone(),
+                        );
+                    }
+                    other => anyhow::bail!("unknown update config server argument: {other}"),
+                }
+                i += 1;
+            }
+            Ok(UpdateCommand {
+                kind: UpdateCommandKind::ConfigServer {
+                    host: host
+                        .ok_or_else(|| anyhow::anyhow!("update config server requires --host"))?,
+                    home: home
+                        .ok_or_else(|| anyhow::anyhow!("update config server requires --home"))?,
+                    profile,
+                },
+                json,
+            })
+        }
+        "clients" | "agents" => {
+            let mut hosts = Vec::new();
+            let mut target = None;
+            let mut docker = None;
+            let mut journald = None;
+            let mut i = 0usize;
+            while i < rest.len() {
+                match rest[i].as_str() {
+                    "--hosts" => {
+                        i += 1;
+                        hosts = rest
+                            .get(i)
+                            .ok_or_else(|| anyhow::anyhow!("--hosts requires a value"))?
+                            .split(',')
+                            .map(str::trim)
+                            .filter(|host| !host.is_empty())
+                            .map(str::to_string)
+                            .collect();
+                    }
+                    "--target" => {
+                        i += 1;
+                        target = Some(
+                            rest.get(i)
+                                .ok_or_else(|| anyhow::anyhow!("--target requires a value"))?
+                                .clone(),
+                        );
+                    }
+                    "--docker" => docker = Some(true),
+                    "--journald" => journald = Some(true),
+                    other => anyhow::bail!("unknown update config clients argument: {other}"),
+                }
+                i += 1;
+            }
+            Ok(UpdateCommand {
+                kind: UpdateCommandKind::ConfigClients {
+                    hosts,
+                    target,
+                    docker,
+                    journald,
+                    profile,
+                },
+                json,
+            })
+        }
+        other => anyhow::bail!("unknown update config target: {other}"),
+    }
 }
 
 /// Which path `ingest shell agent index` should take, given its own flags

--- a/src/main.rs
+++ b/src/main.rs
@@ -1070,11 +1070,7 @@ fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
             "--dry-run" if matches!(subcommand.as_str(), "local" | "remote") => dry_run = true,
             "--home" if subcommand == "remote" => {
                 i += 1;
-                remote_home = Some(
-                    rest.get(i)
-                        .ok_or_else(|| anyhow::anyhow!("--home requires a value"))?
-                        .clone(),
-                );
+                remote_home = Some(required_arg(rest, i, "--home")?);
             }
             "--help" | "-h" => {
                 print_usage();
@@ -1082,39 +1078,19 @@ fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
             }
             "--hosts" if subcommand == "agent" => {
                 i += 1;
-                let val = rest
-                    .get(i)
-                    .ok_or_else(|| anyhow::anyhow!("--hosts requires a value"))?;
-                agent_hosts = val
-                    .split(',')
-                    .map(str::trim)
-                    .filter(|host| !host.is_empty())
-                    .map(str::to_string)
-                    .collect();
+                agent_hosts = parse_host_list(&required_arg(rest, i, "--hosts")?);
             }
             "--target" if subcommand == "agent" => {
                 i += 1;
-                agent_target = Some(
-                    rest.get(i)
-                        .ok_or_else(|| anyhow::anyhow!("--target requires a value"))?
-                        .clone(),
-                );
+                agent_target = Some(required_arg(rest, i, "--target")?);
             }
             "--heartbeat-token" if subcommand == "agent" => {
                 i += 1;
-                agent_token = Some(
-                    rest.get(i)
-                        .ok_or_else(|| anyhow::anyhow!("--heartbeat-token requires a value"))?
-                        .clone(),
-                );
+                agent_token = Some(required_arg(rest, i, "--heartbeat-token")?);
             }
             "--binary" if subcommand == "agent" => {
                 i += 1;
-                agent_binary = Some(
-                    rest.get(i)
-                        .ok_or_else(|| anyhow::anyhow!("--binary requires a value"))?
-                        .clone(),
-                );
+                agent_binary = Some(required_arg(rest, i, "--binary")?);
             }
             "--docker" if subcommand == "agent" => agent_docker = Some(true),
             "--journald" if subcommand == "agent" => agent_journald = Some(true),
@@ -1165,19 +1141,11 @@ fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
             }
             "--profile" => {
                 i += 1;
-                profile = Some(
-                    args.get(i)
-                        .ok_or_else(|| anyhow::anyhow!("--profile requires a value"))?
-                        .clone(),
-                );
+                profile = Some(required_arg(args, i, "--profile")?);
             }
             "--binary" => {
                 i += 1;
-                binary = Some(
-                    args.get(i)
-                        .ok_or_else(|| anyhow::anyhow!("--binary requires a value"))?
-                        .clone(),
-                );
+                binary = Some(required_arg(args, i, "--binary")?);
             }
             "--help" | "-h" => {
                 print_usage();
@@ -1237,19 +1205,11 @@ fn parse_update_config_command(
                 match rest[i].as_str() {
                     "--host" => {
                         i += 1;
-                        host = Some(
-                            rest.get(i)
-                                .ok_or_else(|| anyhow::anyhow!("--host requires a value"))?
-                                .clone(),
-                        );
+                        host = Some(required_arg(rest, i, "--host")?);
                     }
                     "--home" => {
                         i += 1;
-                        home = Some(
-                            rest.get(i)
-                                .ok_or_else(|| anyhow::anyhow!("--home requires a value"))?
-                                .clone(),
-                        );
+                        home = Some(required_arg(rest, i, "--home")?);
                     }
                     other => anyhow::bail!("unknown update config server argument: {other}"),
                 }
@@ -1276,22 +1236,11 @@ fn parse_update_config_command(
                 match rest[i].as_str() {
                     "--hosts" => {
                         i += 1;
-                        hosts = rest
-                            .get(i)
-                            .ok_or_else(|| anyhow::anyhow!("--hosts requires a value"))?
-                            .split(',')
-                            .map(str::trim)
-                            .filter(|host| !host.is_empty())
-                            .map(str::to_string)
-                            .collect();
+                        hosts = parse_host_list(&required_arg(rest, i, "--hosts")?);
                     }
                     "--target" => {
                         i += 1;
-                        target = Some(
-                            rest.get(i)
-                                .ok_or_else(|| anyhow::anyhow!("--target requires a value"))?
-                                .clone(),
-                        );
+                        target = Some(required_arg(rest, i, "--target")?);
                     }
                     "--docker" => docker = Some(true),
                     "--journald" => journald = Some(true),
@@ -1312,6 +1261,21 @@ fn parse_update_config_command(
         }
         other => anyhow::bail!("unknown update config target: {other}"),
     }
+}
+
+fn required_arg(args: &[String], index: usize, flag: &str) -> Result<String> {
+    args.get(index)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("{flag} requires a value"))
+}
+
+fn parse_host_list(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|host| !host.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 /// Which path `ingest shell agent index` should take, given its own flags

--- a/src/main.rs
+++ b/src/main.rs
@@ -1151,6 +1151,7 @@ fn parse_deploy_command(args: &[String]) -> Result<DeployCommand> {
 fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
     let mut json = false;
     let mut dry_run = false;
+    let mut saw_dry_run = false;
     let mut profile: Option<String> = None;
     let mut binary: Option<String> = None;
     let mut rest = Vec::new();
@@ -1158,7 +1159,10 @@ fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
     while i < args.len() {
         match args[i].as_str() {
             "--json" => json = true,
-            "--dry-run" => dry_run = true,
+            "--dry-run" => {
+                dry_run = true;
+                saw_dry_run = true;
+            }
             "--profile" => {
                 i += 1;
                 profile = Some(
@@ -1185,6 +1189,12 @@ fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
     }
 
     if rest.first().map(String::as_str) == Some("config") {
+        if saw_dry_run {
+            anyhow::bail!("--dry-run is only valid for `cortex update` run scopes");
+        }
+        if binary.is_some() {
+            anyhow::bail!("--binary is only valid for `cortex update clients|agents`");
+        }
         return parse_update_config_command(&rest[1..], json, profile);
     }
 
@@ -1196,6 +1206,9 @@ fn parse_update_command(args: &[String]) -> Result<UpdateCommand> {
         [other] => anyhow::bail!("unknown update scope: {other}"),
         _ => anyhow::bail!("update accepts at most one scope"),
     };
+    if scope == cortex::update::UpdateScope::Server && binary.is_some() {
+        anyhow::bail!("--binary is only valid for `cortex update all|clients|agents`");
+    }
     Ok(UpdateCommand {
         kind: UpdateCommandKind::Run {
             scope,

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,6 +248,9 @@ async fn run_deploy(command: DeployCommand) -> Result<()> {
             if report.has_errors {
                 anyhow::bail!("cortex setup deploy remote {host} completed with failed phases");
             }
+            if !dry_run {
+                cortex::update::configure_server_profile(None, &host, &report.home)?;
+            }
             return Ok(());
         }
         DeployCommandKind::Agent {

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -510,7 +510,7 @@ fn parse_deploy_remote_accepts_home_override() {
 }
 
 #[test]
-fn parse_deploy_remote_home_has_enough_data_to_save_update_profile() {
+fn parse_deploy_remote_home_defaults_to_live_profile_seed_shape() {
     let command = super::parse_deploy_command(&[
         "remote".into(),
         "--home".into(),

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -574,6 +574,126 @@ fn parse_deploy_agent_reports_missing_option_values() {
 }
 
 #[test]
+fn mode_parse_accepts_update_defaults_to_all() {
+    let mode = super::Mode::parse(vec!["update".into()]).unwrap();
+
+    assert!(matches!(
+        mode,
+        super::Mode::Update(super::UpdateCommand {
+            kind: super::UpdateCommandKind::Run {
+                scope: cortex::update::UpdateScope::All,
+                dry_run: false,
+                profile: None,
+                binary: None,
+            },
+            json: false,
+        })
+    ));
+}
+
+#[test]
+fn mode_parse_accepts_update_server_dry_run_json_profile() {
+    let mode = super::Mode::parse(vec![
+        "update".into(),
+        "server".into(),
+        "--dry-run".into(),
+        "--json".into(),
+        "--profile".into(),
+        "/tmp/deployments.toml".into(),
+    ])
+    .unwrap();
+
+    assert!(matches!(
+        mode,
+        super::Mode::Update(super::UpdateCommand {
+            kind: super::UpdateCommandKind::Run {
+                scope: cortex::update::UpdateScope::Server,
+                dry_run: true,
+                profile: Some(ref profile),
+                binary: None,
+            },
+            json: true,
+        }) if profile == "/tmp/deployments.toml"
+    ));
+}
+
+#[test]
+fn mode_parse_accepts_update_clients_aliases() {
+    for scope_name in ["clients", "agents"] {
+        let mode = super::Mode::parse(vec!["update".into(), scope_name.into()]).unwrap();
+        assert!(matches!(
+            mode,
+            super::Mode::Update(super::UpdateCommand {
+                kind: super::UpdateCommandKind::Run {
+                    scope: cortex::update::UpdateScope::Clients,
+                    ..
+                },
+                ..
+            })
+        ));
+    }
+}
+
+#[test]
+fn mode_parse_accepts_update_config_server() {
+    let mode = super::Mode::parse(vec![
+        "update".into(),
+        "config".into(),
+        "server".into(),
+        "--host".into(),
+        "tootie".into(),
+        "--home".into(),
+        "/mnt/cache/appdata/cortex".into(),
+        "--profile".into(),
+        "/tmp/deployments.toml".into(),
+        "--json".into(),
+    ])
+    .unwrap();
+
+    assert!(matches!(
+        mode,
+        super::Mode::Update(super::UpdateCommand {
+            kind: super::UpdateCommandKind::ConfigServer {
+                ref host,
+                ref home,
+                profile: Some(ref profile),
+            },
+            json: true,
+        }) if host == "tootie" && home == "/mnt/cache/appdata/cortex" && profile == "/tmp/deployments.toml"
+    ));
+}
+
+#[test]
+fn mode_parse_accepts_update_config_clients() {
+    let mode = super::Mode::parse(vec![
+        "update".into(),
+        "config".into(),
+        "clients".into(),
+        "--hosts".into(),
+        "dookie,shart".into(),
+        "--target".into(),
+        "https://cortex.tootie.tv".into(),
+        "--docker".into(),
+    ])
+    .unwrap();
+
+    assert!(matches!(
+        mode,
+        super::Mode::Update(super::UpdateCommand {
+            kind: super::UpdateCommandKind::ConfigClients {
+                ref hosts,
+                target: Some(ref target),
+                docker: Some(true),
+                journald: None,
+                profile: None,
+            },
+            json: false,
+        }) if hosts == &vec!["dookie".to_string(), "shart".to_string()]
+             && target == "https://cortex.tootie.tv"
+    ));
+}
+
+#[test]
 fn mode_parse_setup_subcommands_default_to_check_and_parse_remove() {
     let cases = [
         (

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -510,6 +510,26 @@ fn parse_deploy_remote_accepts_home_override() {
 }
 
 #[test]
+fn parse_deploy_remote_home_has_enough_data_to_save_update_profile() {
+    let command = super::parse_deploy_command(&[
+        "remote".into(),
+        "--home".into(),
+        "/mnt/cache/appdata/cortex".into(),
+        "tootie".into(),
+    ])
+    .unwrap();
+
+    assert!(matches!(
+        command.kind,
+        super::DeployCommandKind::Remote {
+            ref host,
+            dry_run: false,
+            home: Some(ref home),
+        } if host == "tootie" && home == "/mnt/cache/appdata/cortex"
+    ));
+}
+
+#[test]
 fn parse_deploy_agent_trims_and_drops_empty_hosts() {
     let command = super::parse_deploy_command(&[
         "agent".into(),

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -714,6 +714,56 @@ fn mode_parse_accepts_update_config_clients() {
 }
 
 #[test]
+fn mode_parse_rejects_update_config_run_only_flags() {
+    let dry_run = super::Mode::parse(vec![
+        "update".into(),
+        "config".into(),
+        "server".into(),
+        "--host".into(),
+        "tootie".into(),
+        "--home".into(),
+        "/mnt/cache/appdata/cortex".into(),
+        "--dry-run".into(),
+    ])
+    .unwrap_err();
+    assert!(
+        dry_run.to_string().contains("--dry-run is only valid"),
+        "got: {dry_run}"
+    );
+
+    let binary = super::Mode::parse(vec![
+        "update".into(),
+        "config".into(),
+        "clients".into(),
+        "--hosts".into(),
+        "dookie".into(),
+        "--binary".into(),
+        "/tmp/cortex".into(),
+    ])
+    .unwrap_err();
+    assert!(
+        binary.to_string().contains("--binary is only valid"),
+        "got: {binary}"
+    );
+}
+
+#[test]
+fn mode_parse_rejects_update_server_binary_flag() {
+    let err = super::Mode::parse(vec![
+        "update".into(),
+        "server".into(),
+        "--binary".into(),
+        "/tmp/cortex".into(),
+    ])
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("--binary is only valid"),
+        "got: {err}"
+    );
+}
+
+#[test]
 fn mode_parse_setup_subcommands_default_to_check_and_parse_remove() {
     let cases = [
         (

--- a/src/setup/heartbeat_agent.rs
+++ b/src/setup/heartbeat_agent.rs
@@ -129,11 +129,16 @@ fn write_heartbeat_agent_env(env_path: &Path) -> io::Result<SetupPhase> {
     let docker_url = std::env::var("CORTEX_AGENT_DOCKER_URL")
         .ok()
         .unwrap_or_else(|| heartbeat_agent::DEFAULT_DOCKER_URL.to_string());
+    let rust_log = std::env::var("RUST_LOG")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "warn".to_string());
     let syslog_file = std::env::var("CORTEX_AGENT_SYSLOG_FILE").ok();
     let syslog_target = std::env::var("CORTEX_SYSLOG_TARGET").ok();
     let mut body = format!(
-        "CORTEX_HEARTBEAT_TARGET={}\nRUST_LOG=warn\nCORTEX_AGENT_DOCKER={}\nCORTEX_AGENT_DOCKER_URL={}\nCORTEX_AGENT_JOURNALD={}\n",
+        "CORTEX_HEARTBEAT_TARGET={}\nRUST_LOG={}\nCORTEX_AGENT_DOCKER={}\nCORTEX_AGENT_DOCKER_URL={}\nCORTEX_AGENT_JOURNALD={}\n",
         shell_safe_value(&target)?,
+        shell_safe_value(&rust_log)?,
         shell_safe_value(&docker)?,
         shell_safe_value(&docker_url)?,
         shell_safe_value(&journald)?,
@@ -155,6 +160,13 @@ fn write_heartbeat_agent_env(env_path: &Path) -> io::Result<SetupPhase> {
             "CORTEX_HEARTBEAT_TOKEN={}\n",
             shell_safe_value(&token)?
         ));
+    }
+    for key in heartbeat_agent::OPTIONAL_ENV_KEYS {
+        if let Ok(value) = std::env::var(key) {
+            if !value.trim().is_empty() {
+                body.push_str(&format!("{key}={}\n", shell_safe_value(&value)?));
+            }
+        }
     }
     write_private_file(env_path, &body)?;
     Ok(timer.finish(SetupStatus::Ok, format!("wrote {}", env_path.display())))

--- a/src/setup/heartbeat_agent_tests.rs
+++ b/src/setup/heartbeat_agent_tests.rs
@@ -113,9 +113,27 @@ fn remove_file_phase_treats_missing_file_as_success() {
 }
 
 #[test]
+#[serial]
 fn write_heartbeat_agent_env_writes_private_agent_defaults() {
     let dir = tempfile::tempdir().unwrap();
     let env_path = dir.path().join("nested/heartbeat-agent.env");
+    let _target = EnvGuard::remove("CORTEX_HEARTBEAT_TARGET");
+    let _token = EnvGuard::remove("CORTEX_HEARTBEAT_TOKEN");
+    let _setup_token = EnvGuard::remove("CORTEX_TOKEN");
+    let _docker = EnvGuard::remove("CORTEX_AGENT_DOCKER");
+    let _docker_url = EnvGuard::remove("CORTEX_AGENT_DOCKER_URL");
+    let _journald = EnvGuard::remove("CORTEX_AGENT_JOURNALD");
+    let _syslog_file = EnvGuard::remove("CORTEX_AGENT_SYSLOG_FILE");
+    let _syslog_target = EnvGuard::remove("CORTEX_SYSLOG_TARGET");
+    let _rust_log = EnvGuard::remove("RUST_LOG");
+    let _file_tails = EnvGuard::remove("CORTEX_AGENT_FILE_TAILS");
+    let _ai_transcripts = EnvGuard::remove("CORTEX_AGENT_AI_TRANSCRIPTS");
+    let _ai_checkpoint = EnvGuard::remove("CORTEX_AGENT_AI_TRANSCRIPT_CHECKPOINT");
+    let _command_forward = EnvGuard::remove("CORTEX_AGENT_COMMAND_FORWARD");
+    let _command_spool = EnvGuard::remove("CORTEX_AGENT_COMMAND_SPOOL");
+    let _shell_history = EnvGuard::remove("CORTEX_AGENT_SHELL_HISTORY_FORWARD");
+    let _shell_history_checkpoint = EnvGuard::remove("CORTEX_AGENT_SHELL_HISTORY_CHECKPOINT");
+    let _auto_update = EnvGuard::remove("CORTEX_AGENT_AUTO_UPDATE");
 
     let phase = write_heartbeat_agent_env(&env_path).unwrap();
     let raw = std::fs::read_to_string(&env_path).unwrap();
@@ -320,6 +338,11 @@ fn write_heartbeat_agent_env_reads_setup_env_fallbacks_and_optional_syslog() {
     let _token = EnvGuard::remove("CORTEX_HEARTBEAT_TOKEN");
     let _syslog_file = EnvGuard::set("CORTEX_AGENT_SYSLOG_FILE", "/var/log/syslog");
     let _syslog_target = EnvGuard::set("CORTEX_SYSLOG_TARGET", "127.0.0.1:1514");
+    let _file_tails = EnvGuard::set("CORTEX_AGENT_FILE_TAILS", "/var/log/app.log:app");
+    let _ai_transcripts = EnvGuard::set("CORTEX_AGENT_AI_TRANSCRIPTS", "true");
+    let _command_forward = EnvGuard::set("CORTEX_AGENT_COMMAND_FORWARD", "true");
+    let _shell_history = EnvGuard::set("CORTEX_AGENT_SHELL_HISTORY_FORWARD", "true");
+    let _auto_update = EnvGuard::set("CORTEX_AGENT_AUTO_UPDATE", "false");
 
     write_heartbeat_agent_env(&env_path).unwrap();
     let raw = std::fs::read_to_string(&env_path).unwrap();
@@ -328,4 +351,9 @@ fn write_heartbeat_agent_env_reads_setup_env_fallbacks_and_optional_syslog() {
     assert!(raw.contains("CORTEX_HEARTBEAT_TOKEN=from-setup-env\n"));
     assert!(raw.contains("CORTEX_AGENT_SYSLOG_FILE=/var/log/syslog\n"));
     assert!(raw.contains("CORTEX_SYSLOG_TARGET=127.0.0.1:1514\n"));
+    assert!(raw.contains("CORTEX_AGENT_FILE_TAILS=/var/log/app.log:app\n"));
+    assert!(raw.contains("CORTEX_AGENT_AI_TRANSCRIPTS=true\n"));
+    assert!(raw.contains("CORTEX_AGENT_COMMAND_FORWARD=true\n"));
+    assert!(raw.contains("CORTEX_AGENT_SHELL_HISTORY_FORWARD=true\n"));
+    assert!(raw.contains("CORTEX_AGENT_AUTO_UPDATE=false\n"));
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -198,10 +198,7 @@ fn run_update_with_runner(
     runner: &mut dyn UpdateRunner,
 ) -> io::Result<UpdateReport> {
     let started = Instant::now();
-    let profile_path = match options.profile_path.clone() {
-        Some(path) => path,
-        None => default_profile_path()?,
-    };
+    let profile_path = resolve_profile_path(options.profile_path.as_deref())?;
     let profile = validate_loaded_profile(load_profile(&profile_path)?)?;
     let mut server = None;
     let mut clients = Vec::new();
@@ -301,15 +298,9 @@ fn client_preflight_results(hosts: &[String], probes: Vec<HostProbe>) -> Vec<Dep
     let mut results = Vec::with_capacity(hosts.len());
     for host in hosts {
         match probes.iter().find(|probe| probe.host == *host) {
-            Some(probe) if probe.reachable => results.push(DeployResult {
-                host: host.clone(),
-                ok: true,
-                detail: probe.display_label(),
-                elapsed_ms: 0,
-            }),
             Some(probe) => results.push(DeployResult {
                 host: host.clone(),
-                ok: false,
+                ok: probe.reachable,
                 detail: probe.display_label(),
                 elapsed_ms: 0,
             }),

--- a/src/update.rs
+++ b/src/update.rs
@@ -191,10 +191,10 @@ fn run_update_with_runner(
     runner: &mut dyn UpdateRunner,
 ) -> io::Result<UpdateReport> {
     let started = Instant::now();
-    let profile_path = options
-        .profile_path
-        .clone()
-        .unwrap_or(default_profile_path()?);
+    let profile_path = match options.profile_path.clone() {
+        Some(path) => path,
+        None => default_profile_path()?,
+    };
     let profile = load_profile(&profile_path)?;
     let mut server = None;
     let mut clients = Vec::new();

--- a/src/update.rs
+++ b/src/update.rs
@@ -3,6 +3,7 @@ use std::path::{Component, Path, PathBuf};
 use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::agent_deploy::{
     AgentDeployConfig, DeployResult, HostProbe, deploy_agent_to_host, find_local_binary,
@@ -118,11 +119,15 @@ pub fn configure_clients_profile(
         ));
     }
     let mut profile = load_profile(&path)?;
+    let target = match target {
+        Some(target) => Some(validate_client_target(&target)?),
+        None => profile.clients.target.clone(),
+    };
     profile.clients = ClientsUpdateProfile {
         hosts: validated,
         target,
-        docker,
-        journald,
+        docker: docker.or(profile.clients.docker),
+        journald: journald.or(profile.clients.journald),
     };
     write_profile(&path, &profile)?;
     Ok(profile)
@@ -156,6 +161,10 @@ trait UpdateRunner {
     fn find_binary(&self) -> Option<PathBuf>;
 
     fn probe_clients(&mut self, hosts: Vec<String>) -> Vec<HostProbe>;
+
+    fn validate_binary(&self, path: &Path) -> io::Result<()> {
+        validate_agent_binary(path)
+    }
 }
 
 struct RealUpdateRunner;
@@ -267,6 +276,7 @@ fn run_update_with_runner(
             let config = AgentDeployConfig {
                 target: profile.clients.target.clone(),
                 token: None,
+                require_token: true,
                 docker: profile.clients.docker,
                 journald: profile.clients.journald,
             };
@@ -287,11 +297,39 @@ fn run_update_with_runner(
 }
 
 fn resolve_agent_binary(options: &UpdateOptions, runner: &dyn UpdateRunner) -> io::Result<PathBuf> {
-    options
+    let binary = options
         .binary
         .clone()
         .or_else(|| runner.find_binary())
-        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "cortex binary not found"))
+        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "cortex binary not found"))?;
+    runner.validate_binary(&binary)?;
+    Ok(binary)
+}
+
+fn validate_agent_binary(path: &Path) -> io::Result<()> {
+    let metadata = std::fs::metadata(path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("cortex binary {} is not usable: {error}", path.display()),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("cortex binary {} is not a file", path.display()),
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Err(io::Error::new(
+                ErrorKind::PermissionDenied,
+                format!("cortex binary {} is not executable", path.display()),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn client_preflight_results(hosts: &[String], probes: Vec<HostProbe>) -> Vec<DeployResult> {
@@ -354,6 +392,9 @@ fn validate_loaded_profile(mut profile: UpdateProfile) -> io::Result<UpdateProfi
         .iter()
         .map(|host| validate_host(host))
         .collect::<io::Result<Vec<_>>>()?;
+    if let Some(target) = profile.clients.target.take() {
+        profile.clients.target = Some(validate_client_target(&target)?);
+    }
     Ok(profile)
 }
 
@@ -370,6 +411,23 @@ fn validate_host(host: &str) -> io::Result<String> {
         return Err(io::Error::new(
             ErrorKind::InvalidInput,
             format!("unsafe ssh host: {host}"),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn validate_client_target(target: &str) -> io::Result<String> {
+    let trimmed = target.trim();
+    let parsed = Url::parse(trimmed).map_err(|error| {
+        io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("client target must be an http(s) URL: {error}"),
+        )
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "client target must be an http(s) URL with a host",
         ));
     }
     Ok(trimmed.to_string())

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,9 +1,14 @@
 use std::io::{self, ErrorKind};
 use std::path::{Component, Path, PathBuf};
+use std::time::Instant;
 
 use serde::{Deserialize, Serialize};
 
-use crate::setup::cortex_home_dir;
+use crate::agent_deploy::{
+    AgentDeployConfig, DeployResult, deploy_agent_to_host, find_local_binary,
+};
+use crate::deploy::{RemoteDeployOptions, RemoteDeployReport, run_remote_deploy};
+use crate::setup::{PhaseTimer, SetupPhase, SetupStatus, cortex_home_dir};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UpdateScope {
@@ -120,6 +125,190 @@ pub fn configure_clients_profile(
     };
     write_profile(&path, &profile)?;
     Ok(profile)
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateReport {
+    pub mode: &'static str,
+    pub profile_path: PathBuf,
+    pub server: Option<RemoteDeployReport>,
+    pub clients: Vec<DeployResult>,
+    pub skipped: Vec<SetupPhase>,
+    pub has_errors: bool,
+    pub elapsed_ms: u128,
+}
+
+trait UpdateRunner {
+    fn run_server(
+        &mut self,
+        host: &str,
+        options: RemoteDeployOptions,
+    ) -> io::Result<RemoteDeployReport>;
+
+    fn deploy_client(
+        &mut self,
+        host: &str,
+        binary: &Path,
+        config: &AgentDeployConfig,
+    ) -> DeployResult;
+
+    fn find_binary(&self) -> Option<PathBuf>;
+}
+
+struct RealUpdateRunner;
+
+impl UpdateRunner for RealUpdateRunner {
+    fn run_server(
+        &mut self,
+        host: &str,
+        options: RemoteDeployOptions,
+    ) -> io::Result<RemoteDeployReport> {
+        run_remote_deploy(host, options)
+    }
+
+    fn deploy_client(
+        &mut self,
+        host: &str,
+        binary: &Path,
+        config: &AgentDeployConfig,
+    ) -> DeployResult {
+        deploy_agent_to_host(host, binary, config)
+    }
+
+    fn find_binary(&self) -> Option<PathBuf> {
+        find_local_binary()
+    }
+}
+
+pub fn run_update(scope: UpdateScope, options: UpdateOptions) -> io::Result<UpdateReport> {
+    let mut runner = RealUpdateRunner;
+    run_update_with_runner(scope, options, &mut runner)
+}
+
+fn run_update_with_runner(
+    scope: UpdateScope,
+    options: UpdateOptions,
+    runner: &mut dyn UpdateRunner,
+) -> io::Result<UpdateReport> {
+    let started = Instant::now();
+    let profile_path = options
+        .profile_path
+        .clone()
+        .unwrap_or(default_profile_path()?);
+    let profile = load_profile(&profile_path)?;
+    let mut server = None;
+    let mut clients = Vec::new();
+    let mut skipped = Vec::new();
+
+    if matches!(scope, UpdateScope::All | UpdateScope::Server) {
+        let target = profile.server.as_ref().ok_or_else(|| {
+            io::Error::new(
+                ErrorKind::NotFound,
+                format!(
+                    "no server update profile at {}; run `cortex update config server --host HOST --home PATH`",
+                    profile_path.display()
+                ),
+            )
+        })?;
+        let report = runner.run_server(
+            &target.host,
+            RemoteDeployOptions {
+                dry_run: options.dry_run,
+                home: Some(target.home.clone()),
+            },
+        )?;
+        let failed = report.has_errors;
+        server = Some(report);
+        if failed && matches!(scope, UpdateScope::All) {
+            skipped.push(
+                PhaseTimer::start("clients")
+                    .finish(SetupStatus::Skipped, "skipped because server update failed"),
+            );
+            return Ok(build_report(
+                scope,
+                profile_path,
+                server,
+                clients,
+                skipped,
+                started,
+            ));
+        }
+    }
+
+    if matches!(scope, UpdateScope::All | UpdateScope::Clients) {
+        if profile.clients.hosts.is_empty() {
+            if matches!(scope, UpdateScope::Clients) {
+                return Err(io::Error::new(
+                    ErrorKind::NotFound,
+                    format!(
+                        "no client update profile at {}; run `cortex update config clients --hosts HOST1,HOST2`",
+                        profile_path.display()
+                    ),
+                ));
+            }
+            skipped.push(
+                PhaseTimer::start("clients")
+                    .finish(SetupStatus::Skipped, "no configured client hosts"),
+            );
+        } else if options.dry_run {
+            skipped.push(PhaseTimer::start("clients").finish(
+                SetupStatus::Skipped,
+                "dry-run does not deploy client agents",
+            ));
+        } else {
+            let binary = options
+                .binary
+                .clone()
+                .or_else(|| runner.find_binary())
+                .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "cortex binary not found"))?;
+            let config = AgentDeployConfig {
+                target: profile.clients.target.clone(),
+                token: None,
+                docker: profile.clients.docker,
+                journald: profile.clients.journald,
+            };
+            for host in &profile.clients.hosts {
+                clients.push(runner.deploy_client(host, &binary, &config));
+            }
+        }
+    }
+
+    Ok(build_report(
+        scope,
+        profile_path,
+        server,
+        clients,
+        skipped,
+        started,
+    ))
+}
+
+fn build_report(
+    scope: UpdateScope,
+    profile_path: PathBuf,
+    server: Option<RemoteDeployReport>,
+    clients: Vec<DeployResult>,
+    skipped: Vec<SetupPhase>,
+    started: Instant,
+) -> UpdateReport {
+    let has_errors = server.as_ref().is_some_and(|report| report.has_errors)
+        || clients.iter().any(|result| !result.ok)
+        || skipped
+            .iter()
+            .any(|phase| matches!(phase.status, SetupStatus::Error));
+    UpdateReport {
+        mode: match scope {
+            UpdateScope::All => "all",
+            UpdateScope::Server => "server",
+            UpdateScope::Clients => "clients",
+        },
+        profile_path,
+        server,
+        clients,
+        skipped,
+        has_errors,
+        elapsed_ms: started.elapsed().as_millis(),
+    }
 }
 
 fn resolve_profile_path(path: Option<&Path>) -> io::Result<PathBuf> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,166 @@
+use std::io::{self, ErrorKind};
+use std::path::{Component, Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::setup::cortex_home_dir;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateScope {
+    All,
+    Server,
+    Clients,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct UpdateOptions {
+    pub dry_run: bool,
+    pub profile_path: Option<PathBuf>,
+    pub binary: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServerUpdateProfile {
+    pub host: String,
+    pub home: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ClientsUpdateProfile {
+    #[serde(default)]
+    pub hosts: Vec<String>,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub docker: Option<bool>,
+    #[serde(default)]
+    pub journald: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct UpdateProfile {
+    #[serde(default)]
+    pub server: Option<ServerUpdateProfile>,
+    #[serde(default)]
+    pub clients: ClientsUpdateProfile,
+}
+
+pub fn default_profile_path() -> io::Result<PathBuf> {
+    Ok(cortex_home_dir()?.join("deployments.toml"))
+}
+
+pub fn load_profile(path: &Path) -> io::Result<UpdateProfile> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => toml::from_str(&raw).map_err(|error| {
+            io::Error::new(
+                ErrorKind::InvalidData,
+                format!("parse update profile {}: {error}", path.display()),
+            )
+        }),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(UpdateProfile::default()),
+        Err(error) => Err(error),
+    }
+}
+
+pub fn write_profile(path: &Path, profile: &UpdateProfile) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let rendered = toml::to_string_pretty(profile).map_err(|error| {
+        io::Error::new(
+            ErrorKind::InvalidData,
+            format!("render update profile {}: {error}", path.display()),
+        )
+    })?;
+    let tmp = path.with_extension("toml.tmp");
+    std::fs::write(&tmp, rendered)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+pub fn configure_server_profile(
+    path: Option<&Path>,
+    host: &str,
+    home: &str,
+) -> io::Result<UpdateProfile> {
+    let path = resolve_profile_path(path)?;
+    let mut profile = load_profile(&path)?;
+    profile.server = Some(ServerUpdateProfile {
+        host: validate_host(host)?,
+        home: validate_remote_home(home)?,
+    });
+    write_profile(&path, &profile)?;
+    Ok(profile)
+}
+
+pub fn configure_clients_profile(
+    path: Option<&Path>,
+    hosts: Vec<String>,
+    target: Option<String>,
+    docker: Option<bool>,
+    journald: Option<bool>,
+) -> io::Result<UpdateProfile> {
+    let path = resolve_profile_path(path)?;
+    let mut validated = Vec::new();
+    for host in hosts {
+        validated.push(validate_host(&host)?);
+    }
+    if validated.is_empty() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "at least one client host is required",
+        ));
+    }
+    let mut profile = load_profile(&path)?;
+    profile.clients = ClientsUpdateProfile {
+        hosts: validated,
+        target,
+        docker,
+        journald,
+    };
+    write_profile(&path, &profile)?;
+    Ok(profile)
+}
+
+fn resolve_profile_path(path: Option<&Path>) -> io::Result<PathBuf> {
+    match path {
+        Some(path) => Ok(path.to_path_buf()),
+        None => default_profile_path(),
+    }
+}
+
+fn validate_host(host: &str) -> io::Result<String> {
+    let trimmed = host.trim();
+    if trimmed.is_empty() || !crate::inventory::ssh::is_safe_ssh_host(trimmed) {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("unsafe ssh host: {host}"),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn validate_remote_home(home: &str) -> io::Result<String> {
+    let trimmed = home.trim();
+    let path = Path::new(trimmed);
+    if trimmed.is_empty() || !path.is_absolute() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "server home must be a non-empty absolute path",
+        ));
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "server home must not contain '..'",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+#[path = "update_tests.rs"]
+mod tests;

--- a/src/update.rs
+++ b/src/update.rs
@@ -5,7 +5,8 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 
 use crate::agent_deploy::{
-    AgentDeployConfig, DeployResult, deploy_agent_to_host, find_local_binary,
+    AgentDeployConfig, DeployResult, HostProbe, deploy_agent_to_host, find_local_binary,
+    probe_hosts,
 };
 use crate::deploy::{RemoteDeployOptions, RemoteDeployReport, run_remote_deploy};
 use crate::setup::{PhaseTimer, SetupPhase, SetupStatus, cortex_home_dir};
@@ -153,6 +154,8 @@ trait UpdateRunner {
     ) -> DeployResult;
 
     fn find_binary(&self) -> Option<PathBuf>;
+
+    fn probe_clients(&mut self, hosts: Vec<String>) -> Vec<HostProbe>;
 }
 
 struct RealUpdateRunner;
@@ -178,6 +181,10 @@ impl UpdateRunner for RealUpdateRunner {
     fn find_binary(&self) -> Option<PathBuf> {
         find_local_binary()
     }
+
+    fn probe_clients(&mut self, hosts: Vec<String>) -> Vec<HostProbe> {
+        probe_hosts(hosts)
+    }
 }
 
 pub fn run_update(scope: UpdateScope, options: UpdateOptions) -> io::Result<UpdateReport> {
@@ -195,7 +202,7 @@ fn run_update_with_runner(
         Some(path) => path,
         None => default_profile_path()?,
     };
-    let profile = load_profile(&profile_path)?;
+    let profile = validate_loaded_profile(load_profile(&profile_path)?)?;
     let mut server = None;
     let mut clients = Vec::new();
     let mut skipped = Vec::new();
@@ -251,16 +258,15 @@ fn run_update_with_runner(
                     .finish(SetupStatus::Skipped, "no configured client hosts"),
             );
         } else if options.dry_run {
+            let _binary = resolve_agent_binary(&options, runner)?;
+            let probes = runner.probe_clients(profile.clients.hosts.clone());
+            clients.extend(client_preflight_results(&profile.clients.hosts, probes));
             skipped.push(PhaseTimer::start("clients").finish(
                 SetupStatus::Skipped,
-                "dry-run does not deploy client agents",
+                "dry-run probed client agents without deploying",
             ));
         } else {
-            let binary = options
-                .binary
-                .clone()
-                .or_else(|| runner.find_binary())
-                .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "cortex binary not found"))?;
+            let binary = resolve_agent_binary(&options, runner)?;
             let config = AgentDeployConfig {
                 target: profile.clients.target.clone(),
                 token: None,
@@ -281,6 +287,41 @@ fn run_update_with_runner(
         skipped,
         started,
     ))
+}
+
+fn resolve_agent_binary(options: &UpdateOptions, runner: &dyn UpdateRunner) -> io::Result<PathBuf> {
+    options
+        .binary
+        .clone()
+        .or_else(|| runner.find_binary())
+        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "cortex binary not found"))
+}
+
+fn client_preflight_results(hosts: &[String], probes: Vec<HostProbe>) -> Vec<DeployResult> {
+    let mut results = Vec::with_capacity(hosts.len());
+    for host in hosts {
+        match probes.iter().find(|probe| probe.host == *host) {
+            Some(probe) if probe.reachable => results.push(DeployResult {
+                host: host.clone(),
+                ok: true,
+                detail: probe.display_label(),
+                elapsed_ms: 0,
+            }),
+            Some(probe) => results.push(DeployResult {
+                host: host.clone(),
+                ok: false,
+                detail: probe.display_label(),
+                elapsed_ms: 0,
+            }),
+            None => results.push(DeployResult {
+                host: host.clone(),
+                ok: false,
+                detail: "dry-run probe timed out".to_string(),
+                elapsed_ms: 0,
+            }),
+        }
+    }
+    results
 }
 
 fn build_report(
@@ -309,6 +350,20 @@ fn build_report(
         has_errors,
         elapsed_ms: started.elapsed().as_millis(),
     }
+}
+
+fn validate_loaded_profile(mut profile: UpdateProfile) -> io::Result<UpdateProfile> {
+    if let Some(server) = &mut profile.server {
+        server.host = validate_host(&server.host)?;
+        server.home = validate_remote_home(&server.home)?;
+    }
+    profile.clients.hosts = profile
+        .clients
+        .hosts
+        .iter()
+        .map(|host| validate_host(host))
+        .collect::<io::Result<Vec<_>>>()?;
+    Ok(profile)
 }
 
 fn resolve_profile_path(path: Option<&Path>) -> io::Result<PathBuf> {

--- a/src/update_tests.rs
+++ b/src/update_tests.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+#[test]
+fn update_profile_round_trips_server_and_clients() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+    let profile = UpdateProfile {
+        server: Some(ServerUpdateProfile {
+            host: "tootie".to_string(),
+            home: "/mnt/cache/appdata/cortex".to_string(),
+        }),
+        clients: ClientsUpdateProfile {
+            hosts: vec!["dookie".to_string(), "shart".to_string()],
+            target: Some("https://cortex.tootie.tv".to_string()),
+            docker: Some(true),
+            journald: None,
+        },
+    };
+
+    write_profile(&path, &profile).unwrap();
+    let loaded = load_profile(&path).unwrap();
+
+    assert_eq!(loaded, profile);
+}
+
+#[test]
+fn configure_server_profile_validates_and_preserves_clients() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+    write_profile(
+        &path,
+        &UpdateProfile {
+            server: None,
+            clients: ClientsUpdateProfile {
+                hosts: vec!["dookie".to_string()],
+                target: Some("https://cortex.tootie.tv".to_string()),
+                docker: Some(true),
+                journald: Some(false),
+            },
+        },
+    )
+    .unwrap();
+
+    let updated =
+        configure_server_profile(Some(&path), "tootie", "/mnt/cache/appdata/cortex").unwrap();
+
+    assert_eq!(updated.server.as_ref().unwrap().host, "tootie");
+    assert_eq!(
+        updated.server.as_ref().unwrap().home,
+        "/mnt/cache/appdata/cortex"
+    );
+    assert_eq!(updated.clients.hosts, vec!["dookie"]);
+}
+
+#[test]
+fn configure_server_profile_rejects_unsafe_values() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+
+    let bad_host = configure_server_profile(
+        Some(&path),
+        "-oProxyCommand=touch /tmp/pwned",
+        "/mnt/cache/appdata/cortex",
+    )
+    .unwrap_err();
+    assert!(bad_host.to_string().contains("unsafe ssh host"));
+
+    let bad_home = configure_server_profile(Some(&path), "tootie", "relative/path").unwrap_err();
+    assert!(bad_home.to_string().contains("absolute path"));
+
+    let parent_home =
+        configure_server_profile(Some(&path), "tootie", "/mnt/cache/../cortex").unwrap_err();
+    assert!(parent_home.to_string().contains("must not contain '..'"));
+}

--- a/src/update_tests.rs
+++ b/src/update_tests.rs
@@ -72,3 +72,155 @@ fn configure_server_profile_rejects_unsafe_values() {
         configure_server_profile(Some(&path), "tootie", "/mnt/cache/../cortex").unwrap_err();
     assert!(parent_home.to_string().contains("must not contain '..'"));
 }
+
+#[derive(Default)]
+struct FakeUpdateRunner {
+    server_calls: Vec<(String, RemoteDeployOptions)>,
+    client_calls: Vec<String>,
+    fail_server: bool,
+    fail_client: Option<String>,
+}
+
+impl UpdateRunner for FakeUpdateRunner {
+    fn run_server(
+        &mut self,
+        host: &str,
+        options: RemoteDeployOptions,
+    ) -> io::Result<RemoteDeployReport> {
+        self.server_calls.push((host.to_string(), options.clone()));
+        Ok(RemoteDeployReport {
+            mode: if options.dry_run {
+                "remote dry-run"
+            } else {
+                "remote"
+            },
+            host: host.to_string(),
+            home: options.home.clone().unwrap(),
+            env_path: format!("{}/.env", options.home.clone().unwrap()),
+            compose_dir: format!("{}/compose", options.home.clone().unwrap()),
+            data_dir: format!("{}/data", options.home.clone().unwrap()),
+            health_url: "http://127.0.0.1:3100/health".to_string(),
+            mcp_url: "http://127.0.0.1:3100/mcp".to_string(),
+            phases: Vec::new(),
+            has_errors: self.fail_server,
+            elapsed_ms: 1,
+        })
+    }
+
+    fn deploy_client(
+        &mut self,
+        host: &str,
+        _binary: &Path,
+        _config: &AgentDeployConfig,
+    ) -> DeployResult {
+        self.client_calls.push(host.to_string());
+        let ok = self.fail_client.as_deref() != Some(host);
+        DeployResult {
+            host: host.to_string(),
+            ok,
+            detail: if ok {
+                "ok".to_string()
+            } else {
+                "forced failure".to_string()
+            },
+            elapsed_ms: 1,
+        }
+    }
+
+    fn find_binary(&self) -> Option<PathBuf> {
+        Some(PathBuf::from("/tmp/cortex"))
+    }
+}
+
+#[test]
+fn update_server_uses_saved_profile_without_repeating_home_arg() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+    configure_server_profile(Some(&path), "tootie", "/mnt/cache/appdata/cortex").unwrap();
+    let mut runner = FakeUpdateRunner::default();
+
+    let report = run_update_with_runner(
+        UpdateScope::Server,
+        UpdateOptions {
+            dry_run: true,
+            profile_path: Some(path.clone()),
+            binary: None,
+        },
+        &mut runner,
+    )
+    .unwrap();
+
+    assert!(!report.has_errors);
+    assert_eq!(runner.server_calls.len(), 1);
+    assert_eq!(runner.server_calls[0].0, "tootie");
+    assert_eq!(
+        runner.server_calls[0].1.home.as_deref(),
+        Some("/mnt/cache/appdata/cortex")
+    );
+    assert!(runner.server_calls[0].1.dry_run);
+    assert_eq!(report.profile_path, path);
+}
+
+#[test]
+fn update_clients_deploys_every_configured_client() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+    configure_clients_profile(
+        Some(&path),
+        vec!["dookie".to_string(), "shart".to_string()],
+        Some("https://cortex.tootie.tv".to_string()),
+        Some(true),
+        None,
+    )
+    .unwrap();
+    let mut runner = FakeUpdateRunner::default();
+
+    let report = run_update_with_runner(
+        UpdateScope::Clients,
+        UpdateOptions {
+            dry_run: false,
+            profile_path: Some(path),
+            binary: Some(PathBuf::from("/tmp/cortex")),
+        },
+        &mut runner,
+    )
+    .unwrap();
+
+    assert!(!report.has_errors);
+    assert_eq!(runner.client_calls, vec!["dookie", "shart"]);
+    assert_eq!(report.clients.len(), 2);
+}
+
+#[test]
+fn update_all_stops_before_clients_when_server_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+    configure_server_profile(Some(&path), "tootie", "/mnt/cache/appdata/cortex").unwrap();
+    configure_clients_profile(
+        Some(&path),
+        vec!["dookie".to_string()],
+        Some("https://cortex.tootie.tv".to_string()),
+        None,
+        None,
+    )
+    .unwrap();
+    let mut runner = FakeUpdateRunner {
+        fail_server: true,
+        ..FakeUpdateRunner::default()
+    };
+
+    let report = run_update_with_runner(
+        UpdateScope::All,
+        UpdateOptions {
+            dry_run: false,
+            profile_path: Some(path),
+            binary: Some(PathBuf::from("/tmp/cortex")),
+        },
+        &mut runner,
+    )
+    .unwrap();
+
+    assert!(report.has_errors);
+    assert!(runner.client_calls.is_empty());
+    assert!(report.skipped.iter().any(|phase| phase.name == "clients"));
+}

--- a/src/update_tests.rs
+++ b/src/update_tests.rs
@@ -1,4 +1,33 @@
 use super::*;
+use serial_test::serial;
+
+struct EnvGuard {
+    name: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(name);
+        unsafe { std::env::set_var(name, value) };
+        Self { name, previous }
+    }
+
+    fn remove(name: &'static str) -> Self {
+        let previous = std::env::var_os(name);
+        unsafe { std::env::remove_var(name) };
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => unsafe { std::env::set_var(self.name, value) },
+            None => unsafe { std::env::remove_var(self.name) },
+        }
+    }
+}
 
 #[test]
 fn update_profile_round_trips_server_and_clients() {
@@ -159,6 +188,32 @@ fn update_server_uses_saved_profile_without_repeating_home_arg() {
     );
     assert!(runner.server_calls[0].1.dry_run);
     assert_eq!(report.profile_path, path);
+}
+
+#[test]
+#[serial]
+fn update_with_explicit_profile_does_not_resolve_default_profile_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+    configure_server_profile(Some(&path), "tootie", "/mnt/cache/appdata/cortex").unwrap();
+    let mut runner = FakeUpdateRunner::default();
+    let _home_guard = EnvGuard::set("HOME", "relative-home");
+    let _cortex_home_guard = EnvGuard::remove("CORTEX_HOME");
+
+    let report = run_update_with_runner(
+        UpdateScope::Server,
+        UpdateOptions {
+            dry_run: true,
+            profile_path: Some(path.clone()),
+            binary: None,
+        },
+        &mut runner,
+    )
+    .unwrap();
+
+    assert!(!report.has_errors);
+    assert_eq!(report.profile_path, path);
+    assert_eq!(runner.server_calls.len(), 1);
 }
 
 #[test]

--- a/src/update_tests.rs
+++ b/src/update_tests.rs
@@ -106,6 +106,8 @@ fn configure_server_profile_rejects_unsafe_values() {
 struct FakeUpdateRunner {
     server_calls: Vec<(String, RemoteDeployOptions)>,
     client_calls: Vec<String>,
+    probe_calls: Vec<Vec<String>>,
+    probes: Vec<crate::agent_deploy::HostProbe>,
     fail_server: bool,
     fail_client: Option<String>,
 }
@@ -158,6 +160,23 @@ impl UpdateRunner for FakeUpdateRunner {
 
     fn find_binary(&self) -> Option<PathBuf> {
         Some(PathBuf::from("/tmp/cortex"))
+    }
+
+    fn probe_clients(&mut self, hosts: Vec<String>) -> Vec<crate::agent_deploy::HostProbe> {
+        self.probe_calls.push(hosts.clone());
+        if self.probes.is_empty() {
+            hosts
+                .into_iter()
+                .map(|host| crate::agent_deploy::HostProbe {
+                    host,
+                    reachable: true,
+                    cortex_version: Some("3.9.1".to_string()),
+                    agent_active: Some(true),
+                })
+                .collect()
+        } else {
+            self.probes.clone()
+        }
     }
 }
 
@@ -244,6 +263,81 @@ fn update_clients_deploys_every_configured_client() {
     assert!(!report.has_errors);
     assert_eq!(runner.client_calls, vec!["dookie", "shart"]);
     assert_eq!(report.clients.len(), 2);
+}
+
+#[test]
+fn update_clients_dry_run_probes_clients_without_deploying() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+    configure_clients_profile(
+        Some(&path),
+        vec!["dookie".to_string(), "shart".to_string()],
+        Some("https://cortex.tootie.tv".to_string()),
+        Some(true),
+        None,
+    )
+    .unwrap();
+    let mut runner = FakeUpdateRunner::default();
+
+    let report = run_update_with_runner(
+        UpdateScope::Clients,
+        UpdateOptions {
+            dry_run: true,
+            profile_path: Some(path),
+            binary: Some(PathBuf::from("/tmp/cortex")),
+        },
+        &mut runner,
+    )
+    .unwrap();
+
+    assert!(!report.has_errors);
+    assert_eq!(
+        runner.probe_calls,
+        vec![vec!["dookie".to_string(), "shart".to_string()]]
+    );
+    assert!(runner.client_calls.is_empty());
+    assert_eq!(report.clients.len(), 2);
+    assert!(
+        report
+            .skipped
+            .iter()
+            .any(|phase| phase.detail.contains("without deploying"))
+    );
+}
+
+#[test]
+fn update_clients_revalidates_loaded_profile_hosts() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("deployments.toml");
+    write_profile(
+        &path,
+        &UpdateProfile {
+            server: None,
+            clients: ClientsUpdateProfile {
+                hosts: vec!["-oProxyCommand=touch /tmp/pwned".to_string()],
+                target: None,
+                docker: None,
+                journald: None,
+            },
+        },
+    )
+    .unwrap();
+    let mut runner = FakeUpdateRunner::default();
+
+    let error = run_update_with_runner(
+        UpdateScope::Clients,
+        UpdateOptions {
+            dry_run: false,
+            profile_path: Some(path),
+            binary: Some(PathBuf::from("/tmp/cortex")),
+        },
+        &mut runner,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("unsafe ssh host"));
+    assert!(runner.client_calls.is_empty());
+    assert!(runner.probe_calls.is_empty());
 }
 
 #[test]

--- a/src/update_tests.rs
+++ b/src/update_tests.rs
@@ -1,6 +1,10 @@
 use super::*;
 use serial_test::serial;
 
+const SERVER_HOST: &str = "tootie";
+const SERVER_HOME: &str = "/mnt/cache/appdata/cortex";
+const CLIENT_HOSTS: &[&str] = &["dookie", "shart"];
+
 struct EnvGuard {
     name: &'static str,
     previous: Option<std::ffi::OsString>,
@@ -29,17 +33,60 @@ impl Drop for EnvGuard {
     }
 }
 
+fn profile_path(dir: &tempfile::TempDir) -> PathBuf {
+    dir.path().join("deployments.toml")
+}
+
+fn client_hosts() -> Vec<String> {
+    CLIENT_HOSTS
+        .iter()
+        .map(|host| (*host).to_string())
+        .collect()
+}
+
+fn configure_test_server_profile(path: &Path) {
+    configure_server_profile(Some(path), SERVER_HOST, SERVER_HOME).unwrap();
+}
+
+fn configure_test_clients_profile(path: &Path, hosts: Vec<String>) {
+    configure_clients_profile(
+        Some(path),
+        hosts,
+        Some("https://cortex.tootie.tv".to_string()),
+        Some(true),
+        None,
+    )
+    .unwrap();
+}
+
+fn run_test_update(
+    scope: UpdateScope,
+    path: PathBuf,
+    dry_run: bool,
+    runner: &mut dyn UpdateRunner,
+) -> io::Result<UpdateReport> {
+    run_update_with_runner(
+        scope,
+        UpdateOptions {
+            dry_run,
+            profile_path: Some(path),
+            binary: Some(PathBuf::from("/tmp/cortex")),
+        },
+        runner,
+    )
+}
+
 #[test]
 fn update_profile_round_trips_server_and_clients() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
+    let path = profile_path(&dir);
     let profile = UpdateProfile {
         server: Some(ServerUpdateProfile {
-            host: "tootie".to_string(),
-            home: "/mnt/cache/appdata/cortex".to_string(),
+            host: SERVER_HOST.to_string(),
+            home: SERVER_HOME.to_string(),
         }),
         clients: ClientsUpdateProfile {
-            hosts: vec!["dookie".to_string(), "shart".to_string()],
+            hosts: client_hosts(),
             target: Some("https://cortex.tootie.tv".to_string()),
             docker: Some(true),
             journald: None,
@@ -55,7 +102,7 @@ fn update_profile_round_trips_server_and_clients() {
 #[test]
 fn configure_server_profile_validates_and_preserves_clients() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
+    let path = profile_path(&dir);
     write_profile(
         &path,
         &UpdateProfile {
@@ -70,35 +117,29 @@ fn configure_server_profile_validates_and_preserves_clients() {
     )
     .unwrap();
 
-    let updated =
-        configure_server_profile(Some(&path), "tootie", "/mnt/cache/appdata/cortex").unwrap();
+    let updated = configure_server_profile(Some(&path), SERVER_HOST, SERVER_HOME).unwrap();
 
-    assert_eq!(updated.server.as_ref().unwrap().host, "tootie");
-    assert_eq!(
-        updated.server.as_ref().unwrap().home,
-        "/mnt/cache/appdata/cortex"
-    );
+    let server = updated.server.as_ref().unwrap();
+    assert_eq!(server.host, SERVER_HOST);
+    assert_eq!(server.home, SERVER_HOME);
     assert_eq!(updated.clients.hosts, vec!["dookie"]);
 }
 
 #[test]
 fn configure_server_profile_rejects_unsafe_values() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
+    let path = profile_path(&dir);
 
-    let bad_host = configure_server_profile(
-        Some(&path),
-        "-oProxyCommand=touch /tmp/pwned",
-        "/mnt/cache/appdata/cortex",
-    )
-    .unwrap_err();
+    let bad_host =
+        configure_server_profile(Some(&path), "-oProxyCommand=touch /tmp/pwned", SERVER_HOME)
+            .unwrap_err();
     assert!(bad_host.to_string().contains("unsafe ssh host"));
 
-    let bad_home = configure_server_profile(Some(&path), "tootie", "relative/path").unwrap_err();
+    let bad_home = configure_server_profile(Some(&path), SERVER_HOST, "relative/path").unwrap_err();
     assert!(bad_home.to_string().contains("absolute path"));
 
     let parent_home =
-        configure_server_profile(Some(&path), "tootie", "/mnt/cache/../cortex").unwrap_err();
+        configure_server_profile(Some(&path), SERVER_HOST, "/mnt/cache/../cortex").unwrap_err();
     assert!(parent_home.to_string().contains("must not contain '..'"));
 }
 
@@ -118,18 +159,16 @@ impl UpdateRunner for FakeUpdateRunner {
         host: &str,
         options: RemoteDeployOptions,
     ) -> io::Result<RemoteDeployReport> {
-        self.server_calls.push((host.to_string(), options.clone()));
+        let home = options.home.clone().unwrap();
+        let dry_run = options.dry_run;
+        self.server_calls.push((host.to_string(), options));
         Ok(RemoteDeployReport {
-            mode: if options.dry_run {
-                "remote dry-run"
-            } else {
-                "remote"
-            },
+            mode: if dry_run { "remote dry-run" } else { "remote" },
             host: host.to_string(),
-            home: options.home.clone().unwrap(),
-            env_path: format!("{}/.env", options.home.clone().unwrap()),
-            compose_dir: format!("{}/compose", options.home.clone().unwrap()),
-            data_dir: format!("{}/data", options.home.clone().unwrap()),
+            env_path: format!("{home}/.env"),
+            compose_dir: format!("{home}/compose"),
+            data_dir: format!("{home}/data"),
+            home,
             health_url: "http://127.0.0.1:3100/health".to_string(),
             mcp_url: "http://127.0.0.1:3100/mcp".to_string(),
             phases: Vec::new(),
@@ -183,8 +222,8 @@ impl UpdateRunner for FakeUpdateRunner {
 #[test]
 fn update_server_uses_saved_profile_without_repeating_home_arg() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
-    configure_server_profile(Some(&path), "tootie", "/mnt/cache/appdata/cortex").unwrap();
+    let path = profile_path(&dir);
+    configure_test_server_profile(&path);
     let mut runner = FakeUpdateRunner::default();
 
     let report = run_update_with_runner(
@@ -200,11 +239,8 @@ fn update_server_uses_saved_profile_without_repeating_home_arg() {
 
     assert!(!report.has_errors);
     assert_eq!(runner.server_calls.len(), 1);
-    assert_eq!(runner.server_calls[0].0, "tootie");
-    assert_eq!(
-        runner.server_calls[0].1.home.as_deref(),
-        Some("/mnt/cache/appdata/cortex")
-    );
+    assert_eq!(runner.server_calls[0].0, SERVER_HOST);
+    assert_eq!(runner.server_calls[0].1.home.as_deref(), Some(SERVER_HOME));
     assert!(runner.server_calls[0].1.dry_run);
     assert_eq!(report.profile_path, path);
 }
@@ -213,8 +249,8 @@ fn update_server_uses_saved_profile_without_repeating_home_arg() {
 #[serial]
 fn update_with_explicit_profile_does_not_resolve_default_profile_path() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
-    configure_server_profile(Some(&path), "tootie", "/mnt/cache/appdata/cortex").unwrap();
+    let path = profile_path(&dir);
+    configure_test_server_profile(&path);
     let mut runner = FakeUpdateRunner::default();
     let _home_guard = EnvGuard::set("HOME", "relative-home");
     let _cortex_home_guard = EnvGuard::remove("CORTEX_HOME");
@@ -238,63 +274,29 @@ fn update_with_explicit_profile_does_not_resolve_default_profile_path() {
 #[test]
 fn update_clients_deploys_every_configured_client() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
-    configure_clients_profile(
-        Some(&path),
-        vec!["dookie".to_string(), "shart".to_string()],
-        Some("https://cortex.tootie.tv".to_string()),
-        Some(true),
-        None,
-    )
-    .unwrap();
+    let path = profile_path(&dir);
+    configure_test_clients_profile(&path, client_hosts());
     let mut runner = FakeUpdateRunner::default();
 
-    let report = run_update_with_runner(
-        UpdateScope::Clients,
-        UpdateOptions {
-            dry_run: false,
-            profile_path: Some(path),
-            binary: Some(PathBuf::from("/tmp/cortex")),
-        },
-        &mut runner,
-    )
-    .unwrap();
+    let report = run_test_update(UpdateScope::Clients, path, false, &mut runner).unwrap();
 
     assert!(!report.has_errors);
-    assert_eq!(runner.client_calls, vec!["dookie", "shart"]);
+    assert_eq!(runner.client_calls, client_hosts());
     assert_eq!(report.clients.len(), 2);
 }
 
 #[test]
 fn update_clients_dry_run_probes_clients_without_deploying() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
-    configure_clients_profile(
-        Some(&path),
-        vec!["dookie".to_string(), "shart".to_string()],
-        Some("https://cortex.tootie.tv".to_string()),
-        Some(true),
-        None,
-    )
-    .unwrap();
+    let path = profile_path(&dir);
+    let hosts = client_hosts();
+    configure_test_clients_profile(&path, hosts.clone());
     let mut runner = FakeUpdateRunner::default();
 
-    let report = run_update_with_runner(
-        UpdateScope::Clients,
-        UpdateOptions {
-            dry_run: true,
-            profile_path: Some(path),
-            binary: Some(PathBuf::from("/tmp/cortex")),
-        },
-        &mut runner,
-    )
-    .unwrap();
+    let report = run_test_update(UpdateScope::Clients, path, true, &mut runner).unwrap();
 
     assert!(!report.has_errors);
-    assert_eq!(
-        runner.probe_calls,
-        vec![vec!["dookie".to_string(), "shart".to_string()]]
-    );
+    assert_eq!(runner.probe_calls, vec![hosts]);
     assert!(runner.client_calls.is_empty());
     assert_eq!(report.clients.len(), 2);
     assert!(
@@ -308,7 +310,7 @@ fn update_clients_dry_run_probes_clients_without_deploying() {
 #[test]
 fn update_clients_revalidates_loaded_profile_hosts() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
+    let path = profile_path(&dir);
     write_profile(
         &path,
         &UpdateProfile {
@@ -324,16 +326,7 @@ fn update_clients_revalidates_loaded_profile_hosts() {
     .unwrap();
     let mut runner = FakeUpdateRunner::default();
 
-    let error = run_update_with_runner(
-        UpdateScope::Clients,
-        UpdateOptions {
-            dry_run: false,
-            profile_path: Some(path),
-            binary: Some(PathBuf::from("/tmp/cortex")),
-        },
-        &mut runner,
-    )
-    .unwrap_err();
+    let error = run_test_update(UpdateScope::Clients, path, false, &mut runner).unwrap_err();
 
     assert!(error.to_string().contains("unsafe ssh host"));
     assert!(runner.client_calls.is_empty());
@@ -343,31 +336,15 @@ fn update_clients_revalidates_loaded_profile_hosts() {
 #[test]
 fn update_all_stops_before_clients_when_server_fails() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("deployments.toml");
-    configure_server_profile(Some(&path), "tootie", "/mnt/cache/appdata/cortex").unwrap();
-    configure_clients_profile(
-        Some(&path),
-        vec!["dookie".to_string()],
-        Some("https://cortex.tootie.tv".to_string()),
-        None,
-        None,
-    )
-    .unwrap();
+    let path = profile_path(&dir);
+    configure_test_server_profile(&path);
+    configure_clients_profile(Some(&path), vec!["dookie".to_string()], None, None, None).unwrap();
     let mut runner = FakeUpdateRunner {
         fail_server: true,
         ..FakeUpdateRunner::default()
     };
 
-    let report = run_update_with_runner(
-        UpdateScope::All,
-        UpdateOptions {
-            dry_run: false,
-            profile_path: Some(path),
-            binary: Some(PathBuf::from("/tmp/cortex")),
-        },
-        &mut runner,
-    )
-    .unwrap();
+    let report = run_test_update(UpdateScope::All, path, false, &mut runner).unwrap();
 
     assert!(report.has_errors);
     assert!(runner.client_calls.is_empty());

--- a/src/update_tests.rs
+++ b/src/update_tests.rs
@@ -143,6 +143,49 @@ fn configure_server_profile_rejects_unsafe_values() {
     assert!(parent_home.to_string().contains("must not contain '..'"));
 }
 
+#[test]
+fn configure_clients_profile_merges_omitted_options() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = profile_path(&dir);
+    configure_clients_profile(
+        Some(&path),
+        vec!["dookie".to_string()],
+        Some("https://cortex.tootie.tv".to_string()),
+        Some(true),
+        Some(false),
+    )
+    .unwrap();
+
+    let updated =
+        configure_clients_profile(Some(&path), vec!["shart".to_string()], None, None, None)
+            .unwrap();
+
+    assert_eq!(updated.clients.hosts, vec!["shart"]);
+    assert_eq!(
+        updated.clients.target.as_deref(),
+        Some("https://cortex.tootie.tv")
+    );
+    assert_eq!(updated.clients.docker, Some(true));
+    assert_eq!(updated.clients.journald, Some(false));
+}
+
+#[test]
+fn configure_clients_profile_rejects_invalid_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = profile_path(&dir);
+
+    let error = configure_clients_profile(
+        Some(&path),
+        vec!["dookie".to_string()],
+        Some("not a url".to_string()),
+        None,
+        None,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("client target"));
+}
+
 #[derive(Default)]
 struct FakeUpdateRunner {
     server_calls: Vec<(String, RemoteDeployOptions)>,
@@ -217,6 +260,31 @@ impl UpdateRunner for FakeUpdateRunner {
             self.probes.clone()
         }
     }
+
+    fn validate_binary(&self, _path: &Path) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn validate_agent_binary_rejects_missing_explicit_binary() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = profile_path(&dir);
+    configure_test_clients_profile(&path, client_hosts());
+    let mut runner = RealUpdateRunner;
+
+    let error = run_update_with_runner(
+        UpdateScope::Clients,
+        UpdateOptions {
+            dry_run: true,
+            profile_path: Some(path),
+            binary: Some(dir.path().join("missing-cortex")),
+        },
+        &mut runner,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("is not usable"));
 }
 
 #[test]
@@ -286,6 +354,23 @@ fn update_clients_deploys_every_configured_client() {
 }
 
 #[test]
+fn update_clients_marks_report_error_when_a_client_deploy_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = profile_path(&dir);
+    configure_test_clients_profile(&path, client_hosts());
+    let mut runner = FakeUpdateRunner {
+        fail_client: Some("shart".to_string()),
+        ..FakeUpdateRunner::default()
+    };
+
+    let report = run_test_update(UpdateScope::Clients, path, false, &mut runner).unwrap();
+
+    assert!(report.has_errors);
+    assert_eq!(runner.client_calls, client_hosts());
+    assert!(report.clients.iter().any(|result| !result.ok));
+}
+
+#[test]
 fn update_clients_dry_run_probes_clients_without_deploying() {
     let dir = tempfile::tempdir().unwrap();
     let path = profile_path(&dir);
@@ -305,6 +390,31 @@ fn update_clients_dry_run_probes_clients_without_deploying() {
             .iter()
             .any(|phase| phase.detail.contains("without deploying"))
     );
+}
+
+#[test]
+fn update_clients_dry_run_marks_missing_probe_as_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = profile_path(&dir);
+    let hosts = client_hosts();
+    configure_test_clients_profile(&path, hosts.clone());
+    let mut runner = FakeUpdateRunner {
+        probes: vec![crate::agent_deploy::HostProbe {
+            host: "dookie".to_string(),
+            reachable: true,
+            cortex_version: Some("3.9.1".to_string()),
+            agent_active: Some(true),
+        }],
+        ..FakeUpdateRunner::default()
+    };
+
+    let report = run_test_update(UpdateScope::Clients, path, true, &mut runner).unwrap();
+
+    assert!(report.has_errors);
+    assert_eq!(report.clients.len(), 2);
+    assert!(report.clients.iter().any(|result| {
+        result.host == "shart" && !result.ok && result.detail.contains("timed out")
+    }));
 }
 
 #[test]
@@ -334,6 +444,32 @@ fn update_clients_revalidates_loaded_profile_hosts() {
 }
 
 #[test]
+fn update_clients_revalidates_loaded_profile_target() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = profile_path(&dir);
+    write_profile(
+        &path,
+        &UpdateProfile {
+            server: None,
+            clients: ClientsUpdateProfile {
+                hosts: vec!["dookie".to_string()],
+                target: Some("notaurl".to_string()),
+                docker: None,
+                journald: None,
+            },
+        },
+    )
+    .unwrap();
+    let mut runner = FakeUpdateRunner::default();
+
+    let error = run_test_update(UpdateScope::Clients, path, false, &mut runner).unwrap_err();
+
+    assert!(error.to_string().contains("client target"));
+    assert!(runner.client_calls.is_empty());
+    assert!(runner.probe_calls.is_empty());
+}
+
+#[test]
 fn update_all_stops_before_clients_when_server_fails() {
     let dir = tempfile::tempdir().unwrap();
     let path = profile_path(&dir);
@@ -349,4 +485,19 @@ fn update_all_stops_before_clients_when_server_fails() {
     assert!(report.has_errors);
     assert!(runner.client_calls.is_empty());
     assert!(report.skipped.iter().any(|phase| phase.name == "clients"));
+}
+
+#[test]
+fn update_all_runs_server_then_clients_when_server_succeeds() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = profile_path(&dir);
+    configure_test_server_profile(&path);
+    configure_test_clients_profile(&path, client_hosts());
+    let mut runner = FakeUpdateRunner::default();
+
+    let report = run_test_update(UpdateScope::All, path, false, &mut runner).unwrap();
+
+    assert!(!report.has_errors);
+    assert_eq!(runner.server_calls.len(), 1);
+    assert_eq!(runner.client_calls, client_hosts());
 }

--- a/tests/cli_help.rs
+++ b/tests/cli_help.rs
@@ -39,6 +39,20 @@ fn per_command_help_shows_detailed_flags() {
 }
 
 #[test]
+fn update_help_shows_server_clients_and_config_commands() {
+    let output = Command::new(env!("CARGO_BIN_EXE_cortex"))
+        .args(["update", "--help"])
+        .output()
+        .expect("run cortex update --help");
+
+    assert!(output.status.success(), "update --help should exit 0");
+    let stdout = String::from_utf8(output.stdout).expect("valid UTF-8");
+    assert!(stdout.contains("cortex update [all|server|clients|agents]"));
+    assert!(stdout.contains("cortex update config server --host HOST --home PATH"));
+    assert!(stdout.contains("cortex update config clients --hosts h1,h2"));
+}
+
+#[test]
 fn sessions_cli_add_and_query_commands_emit_json() {
     let dir = tempfile::tempdir().unwrap();
     let db_path = dir.path().join("cli-ai.db");


### PR DESCRIPTION
## Summary
- add `cortex update` / `server` / `clients` / `agents` with profile-backed server and agent update execution
- persist the server update profile after successful non-dry-run `setup deploy remote --home PATH HOST`
- document the normal update workflow while keeping `setup deploy remote` as the low-level primitive

## Verification
- `cargo fmt --check`
- `RUSTC_WRAPPER=<empty> cargo test --config build.rustc-wrapper="" update_ -- --nocapture`
- `RUSTC_WRAPPER=<empty> cargo test --config build.rustc-wrapper="" mode_parse_accepts_update -- --nocapture`
- `RUSTC_WRAPPER=<empty> cargo test --config build.rustc-wrapper="" --test cli_help -- --nocapture --test-threads=1`
- `RUSTC_WRAPPER=<empty> cargo clippy --locked --config build.rustc-wrapper="" -- -D warnings`
- `RUSTC_WRAPPER=<empty> cargo build --release --locked --config build.rustc-wrapper=""`
- pre-push: `cargo xtask check-version-sync`, module-size check, `cargo clippy --all-targets --all-features --locked -- -D warnings`

## Live tootie verification
- `./.cache/cargo/release/cortex update config server --host tootie --home /mnt/cache/appdata/cortex --json`
- `./.cache/cargo/release/cortex update server --dry-run --json`
- `./.cache/cargo/release/cortex update server --json`
- tootie compose image resolved `ghcr.io/jmagar/cortex:3.9.1`
- tootie container reported healthy
- `/api/version` returned `{"version":"3.9.1","schema_version":40}`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `cortex update` workflow to update the server and host-agents from a saved profile with dry-run and JSON reports. Hardens SSH and client auth, and preserves existing Linux agent settings.

- **New Features**
  - New `cortex update` command with scopes: `all` (default), `server`, `clients`/`agents`.
  - Profile at `~/.cortex/deployments.toml`; configure via `cortex update config server` and `cortex update config clients` (preserves omitted `--target`, `--docker`, `--journald`).
  - `cortex setup deploy remote --home PATH HOST` now saves the server profile after a successful non-dry-run run.
  - Dry-runs for both `server` and `clients`; clients probe hosts over SSH without deploying. Supports `--json` and `--binary PATH` for client updates.
  - Linux client redeploys read `~/.cortex/heartbeat-agent.env` and keep auth/forwarding flags unless overridden.

- **Bug Fixes**
  - Validate SSH hosts and server home paths (absolute, no `..`) before any SSH/SCP and when loading profiles; block unsafe host strings and use `--` to separate SSH args.
  - Require a valid heartbeat token for `update clients`; abort if missing to prevent stripping auth on configured agents.
  - Redact tokens from failure messages in client deploy output.
  - CLI guards: reject `--binary` with `server` and `--dry-run` with `update config`; honor explicit `--profile` path.
  - When running `all`, skip client updates if the server update fails.

<sup>Written for commit 2eede819c95d207b5ee54394ea204a41319acf66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

