### PR TITLE
feat(mcp): make query widget usable on hosts without resources/read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ CORTEX_MCP_BIND=127.0.0.1           # Compose host publish interface for port 31
 CORTEX_TOKEN=your-secret-token      # optional on loopback; required on non-loopback binds
 CORTEX_ALLOWED_HOSTS=myhost.local   # optional; comma-separated extra Host allowlist
 CORTEX_ALLOWED_ORIGINS=https://app  # optional; comma-separated extra Origin allowlist
+CORTEX_WIDGET_EMBED=false           # opt-in: also embed the query widget (~16 KiB, audience=user) in search/filter/tail/errors tool results, for hosts whose connection path lacks resources/read (e.g. claude.ai connector proxy)
 
 # Storage
 CORTEX_DB_PATH=data/cortex.db

--- a/src/mcp/rmcp_server.rs
+++ b/src/mcp/rmcp_server.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, net::Ipv6Addr, sync::Arc};
+use std::{
+    borrow::Cow,
+    net::Ipv6Addr,
+    sync::{Arc, OnceLock},
+};
 
 use lab_auth::AuthContext;
 use rmcp::{
@@ -7,7 +11,7 @@ use rmcp::{
         CallToolRequestParams, CallToolResult, Content, GetPromptRequestParams, GetPromptResult,
         Implementation, ListPromptsResult, ListResourcesResult, ListToolsResult, Meta,
         PaginatedRequestParams, RawResource, ReadResourceRequestParams, ReadResourceResult,
-        Resource, ResourceContents, ServerCapabilities, ServerInfo, Tool,
+        Resource, ResourceContents, Role, ServerCapabilities, ServerInfo, Tool,
     },
     service::RequestContext,
     transport::streamable_http_server::{
@@ -94,7 +98,11 @@ impl ServerHandler for CortexRmcpServer {
                     result_count,
                     "MCP tool execution completed"
                 );
-                tool_result_from_json(result)
+                let mut call_result = tool_result_from_json(result)?;
+                if should_embed_widget(&action, widget_embed_enabled()) {
+                    call_result.content.push(embedded_widget_content());
+                }
+                Ok(call_result)
             }
             // Mirror api.rs::respond(): every ServiceError variant maps to a
             // distinct client-visible class so MCP clients can tell retryable
@@ -400,8 +408,65 @@ fn query_widget_contents() -> ResourceContents {
     .with_mime_type(MCP_APP_HTML_MIME_TYPE)
 }
 
+/// Actions whose successful results additionally carry the query widget as an
+/// embedded resource content block.
+///
+/// MCP Apps hosts normally hydrate the widget by calling `resources/read` on
+/// `_meta.ui.resourceUri`, but some connection paths (notably the claude.ai
+/// connector proxy) expose tools only and report "does not support
+/// resources", leaving a permanent "Rendering widget" placeholder. Embedding
+/// the widget in the tool result gives such hosts an mcp-ui-style fallback
+/// they can render without a resource round-trip.
+const WIDGET_EMBED_ACTIONS: &[&str] = &["search", "filter", "tail", "errors"];
+
+/// Whether `action`'s successful result should carry the embedded widget.
+fn should_embed_widget(action: &str, enabled: bool) -> bool {
+    enabled && WIDGET_EMBED_ACTIONS.contains(&action)
+}
+
+/// Parse the `CORTEX_WIDGET_EMBED` opt-in value. Defaults to `false`: the
+/// widget HTML is ~16 KiB per result, and although the block is annotated
+/// `audience: ["user"]`, hosts that ignore audience annotations would feed it
+/// to the model on every query — so operators enable it deliberately.
+fn parse_widget_embed(raw: Option<&str>) -> bool {
+    raw.map(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+    .unwrap_or(false)
+}
+
+/// Process-lifetime cache of the `CORTEX_WIDGET_EMBED` opt-in.
+fn widget_embed_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED
+        .get_or_init(|| parse_widget_embed(std::env::var("CORTEX_WIDGET_EMBED").ok().as_deref()))
+}
+
+/// The query widget as an embedded resource content block, annotated
+/// `audience: ["user"]` so audience-aware hosts keep it out of model context.
+fn embedded_widget_content() -> Content {
+    Content::resource(
+        ResourceContents::text(
+            include_str!("ui/query_widget.html"),
+            QUERY_WIDGET_RESOURCE_URI,
+        )
+        .with_mime_type(MCP_APP_HTML_MIME_TYPE),
+    )
+    .with_audience(vec![Role::User])
+}
+
 fn cortex_tool_meta() -> Meta {
     let mut meta = Map::new();
+    // Both formats the MCP Apps SDK tells hosts to check: the flat
+    // `ui/resourceUri` key (ext-apps `RESOURCE_URI_META_KEY`) and the nested
+    // `ui` object. Host generations differ in which one they read.
+    meta.insert(
+        "ui/resourceUri".to_string(),
+        Value::String(QUERY_WIDGET_RESOURCE_URI.to_string()),
+    );
     meta.insert(
         "ui".to_string(),
         serde_json::json!({

--- a/src/mcp/rmcp_server_tests.rs
+++ b/src/mcp/rmcp_server_tests.rs
@@ -343,6 +343,12 @@ async fn rmcp_tools_list_exposes_one_action_tool() {
         tools[0]["_meta"]["ui"]["visibility"],
         json!(["model", "app"])
     );
+    // Modern flat key (ext-apps RESOURCE_URI_META_KEY) must ride alongside
+    // the nested object — host generations differ in which one they read.
+    assert_eq!(
+        tools[0]["_meta"]["ui/resourceUri"],
+        super::QUERY_WIDGET_RESOURCE_URI
+    );
 }
 
 #[tokio::test]
@@ -1537,5 +1543,71 @@ async fn llm_invocations_action_is_denied_for_read_only_scope() {
     assert!(
         msg.contains("requires scope: cortex:admin"),
         "denial message should reference admin scope; got: {msg}"
+    );
+}
+
+#[test]
+fn widget_embed_opt_in_defaults_off() {
+    use super::parse_widget_embed;
+    assert!(!parse_widget_embed(None));
+    assert!(!parse_widget_embed(Some("")));
+    assert!(!parse_widget_embed(Some("0")));
+    assert!(!parse_widget_embed(Some("false")));
+    assert!(!parse_widget_embed(Some("nonsense")));
+    assert!(parse_widget_embed(Some("1")));
+    assert!(parse_widget_embed(Some("true")));
+    assert!(parse_widget_embed(Some(" TRUE ")));
+    assert!(parse_widget_embed(Some("yes")));
+    assert!(parse_widget_embed(Some("on")));
+}
+
+#[test]
+fn widget_embeds_only_for_query_actions_and_only_when_enabled() {
+    use super::should_embed_widget;
+    for action in ["search", "filter", "tail", "errors"] {
+        assert!(
+            should_embed_widget(action, true),
+            "{action} should embed when enabled"
+        );
+        assert!(
+            !should_embed_widget(action, false),
+            "{action} must not embed when disabled"
+        );
+    }
+    for action in ["help", "stats", "get", "ack_error", "hosts", ""] {
+        assert!(
+            !should_embed_widget(action, true),
+            "{action} must never embed"
+        );
+    }
+}
+
+#[test]
+fn embedded_widget_content_matches_resource_declaration() {
+    use rmcp::model::{ResourceContents, Role};
+
+    let content = super::embedded_widget_content();
+    assert_eq!(
+        content.audience(),
+        Some(&vec![Role::User]),
+        "widget block must be user-audience so audience-aware hosts keep it out of model context"
+    );
+    let embedded = content
+        .as_resource()
+        .expect("widget block must be an embedded resource");
+    let ResourceContents::TextResourceContents {
+        uri,
+        mime_type,
+        text,
+        ..
+    } = &embedded.resource
+    else {
+        panic!("widget resource must be text contents");
+    };
+    assert_eq!(uri, super::QUERY_WIDGET_RESOURCE_URI);
+    assert_eq!(mime_type.as_deref(), Some(super::MCP_APP_HTML_MIME_TYPE));
+    assert!(
+        text.contains("data-syslog-query-widget"),
+        "embedded HTML should be the query widget"
     );
 }

--- a/src/mcp/ui/query_widget.html
+++ b/src/mcp/ui/query_widget.html
@@ -312,12 +312,117 @@
       });
     }
 
+    // ---- MCP Apps JSON-RPC bridge (SEP-1865) ---------------------------------
+    // Official MCP Apps hosts exchange raw JSON-RPC 2.0 messages with the view
+    // over postMessage: the view opens with a `ui/initialize` request, confirms
+    // with `ui/notifications/initialized`, then calls tools via standard
+    // `tools/call` requests to the parent. Messages carry no envelope, so the
+    // `jsonrpc` field is what separates this protocol from the legacy mcp-ui
+    // listener below (whose messages have `type`/`messageId` and no `jsonrpc`).
+    var rpcSeq = 0;
+    var rpcPending = {};
+    var rpcReady = false;
+
+    window.addEventListener("message", function (event) {
+      if (event.source !== window.parent) return;
+      var m = event.data;
+      if (!m || typeof m !== "object" || m.jsonrpc !== "2.0") return;
+      if (m.id != null && m.method == null) {
+        var pending = rpcPending[m.id];
+        if (!pending) return;
+        delete rpcPending[m.id];
+        if (m.error) {
+          pending.reject(new Error(
+            (m.error.message ? String(m.error.message) : "host error").slice(0, MAX_ERR_LEN)
+          ));
+        } else {
+          pending.resolve(m.result);
+        }
+        return;
+      }
+      if (m.method === "ui/notifications/tool-result") {
+        // Host pushed the result of the tool call that opened this widget —
+        // render it so the view is populated before any manual query.
+        var pushed = m.params && m.params.result ? normalize(m.params.result) : null;
+        if (pushed) render(pushed);
+        return;
+      }
+      if (m.id != null) {
+        // Host-initiated request. Answer what the protocol requires; refuse
+        // the rest explicitly so the host is not left waiting on a timeout.
+        if (m.method === "ping" || m.method === "ui/resource-teardown") {
+          rpcRespond(m.id, {});
+        } else {
+          rpcRespondError(m.id, -32601, "method not found: " + String(m.method).slice(0, 64));
+        }
+      }
+      // Remaining notifications (tool-input, host-context-changed, …) are
+      // intentionally ignored — the widget re-queries on demand.
+    });
+
+    function rpcPost(message) {
+      window.parent.postMessage(message, "*");
+    }
+
+    function rpcRespond(id, result) {
+      rpcPost({ jsonrpc: "2.0", id: id, result: result });
+    }
+
+    function rpcRespondError(id, code, message) {
+      rpcPost({ jsonrpc: "2.0", id: id, error: { code: code, message: message } });
+    }
+
+    function rpcRequest(method, params, timeoutMs, timeoutMessage) {
+      if (window.parent === window) return Promise.reject(new Error("no-bridge"));
+      return new Promise(function (resolve, reject) {
+        var id = "cortex-rpc-" + (++rpcSeq);
+        var timer = setTimeout(function () {
+          delete rpcPending[id];
+          reject(new Error(timeoutMessage || "no-bridge"));
+        }, timeoutMs);
+        rpcPending[id] = {
+          resolve: function (v) { clearTimeout(timer); resolve(v); },
+          reject: function (e) { clearTimeout(timer); reject(e); }
+        };
+        try {
+          rpcPost({ jsonrpc: "2.0", id: id, method: method, params: params });
+        } catch (e) {
+          clearTimeout(timer);
+          delete rpcPending[id];
+          reject(e);
+        }
+      });
+    }
+
+    // Handshake eagerly so the first submit already knows which bridge works.
+    // A host that never answers is fine — the submit path falls back to the
+    // injected-helper and legacy mcp-ui bridges below.
+    if (window.parent !== window) {
+      rpcRequest("ui/initialize", {
+        appInfo: { name: "cortex-query-widget", version: "1.0.0" },
+        appCapabilities: {},
+        protocolVersion: "2025-11-21"
+      }, 3000).then(function () {
+        rpcReady = true;
+        rpcPost({ jsonrpc: "2.0", method: "ui/notifications/initialized", params: {} });
+      }, function () { /* not an MCP Apps JSON-RPC host; fall back on submit */ });
+    }
+
     // ---- Host bridge ---------------------------------------------------------
-    // Primary: OpenAI/MCP Apps injected helper, if the host provides one.
+    // Primary: MCP Apps JSON-RPC bridge, once its handshake has succeeded.
+    // Next: OpenAI-style injected helper, if the host provides one.
     // Fallback: mcp-ui async postMessage protocol (type:"tool" ->
-    // "ui-message-response"). If neither responds, degrade to an unavailable
+    // "ui-message-response"). If none responds, degrade to an unavailable
     // state instead of failing silently.
     function callTool(params) {
+      if (rpcReady) {
+        return rpcRequest(
+          "tools/call",
+          { name: TOOL_NAME, arguments: params },
+          BRIDGE_TIMEOUT_MS,
+          "host bridge timed out"
+        );
+      }
       var host = window.openai;
       if (host && typeof host.callTool === "function") {
         var call;


### PR DESCRIPTION
## What

Three coordinated changes so the MCP Apps query widget works beyond direct HTTP connections (bead `syslog-mcp-8e5uj`):

1. **Embedded-resource fallback (opt-in).** Successful `search` / `filter` / `tail` / `errors` results now additionally carry the widget HTML as an embedded-resource content block (`ui://cortex/query-widget`, `text/html;profile=mcp-app`, annotated `audience: ["user"]`), gated behind the new `CORTEX_WIDGET_EMBED` env var (default **off**).
2. **Dual-format tool UI meta.** The `cortex` tool now emits both formats the ext-apps SDK tells hosts to check: the modern flat `_meta["ui/resourceUri"]` key alongside the legacy nested `_meta.ui` object.
3. **Official MCP Apps bridge in the widget.** `query_widget.html` now speaks JSON-RPC 2.0 over postMessage as its primary host bridge: eager `ui/initialize` handshake, `ui/notifications/initialized`, `tools/call` requests, `ping`/`ui/resource-teardown` handling, and rendering of host-pushed `ui/notifications/tool-result`. The existing `window.openai.callTool` helper and legacy mcp-ui `type:"tool"` protocol remain as ordered fallbacks.

## Why

Live debugging showed the widget never renders when cortex is reached through the claude.ai connector proxy: the proxy exposes tools only and the client reports `does not support resources`, so hosts can never hydrate `_meta.ui.resourceUri` and show a permanent "Rendering widget cortex" placeholder. Server-side was verified correct (initialize advertises `resources`, direct `resources/read` returns the HTML).

Separately, auditing against `modelcontextprotocol/ext-apps` showed the widget's host bridge predated the official protocol — even on a host that rendered it, every search would have failed with "Host bridge unavailable".

## Reviewer notes

- `CORTEX_WIDGET_EMBED` defaults off deliberately: the widget is ~16 KiB per result, and hosts that ignore `audience` annotations would feed it to the model on every query. Operators opt in per deployment.
- The env read is cached in a `OnceLock`; parsing and gating are pure functions with sidecar tests (`parse_widget_embed`, `should_embed_widget`, `embedded_widget_content` shape, dual-meta assertion in the `tools/list` test).
- In the widget, the JSON-RPC listener and the legacy mcp-ui listener share `window` messages but are disjoint by shape (`jsonrpc` field vs `type`/`messageId`).
- `cargo clippy` clean; `cargo test --lib mcp::` 148/148 green locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the MCP query widget work on hosts that don’t support `resources/read` by embedding the widget in tool results (opt-in) and adding the official MCP Apps JSON‑RPC bridge. Also emit both UI meta formats so more hosts can render the widget.

- **New Features**
  - Embed the query widget HTML in successful `search`/`filter`/`tail`/`errors` results as an embedded resource (`ui://cortex/query-widget`, `text/html;profile=mcp-app`, audience `user`), gated by `CORTEX_WIDGET_EMBED` (default off).
  - Expose both `_meta["ui/resourceUri"]` and legacy `_meta.ui` for the `cortex` tool so newer and older hosts find the widget.
  - Add a JSON‑RPC 2.0 postMessage bridge in `query_widget.html` (`ui/initialize`, `ui/notifications/initialized`, `tools/call`, `ping`, `ui/resource-teardown`, and render `ui/notifications/tool-result`), with `window.openai.callTool` and legacy mcp‑ui as fallbacks.

- **Migration**
  - No action needed for hosts with `resources/read`.
  - For hosts that expose tools only (e.g., Claude connector proxy), set `CORTEX_WIDGET_EMBED=true` to embed the widget in tool results.

<sup>Written for commit 7c1caf35678944757fc8ac21e4151f462e1ee5e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in query widget for selected search and diagnostics actions when required access is unavailable.
  * The widget now works with MCP Apps hosts through the standard JSON-RPC bridge, while retaining compatibility with existing integration methods.
  * Expanded tool metadata to improve widget resource discovery across supported MCP clients.

* **Documentation**
  * Documented the configuration option for enabling query widget embedding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->