### PR TITLE
feat(notifications): heartbeat-silence and stream-silence fleet alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,17 @@ CORTEX_GOOGLE_CLIENT_ID=...         # required when CORTEX_AUTH_MODE=oauth
 CORTEX_GOOGLE_CLIENT_SECRET=...     # required when CORTEX_AUTH_MODE=oauth
 # Paths, TTLs, allowlist → config.toml [mcp.auth] (not env vars). See docs/OAUTH.md.
 
+# Fleet-silence notifications (ride the Apprise pipeline; see also CORTEX_NOTIFICATIONS_*)
+CORTEX_NOTIFICATIONS_HEARTBEAT_SILENCE=true        # notify when a host's newest heartbeat goes stale
+CORTEX_NOTIFICATIONS_HEARTBEAT_SILENCE_SECS=600    # heartbeat age that counts as silent (10 min)
+CORTEX_NOTIFICATIONS_STREAM_SILENCE=true           # notify when a previously-active log stream stops
+CORTEX_NOTIFICATIONS_STREAM_SILENCE_SECS=3600      # stream age that counts as silent (1 h)
+CORTEX_NOTIFICATIONS_STREAM_SILENCE_KINDS=syslog-udp,syslog-tcp,agent-docker,docker-stream,docker-event,file-tail
+CORTEX_NOTIFICATIONS_SILENCE_FORGET_SECS=604800    # outages older than this stop alerting (7 d); must exceed both thresholds
+# Both rules fire ONCE per outage (the stalled last-seen timestamp rides in the dedup key).
+# Expected streams are learned from observation via the stream_last_seen rollup (migration 43),
+# refreshed each evaluator cycle and seeded from a bounded 24h window on first run.
+
 # Non-MCP REST API (always on; gated by its token)
 CORTEX_API_TOKEN=your-api-token         # REQUIRED at startup — /api/* is always mounted
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,9 +144,47 @@ pub struct NotificationEvaluatorsConfig {
     /// Age of the newest ingested row (seconds) after which ingest is
     /// considered silent. Default: 900 (15 minutes).
     pub ingest_silence_threshold_secs: u64,
+    /// Enable heartbeat-silence detection: fire when a host's latest accepted
+    /// heartbeat is older than `heartbeat_silence_threshold_secs`. Fires once
+    /// per outage — the host's last heartbeat timestamp rides in the dedup
+    /// key, so a continuing outage does not re-page every dedup window.
+    /// Default: true.
+    pub heartbeat_silence: bool,
+    /// Age of a host's newest accepted heartbeat (seconds) after which the
+    /// host is considered silent. Default: 600 (10 minutes).
+    pub heartbeat_silence_threshold_secs: u64,
+    /// Enable stream-silence detection: fire when a previously-active log
+    /// stream (hostname + source kind) stops producing rows for longer than
+    /// `stream_silence_threshold_secs`. Expected streams are learned from
+    /// observation (the `stream_last_seen` rollup), since agents do not
+    /// report their collector configuration. Fires once per outage, like
+    /// `heartbeat_silence`. Default: true.
+    pub stream_silence: bool,
+    /// Age of a stream's newest row (seconds) after which the stream is
+    /// considered silent. Default: 3600 (1 hour).
+    pub stream_silence_threshold_secs: u64,
+    /// Source kinds eligible for stream-silence alerts. Only continuous
+    /// streams belong here — sporadic, activity-driven kinds (transcripts,
+    /// shell history, agent commands) would alert on every quiet afternoon.
+    pub stream_silence_kinds: Vec<String>,
+    /// Outages older than this (seconds) stop alerting, and stream rollup
+    /// entries this stale are pruned — a decommissioned host or stream must
+    /// not stay eligible for paging forever. Shared by heartbeat- and
+    /// stream-silence. Default: 604800 (7 days).
+    pub silence_forget_secs: u64,
     /// How often to run evaluation (seconds). Default: 300 (5 minutes).
     pub evaluator_interval_secs: u64,
 }
+
+/// Default source kinds for stream-silence alerting: the continuous streams.
+pub const DEFAULT_STREAM_SILENCE_KINDS: &[&str] = &[
+    "syslog-udp",
+    "syslog-tcp",
+    "agent-docker",
+    "docker-stream",
+    "docker-event",
+    "file-tail",
+];
 
 impl Default for NotificationEvaluatorsConfig {
     fn default() -> Self {
@@ -159,6 +197,15 @@ impl Default for NotificationEvaluatorsConfig {
             ingest_queue_pressure: true,
             ingest_silence: true,
             ingest_silence_threshold_secs: 900,
+            heartbeat_silence: true,
+            heartbeat_silence_threshold_secs: 600,
+            stream_silence: true,
+            stream_silence_threshold_secs: 3600,
+            stream_silence_kinds: DEFAULT_STREAM_SILENCE_KINDS
+                .iter()
+                .map(|kind| kind.to_string())
+                .collect(),
+            silence_forget_secs: 604_800,
             evaluator_interval_secs: 300,
         }
     }
@@ -1125,6 +1172,36 @@ impl Config {
             "CORTEX_NOTIFICATIONS_APPRISE_URLS",
             &mut config.notifications.apprise_urls,
         );
+        env_override_bool(
+            "CORTEX_NOTIFICATIONS_HEARTBEAT_SILENCE",
+            &mut config.notifications.evaluators.heartbeat_silence,
+        )?;
+        env_override_parse(
+            "CORTEX_NOTIFICATIONS_HEARTBEAT_SILENCE_SECS",
+            &mut config
+                .notifications
+                .evaluators
+                .heartbeat_silence_threshold_secs,
+        )?;
+        env_override_bool(
+            "CORTEX_NOTIFICATIONS_STREAM_SILENCE",
+            &mut config.notifications.evaluators.stream_silence,
+        )?;
+        env_override_parse(
+            "CORTEX_NOTIFICATIONS_STREAM_SILENCE_SECS",
+            &mut config
+                .notifications
+                .evaluators
+                .stream_silence_threshold_secs,
+        )?;
+        env_override_list(
+            "CORTEX_NOTIFICATIONS_STREAM_SILENCE_KINDS",
+            &mut config.notifications.evaluators.stream_silence_kinds,
+        );
+        env_override_parse(
+            "CORTEX_NOTIFICATIONS_SILENCE_FORGET_SECS",
+            &mut config.notifications.evaluators.silence_forget_secs,
+        )?;
 
         env_override_bool(
             "CORTEX_DOCKER_INGEST_ENABLED",
@@ -1813,6 +1890,44 @@ fn validate_notifications_config(cfg: &NotificationsConfig) -> anyhow::Result<()
             "[notifications] ingest_silence_threshold_secs must be > 0 when \
              ingest_silence is enabled"
         );
+    }
+    if cfg.evaluators.heartbeat_silence && cfg.evaluators.heartbeat_silence_threshold_secs == 0 {
+        anyhow::bail!(
+            "[notifications] heartbeat_silence_threshold_secs must be > 0 when \
+             heartbeat_silence is enabled"
+        );
+    }
+    if cfg.evaluators.stream_silence {
+        if cfg.evaluators.stream_silence_threshold_secs == 0 {
+            anyhow::bail!(
+                "[notifications] stream_silence_threshold_secs must be > 0 when \
+                 stream_silence is enabled"
+            );
+        }
+        if cfg
+            .evaluators
+            .stream_silence_kinds
+            .iter()
+            .all(|kind| kind.trim().is_empty())
+        {
+            anyhow::bail!(
+                "[notifications] stream_silence_kinds must not be empty when \
+                 stream_silence is enabled (set stream_silence = false to disable)"
+            );
+        }
+    }
+    if cfg.evaluators.heartbeat_silence || cfg.evaluators.stream_silence {
+        let max_threshold = cfg
+            .evaluators
+            .heartbeat_silence_threshold_secs
+            .max(cfg.evaluators.stream_silence_threshold_secs);
+        if cfg.evaluators.silence_forget_secs <= max_threshold {
+            anyhow::bail!(
+                "[notifications] silence_forget_secs must exceed the silence \
+                 thresholds (forget: {}, max threshold: {max_threshold})",
+                cfg.evaluators.silence_forget_secs
+            );
+        }
     }
     // Trim whitespace before checking emptiness to catch " " entries.
     // Delivery requires BOTH the Apprise API base URL (`apprise_url`, where the

--- a/src/config_tests.rs
+++ b/src/config_tests.rs
@@ -1584,3 +1584,75 @@ fn recovery_db_size_no_adjust_when_max_near_default() {
         "recovery_db_size_mb should stay at default (900) when max is only 2x default (2048)"
     );
 }
+
+#[test]
+fn heartbeat_silence_zero_threshold_rejected_when_enabled() {
+    let mut cfg = NotificationsConfig::default();
+    cfg.evaluators.heartbeat_silence = true;
+    cfg.evaluators.heartbeat_silence_threshold_secs = 0;
+    let err = validate_notifications_config(&cfg).expect_err("zero threshold must fail");
+    assert!(
+        err.to_string().contains("heartbeat_silence_threshold_secs"),
+        "wrong error: {err}"
+    );
+}
+
+#[test]
+fn stream_silence_zero_threshold_rejected_when_enabled() {
+    let mut cfg = NotificationsConfig::default();
+    cfg.evaluators.stream_silence = true;
+    cfg.evaluators.stream_silence_threshold_secs = 0;
+    let err = validate_notifications_config(&cfg).expect_err("zero threshold must fail");
+    assert!(
+        err.to_string().contains("stream_silence_threshold_secs"),
+        "wrong error: {err}"
+    );
+}
+
+#[test]
+fn stream_silence_empty_kinds_rejected_when_enabled() {
+    let mut cfg = NotificationsConfig::default();
+    cfg.evaluators.stream_silence = true;
+    cfg.evaluators.stream_silence_kinds = vec!["  ".to_string()];
+    let err = validate_notifications_config(&cfg).expect_err("blank kinds must fail");
+    assert!(
+        err.to_string().contains("stream_silence_kinds"),
+        "wrong error: {err}"
+    );
+}
+
+#[test]
+fn silence_forget_must_exceed_thresholds() {
+    let mut cfg = NotificationsConfig::default();
+    cfg.evaluators.silence_forget_secs = 3600; // == stream threshold default
+    let err = validate_notifications_config(&cfg).expect_err("forget <= threshold must fail");
+    assert!(
+        err.to_string().contains("silence_forget_secs"),
+        "wrong error: {err}"
+    );
+}
+
+#[test]
+fn silence_rules_disabled_skip_threshold_checks() {
+    let mut cfg = NotificationsConfig::default();
+    cfg.evaluators.heartbeat_silence = false;
+    cfg.evaluators.stream_silence = false;
+    cfg.evaluators.heartbeat_silence_threshold_secs = 0;
+    cfg.evaluators.stream_silence_threshold_secs = 0;
+    cfg.evaluators.silence_forget_secs = 0;
+    assert!(validate_notifications_config(&cfg).is_ok());
+}
+
+#[test]
+fn silence_defaults_pass_validation() {
+    let cfg = NotificationsConfig::default();
+    assert!(validate_notifications_config(&cfg).is_ok());
+    assert_eq!(cfg.evaluators.heartbeat_silence_threshold_secs, 600);
+    assert_eq!(cfg.evaluators.stream_silence_threshold_secs, 3600);
+    assert_eq!(cfg.evaluators.silence_forget_secs, 604_800);
+    assert!(
+        cfg.evaluators
+            .stream_silence_kinds
+            .contains(&"agent-docker".to_string())
+    );
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -27,6 +27,7 @@ mod queries_service_instances;
 mod skill_events;
 mod skill_incident_evidence;
 mod skill_incidents;
+pub(crate) mod stream_health;
 
 pub(crate) use analytics::PATTERN_SCAN_LIMIT_MAX;
 pub use analytics::{
@@ -50,8 +51,9 @@ pub use graph_findings::{
 };
 pub use heartbeat::{
     HeartbeatHostLookup, HeartbeatHostState, HeartbeatLatestEntry, HeartbeatMetricSnapshot,
-    HeartbeatSampleState, HeartbeatStateFlags, HeartbeatWindowSummary, heartbeat_host_state,
-    heartbeat_latest_all, heartbeat_metric_snapshot_batch, heartbeat_window_summaries,
+    HeartbeatSampleState, HeartbeatStateFlags, HeartbeatWindowSummary, StaleHeartbeatHost,
+    heartbeat_host_state, heartbeat_latest_all, heartbeat_metric_snapshot_batch,
+    heartbeat_window_summaries, stale_heartbeat_hosts,
 };
 pub(crate) use hook_events::insert_hook_events_in_tx;
 pub use hook_events::{

--- a/src/db/heartbeat.rs
+++ b/src/db/heartbeat.rs
@@ -140,6 +140,48 @@ pub struct HeartbeatMetricSnapshot {
     pub container_unhealthy_count: Option<i64>,
 }
 
+/// A host whose latest accepted heartbeat has gone stale.
+#[derive(Debug, Clone)]
+pub struct StaleHeartbeatHost {
+    pub host_id: String,
+    pub hostname: String,
+    pub received_at: String,
+    pub age_secs: u64,
+}
+
+/// Hosts whose newest heartbeat is older than `threshold_secs` but younger
+/// than `forget_secs` — the heartbeat_silence notification rule's input.
+/// O(hosts) scan of the small `host_heartbeats_latest` cache; the forget
+/// bound keeps decommissioned hosts from staying alert-eligible forever.
+pub fn stale_heartbeat_hosts(
+    conn: &rusqlite::Connection,
+    threshold_secs: u64,
+    forget_secs: u64,
+) -> Result<Vec<StaleHeartbeatHost>> {
+    let age_expr = "CAST(strftime('%s','now') AS INTEGER) - \
+                    CAST(strftime('%s', received_at) AS INTEGER)";
+    // Thresholds are trusted u64 config values, inlined because SQLite does
+    // not allow SELECT aliases in WHERE.
+    let sql = format!(
+        "SELECT host_id, hostname, received_at, {age_expr} AS age_secs
+         FROM host_heartbeats_latest
+         WHERE ({age_expr}) > {threshold_secs} AND ({age_expr}) < {forget_secs}
+         ORDER BY hostname ASC"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(StaleHeartbeatHost {
+                host_id: row.get(0)?,
+                hostname: row.get(1)?,
+                received_at: row.get(2)?,
+                age_secs: row.get::<_, i64>(3)?.max(0) as u64,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
 /// Return all entries from `host_heartbeats_latest`, ordered by hostname.
 ///
 /// This is an O(hosts) full scan of a small cache table — it deliberately

--- a/src/db/heartbeat_tests.rs
+++ b/src/db/heartbeat_tests.rs
@@ -421,3 +421,64 @@ fn heartbeat_window_summaries_resolves_latest_sample_metrics() {
     assert_eq!(one[0].max_cpu_usage_percent, Some(80.0));
     assert_eq!(one[0].min_mem_available_bytes, Some(2_000));
 }
+
+mod stale_heartbeat_hosts_tests {
+    use rusqlite::Connection;
+
+    fn conn_with_latest(entries: &[(&str, &str, i64)]) -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            "CREATE TABLE host_heartbeats_latest (
+                 host_id       TEXT PRIMARY KEY,
+                 heartbeat_id  INTEGER NOT NULL,
+                 hostname      TEXT NOT NULL,
+                 sampled_at    TEXT NOT NULL,
+                 received_at   TEXT NOT NULL,
+                 partial       INTEGER NOT NULL DEFAULT 0,
+                 agent_version TEXT NOT NULL DEFAULT '',
+                 os            TEXT NOT NULL DEFAULT '',
+                 architecture  TEXT NOT NULL DEFAULT '',
+                 metadata_json TEXT
+             );",
+        )
+        .expect("schema");
+        for (host_id, hostname, age_secs) in entries {
+            conn.execute(
+                "INSERT INTO host_heartbeats_latest
+                     (host_id, heartbeat_id, hostname, sampled_at, received_at)
+                 VALUES (?1, 1, ?2,
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now', printf('-%d seconds', ?3)),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now', printf('-%d seconds', ?3)))",
+                rusqlite::params![host_id, hostname, age_secs],
+            )
+            .expect("insert");
+        }
+        conn
+    }
+
+    #[test]
+    fn returns_only_hosts_between_threshold_and_forget() {
+        let conn = conn_with_latest(&[
+            ("id-fresh", "dookie", 30),           // current — below threshold
+            ("id-stale", "shart", 1200),          // stale — alertable
+            ("id-ancient", "steamdeck", 700_000), // past forget horizon
+        ]);
+        let stale = crate::db::stale_heartbeat_hosts(&conn, 600, 604_800).expect("query");
+        assert_eq!(
+            stale.len(),
+            1,
+            "only the stale-but-remembered host: {stale:?}"
+        );
+        assert_eq!(stale[0].hostname, "shart");
+        assert_eq!(stale[0].host_id, "id-stale");
+        assert!(stale[0].age_secs > 600 && stale[0].age_secs < 2000);
+        assert!(!stale[0].received_at.is_empty());
+    }
+
+    #[test]
+    fn empty_table_yields_no_hosts() {
+        let conn = conn_with_latest(&[]);
+        let stale = crate::db::stale_heartbeat_hosts(&conn, 600, 604_800).expect("query");
+        assert!(stale.is_empty());
+    }
+}

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -39,7 +39,7 @@ pub fn write_lock() -> parking_lot::ReentrantMutexGuard<'static, ()> {
     WRITE_LOCK.lock()
 }
 
-pub const KNOWN_SCHEMA_VERSION: i64 = 42;
+pub const KNOWN_SCHEMA_VERSION: i64 = 43;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SchemaVersionInfo {
@@ -2486,6 +2486,27 @@ pub fn init_pool(config: &StorageConfig) -> Result<DbPool> {
              COMMIT;",
         )?;
         tracing::info!("Migration 42: added refuted trust level to graph_entity_aliases");
+    }
+
+    // Migration 43: `stream_last_seen` — one row per (hostname, source_kind),
+    // maintained by the notification evaluator each cycle. Foundation for the
+    // stream_silence rule: alerting needs "newest row per host + source kind"
+    // and the logs table cannot answer that cheaply (source kind lives inside
+    // metadata_json). No backfill here — the evaluator seeds the table from a
+    // bounded window on its first cycle, keeping migration time flat.
+    if !migration_applied(&conn, 43)? {
+        conn.execute_batch(
+            "BEGIN IMMEDIATE;
+             CREATE TABLE IF NOT EXISTS stream_last_seen (
+                 hostname     TEXT NOT NULL,
+                 source_kind  TEXT NOT NULL,
+                 last_seen_at TEXT NOT NULL,
+                 PRIMARY KEY (hostname, source_kind)
+             ) WITHOUT ROWID;
+             INSERT OR IGNORE INTO schema_migrations (version) VALUES (43);
+             COMMIT;",
+        )?;
+        tracing::info!("Migration 43: stream_last_seen rollup for stream-silence alerting");
     }
 
     if table_exists(&conn, "host_heartbeats")? && table_exists(&conn, "host_heartbeats_latest")? {

--- a/src/db/stream_health.rs
+++ b/src/db/stream_health.rs
@@ -1,0 +1,140 @@
+//! Per-stream last-seen rollup for stream-silence alerting.
+//!
+//! `stream_last_seen` (migration 43) holds one row per `(hostname,
+//! source_kind)` with the newest `received_at` observed for that stream. The
+//! notification evaluator refreshes it each cycle from a bounded window of
+//! recent rows, then alerts on entries whose age crosses
+//! `stream_silence_threshold_secs` — "this stream used to produce logs and
+//! stopped". The logs table itself cannot answer that cheaply: source kind
+//! lives inside `metadata_json`, so a direct newest-row-per-stream query
+//! would scan and JSON-parse the whole window every cycle.
+//!
+//! The rollup tracks ALL kinds it observes; the alert query applies the
+//! configured kind allowlist. Entries older than the forget horizon are
+//! pruned so decommissioned streams stop being alert-eligible.
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+/// Window used to seed an empty rollup on the evaluator's first cycle.
+/// Bounded so the one-time seed scan stays predictable; streams already
+/// silent for longer than this at seed time never enter the rollup and
+/// therefore never alert (documented tradeoff vs. a startup-blocking
+/// backfill over the full retention window).
+pub const STREAM_SEED_WINDOW_SECS: u64 = 86_400;
+
+/// Classify a log row's source kind. Single source of truth shared with
+/// `ingest_health::ingest_source_kind_health` — prefix-mapped synthetic
+/// sources first, then the denormalised `metadata_json.source_kind`.
+const SOURCE_KIND_CASE: &str = "CASE
+        WHEN ai_transcript_path IS NOT NULL OR source_ip LIKE 'transcript://%' THEN 'transcript'
+        WHEN source_ip LIKE 'docker://%' THEN 'docker-stream'
+        WHEN source_ip LIKE 'docker-event://%' THEN 'docker-event'
+        WHEN source_ip LIKE 'agent-command://%' THEN 'agent-command'
+        WHEN source_ip LIKE 'shell-history://%' THEN 'shell-history'
+        WHEN source_ip LIKE 'file-tail://%' THEN 'file-tail'
+        ELSE json_extract(metadata_json, '$.source_kind')
+    END";
+
+/// A stream that was active in the past but has gone silent.
+#[derive(Debug, Clone)]
+pub struct SilentStream {
+    pub hostname: String,
+    pub source_kind: String,
+    pub last_seen_at: String,
+    pub age_secs: u64,
+}
+
+/// True when the rollup has no rows yet (fresh migration) — the caller
+/// should refresh with [`STREAM_SEED_WINDOW_SECS`] instead of the cycle
+/// window.
+pub fn stream_last_seen_is_empty(conn: &Connection) -> Result<bool> {
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM stream_last_seen", [], |row| {
+        row.get(0)
+    })?;
+    Ok(count == 0)
+}
+
+/// Fold the newest `received_at` per `(hostname, source_kind)` from the last
+/// `window_secs` seconds of logs into the rollup. Monotonic: a conflict only
+/// moves `last_seen_at` forward, so overlapping or stale windows can never
+/// regress an entry.
+pub fn refresh_stream_last_seen(conn: &Connection, window_secs: u64) -> Result<usize> {
+    let sql = format!(
+        "INSERT INTO stream_last_seen (hostname, source_kind, last_seen_at)
+         SELECT hostname, kind, MAX(received_at)
+         FROM (
+             SELECT hostname, {SOURCE_KIND_CASE} AS kind, received_at
+             FROM logs
+             WHERE received_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', printf('-%d seconds', ?1))
+         )
+         WHERE kind IS NOT NULL AND kind != ''
+         GROUP BY hostname, kind
+         ON CONFLICT (hostname, source_kind) DO UPDATE SET
+             last_seen_at = CASE
+                 WHEN excluded.last_seen_at > stream_last_seen.last_seen_at
+                 THEN excluded.last_seen_at
+                 ELSE stream_last_seen.last_seen_at
+             END"
+    );
+    let changed = conn.execute(&sql, rusqlite::params![window_secs as i64])?;
+    Ok(changed)
+}
+
+/// Streams whose newest row is older than `threshold_secs` but younger than
+/// `forget_secs`, restricted to the configured kind allowlist. The forget
+/// bound keeps long-dead streams from re-alerting after every dedup window
+/// until pruning catches up.
+pub fn silent_streams(
+    conn: &Connection,
+    kinds: &[String],
+    threshold_secs: u64,
+    forget_secs: u64,
+) -> Result<Vec<SilentStream>> {
+    if kinds.is_empty() {
+        return Ok(Vec::new());
+    }
+    let placeholders = (1..=kinds.len())
+        .map(|i| format!("?{i}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    // Threshold and forget are trusted u64 config values, inlined because
+    // SQLite does not allow SELECT aliases in WHERE; the sender-controlled
+    // kind strings stay bound as parameters.
+    let age_expr = "CAST(strftime('%s','now') AS INTEGER) - \
+                    CAST(strftime('%s', last_seen_at) AS INTEGER)";
+    let sql = format!(
+        "SELECT hostname, source_kind, last_seen_at, {age_expr} AS age_secs
+         FROM stream_last_seen
+         WHERE ({age_expr}) > {threshold_secs} AND ({age_expr}) < {forget_secs}
+           AND source_kind IN ({placeholders})
+         ORDER BY hostname ASC, source_kind ASC"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(kinds.iter()), |row| {
+            Ok(SilentStream {
+                hostname: row.get(0)?,
+                source_kind: row.get(1)?,
+                last_seen_at: row.get(2)?,
+                age_secs: row.get::<_, i64>(3)?.max(0) as u64,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// Drop rollup entries older than the forget horizon.
+pub fn prune_stream_last_seen(conn: &Connection, forget_secs: u64) -> Result<usize> {
+    let deleted = conn.execute(
+        "DELETE FROM stream_last_seen
+         WHERE CAST(strftime('%s','now') AS INTEGER) -
+               CAST(strftime('%s', last_seen_at) AS INTEGER) >= ?1",
+        rusqlite::params![forget_secs as i64],
+    )?;
+    Ok(deleted)
+}
+
+#[cfg(test)]
+#[path = "stream_health_tests.rs"]
+mod tests;

--- a/src/db/stream_health_tests.rs
+++ b/src/db/stream_health_tests.rs
@@ -1,0 +1,167 @@
+use rusqlite::Connection;
+
+use super::{
+    prune_stream_last_seen, refresh_stream_last_seen, silent_streams, stream_last_seen_is_empty,
+};
+
+fn conn_with_schema() -> Connection {
+    let conn = Connection::open_in_memory().expect("in-memory db");
+    conn.execute_batch(
+        "CREATE TABLE stream_last_seen (
+             hostname     TEXT NOT NULL,
+             source_kind  TEXT NOT NULL,
+             last_seen_at TEXT NOT NULL,
+             PRIMARY KEY (hostname, source_kind)
+         ) WITHOUT ROWID;
+         CREATE TABLE logs (
+             id INTEGER PRIMARY KEY AUTOINCREMENT,
+             hostname TEXT NOT NULL,
+             source_ip TEXT NOT NULL DEFAULT '',
+             ai_transcript_path TEXT,
+             metadata_json TEXT,
+             received_at TEXT NOT NULL
+         );",
+    )
+    .expect("schema");
+    conn
+}
+
+/// Insert a log row `age_secs` in the past.
+fn insert_log(
+    conn: &Connection,
+    hostname: &str,
+    source_ip: &str,
+    metadata: Option<&str>,
+    age_secs: i64,
+) {
+    conn.execute(
+        "INSERT INTO logs (hostname, source_ip, metadata_json, received_at)
+         VALUES (?1, ?2, ?3, strftime('%Y-%m-%dT%H:%M:%fZ', 'now', printf('-%d seconds', ?4)))",
+        rusqlite::params![hostname, source_ip, metadata, age_secs],
+    )
+    .expect("insert log");
+}
+
+fn rollup_entry(conn: &Connection, hostname: &str, kind: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT last_seen_at FROM stream_last_seen WHERE hostname = ?1 AND source_kind = ?2",
+        rusqlite::params![hostname, kind],
+        |row| row.get(0),
+    )
+    .ok()
+}
+
+fn seed_rollup(conn: &Connection, hostname: &str, kind: &str, age_secs: i64) {
+    conn.execute(
+        "INSERT INTO stream_last_seen (hostname, source_kind, last_seen_at)
+         VALUES (?1, ?2, strftime('%Y-%m-%dT%H:%M:%fZ', 'now', printf('-%d seconds', ?3)))",
+        rusqlite::params![hostname, kind, age_secs],
+    )
+    .expect("seed rollup");
+}
+
+#[test]
+fn refresh_classifies_prefixes_and_metadata_kinds() {
+    let conn = conn_with_schema();
+    insert_log(&conn, "tootie", "docker://tootie/plex/stdout", None, 10);
+    insert_log(
+        &conn,
+        "dookie",
+        "10.1.0.6:1234",
+        Some(r#"{"source_kind":"agent-docker"}"#),
+        10,
+    );
+    insert_log(&conn, "squirts", "10.1.0.8:99", None, 10); // no kind — skipped
+
+    refresh_stream_last_seen(&conn, 3600).expect("refresh");
+
+    assert!(rollup_entry(&conn, "tootie", "docker-stream").is_some());
+    assert!(rollup_entry(&conn, "dookie", "agent-docker").is_some());
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM stream_last_seen", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 2, "kindless row must not create an entry");
+}
+
+#[test]
+fn refresh_is_monotonic_and_window_bounded() {
+    let conn = conn_with_schema();
+    seed_rollup(&conn, "tootie", "syslog-tcp", 30);
+    // An older row inside the window must not regress the newer entry.
+    insert_log(
+        &conn,
+        "tootie",
+        "1.2.3.4:1",
+        Some(r#"{"source_kind":"syslog-tcp"}"#),
+        600,
+    );
+    // A row outside the window must be invisible to the refresh.
+    insert_log(
+        &conn,
+        "shart",
+        "1.2.3.5:1",
+        Some(r#"{"source_kind":"syslog-tcp"}"#),
+        7200,
+    );
+
+    refresh_stream_last_seen(&conn, 3600).expect("refresh");
+
+    let kept = rollup_entry(&conn, "tootie", "syslog-tcp").expect("entry");
+    let age: i64 = conn
+        .query_row(
+            "SELECT CAST(strftime('%s','now') AS INTEGER) - CAST(strftime('%s', ?1) AS INTEGER)",
+            [&kept],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(age < 120, "newer rollup value must survive, got age {age}s");
+    assert!(
+        rollup_entry(&conn, "shart", "syslog-tcp").is_none(),
+        "row outside window must not enter the rollup"
+    );
+}
+
+#[test]
+fn silent_streams_applies_threshold_forget_and_kind_bounds() {
+    let conn = conn_with_schema();
+    seed_rollup(&conn, "tootie", "agent-docker", 7200); // silent 2h — alertable
+    seed_rollup(&conn, "dookie", "agent-docker", 60); // fresh — not silent
+    seed_rollup(&conn, "shart", "agent-docker", 700_000); // past forget — ignored
+    seed_rollup(&conn, "tootie", "shell-history", 7200); // silent but kind not listed
+
+    let kinds = vec!["agent-docker".to_string()];
+    let silent = silent_streams(&conn, &kinds, 3600, 604_800).expect("query");
+
+    assert_eq!(silent.len(), 1, "exactly one alertable stream: {silent:?}");
+    assert_eq!(silent[0].hostname, "tootie");
+    assert_eq!(silent[0].source_kind, "agent-docker");
+    assert!(silent[0].age_secs > 3600 && silent[0].age_secs < 8000);
+}
+
+#[test]
+fn silent_streams_empty_kinds_returns_nothing() {
+    let conn = conn_with_schema();
+    seed_rollup(&conn, "tootie", "agent-docker", 7200);
+    let silent = silent_streams(&conn, &[], 3600, 604_800).expect("query");
+    assert!(silent.is_empty());
+}
+
+#[test]
+fn prune_drops_only_forgotten_entries() {
+    let conn = conn_with_schema();
+    seed_rollup(&conn, "tootie", "agent-docker", 700_000);
+    seed_rollup(&conn, "dookie", "agent-docker", 60);
+
+    let deleted = prune_stream_last_seen(&conn, 604_800).expect("prune");
+    assert_eq!(deleted, 1);
+    assert!(rollup_entry(&conn, "dookie", "agent-docker").is_some());
+    assert!(rollup_entry(&conn, "tootie", "agent-docker").is_none());
+}
+
+#[test]
+fn is_empty_reflects_rollup_population() {
+    let conn = conn_with_schema();
+    assert!(stream_last_seen_is_empty(&conn).unwrap());
+    seed_rollup(&conn, "tootie", "agent-docker", 60);
+    assert!(!stream_last_seen_is_empty(&conn).unwrap());
+}

--- a/src/notifications/evaluator.rs
+++ b/src/notifications/evaluator.rs
@@ -21,7 +21,8 @@ use crate::config::NotificationsConfig;
 use crate::db::DbPool;
 use crate::notifications::rules::{
     LogRow, evaluate_authelia_mfa_fail, evaluate_container_die_nonzero, evaluate_fail2ban_ban,
-    evaluate_ingest_silence, evaluate_oom_kill,
+    evaluate_heartbeat_silence, evaluate_ingest_silence, evaluate_oom_kill,
+    evaluate_stream_silence,
 };
 
 /// Run one evaluation cycle.
@@ -38,6 +39,58 @@ pub(crate) async fn run_evaluation_cycle(
 ) -> Result<u64> {
     let apprise_urls_json = build_urls_json(&cfg);
     let window_secs = cfg.evaluators.evaluator_interval_secs * 2; // look back 2x interval
+
+    // --- Phase 0: stream rollup maintenance (write — permit held) ------------
+    // Fold the newest row per (hostname, source kind) from the recent window
+    // into `stream_last_seen`, then prune entries past the forget horizon.
+    // Runs BEFORE evaluation so silence checks see the freshest state — a
+    // stream that resumed inside this window must not alert from its stale
+    // rollup entry. On failure the stream rule is skipped for this cycle
+    // rather than evaluated against stale data.
+    let mut stream_rollup_ok = false;
+    if cfg.evaluators.stream_silence {
+        let Ok(_permit) = Arc::clone(&permit_sem).acquire_owned().await else {
+            tracing::error!("evaluator: maintenance semaphore closed, skipping stream rollup");
+            return Ok(0);
+        };
+        let pool_m = Arc::clone(&pool);
+        let forget_secs = cfg.evaluators.silence_forget_secs;
+        let exec_start = Instant::now();
+        let rollup_result = tokio::task::spawn_blocking(move || -> Result<()> {
+            let _permit = _permit;
+            let conn = pool_m.get()?;
+            let window = if crate::db::stream_health::stream_last_seen_is_empty(&conn)? {
+                tracing::info!(
+                    seed_window_secs = crate::db::stream_health::STREAM_SEED_WINDOW_SECS,
+                    "stream_last_seen is empty; seeding from bounded window"
+                );
+                crate::db::stream_health::STREAM_SEED_WINDOW_SECS
+            } else {
+                window_secs
+            };
+            crate::db::stream_health::refresh_stream_last_seen(&conn, window)?;
+            crate::db::stream_health::prune_stream_last_seen(&conn, forget_secs)?;
+            Ok(())
+        })
+        .await;
+        let exec_ms = exec_start.elapsed().as_millis();
+        match rollup_result {
+            Ok(Ok(())) => {
+                stream_rollup_ok = true;
+                if exec_ms > SLOW_DB_MS {
+                    tracing::warn!(op = "notif.stream_rollup", exec_ms, "db op ok");
+                } else {
+                    tracing::debug!(op = "notif.stream_rollup", exec_ms, "db op ok");
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(op = "notif.stream_rollup", exec_ms, error = %e, "stream rollup failed; skipping stream_silence this cycle");
+            }
+            Err(e) => {
+                tracing::warn!(op = "notif.stream_rollup", exec_ms, error = %e, "stream rollup join error; skipping stream_silence this cycle");
+            }
+        }
+    }
 
     // --- Phase 1: fetch + evaluate (NO permit needed — read-only DB access) ---
     // Paginate in batches of 1,000 rows up to a 50,000 row total cap to avoid
@@ -91,6 +144,49 @@ pub(crate) async fn run_evaluation_cycle(
                     cfg.evaluators.ingest_silence_threshold_secs,
                     &apprise_urls_json,
                 ));
+            }
+
+            // Metric rule: heartbeat silence. O(hosts) scan of the
+            // host_heartbeats_latest cache; threshold and forget bounds are
+            // applied in SQL, so every returned host fires.
+            if cfg.evaluators.heartbeat_silence {
+                let stale = crate::db::stale_heartbeat_hosts(
+                    &conn,
+                    cfg.evaluators.heartbeat_silence_threshold_secs,
+                    cfg.evaluators.silence_forget_secs,
+                )?;
+                for host in stale {
+                    out.push(evaluate_heartbeat_silence(
+                        &host.host_id,
+                        &host.hostname,
+                        &host.received_at,
+                        host.age_secs,
+                        cfg.evaluators.heartbeat_silence_threshold_secs,
+                        &apprise_urls_json,
+                    ));
+                }
+            }
+
+            // Metric rule: stream silence. Reads the rollup phase 0 just
+            // refreshed; skipped when the refresh failed so stale entries
+            // cannot false-positive.
+            if stream_rollup_ok {
+                let silent = crate::db::stream_health::silent_streams(
+                    &conn,
+                    &cfg.evaluators.stream_silence_kinds,
+                    cfg.evaluators.stream_silence_threshold_secs,
+                    cfg.evaluators.silence_forget_secs,
+                )?;
+                for stream in silent {
+                    out.push(evaluate_stream_silence(
+                        &stream.hostname,
+                        &stream.source_kind,
+                        &stream.last_seen_at,
+                        stream.age_secs,
+                        cfg.evaluators.stream_silence_threshold_secs,
+                        &apprise_urls_json,
+                    ));
+                }
             }
             drop(conn);
             Ok(out)

--- a/src/notifications/rules.rs
+++ b/src/notifications/rules.rs
@@ -302,6 +302,94 @@ pub fn evaluate_ingest_silence(
     })
 }
 
+/// Evaluate heartbeat silence for one host — the agent-level complement to
+/// `evaluate_ingest_silence` (bead syslog-mcp-5uqus).
+///
+/// Like the other metric rules this takes precomputed inputs: the evaluator
+/// reads stale hosts from `host_heartbeats_latest` (already bounded by
+/// threshold and forget horizon in SQL) and calls this per host.
+///
+/// **Fires once per outage**: `last_heartbeat_at` rides in the dedup key, so
+/// the same outage maps to the same key forever — the dispatcher's firings
+/// dedup then drops re-enqueues. A recovery followed by a new outage changes
+/// `last_heartbeat_at` and produces a fresh key.
+pub fn evaluate_heartbeat_silence(
+    host_id: &str,
+    hostname: &str,
+    last_heartbeat_at: &str,
+    age_secs: u64,
+    threshold_secs: u64,
+    apprise_urls_json: &str,
+) -> OutboxInsertParams {
+    let age_mins = age_secs / 60;
+    let title = escape_for_notification(&format!(
+        "[CRITICAL] cortex agent silent on {hostname}: no heartbeat for {age_mins} min"
+    ));
+    let body = escape_for_notification(&format!(
+        "The cortex agent on **{hostname}** has not delivered a heartbeat for \
+         {age_mins} minutes (threshold: {} min). Last accepted heartbeat: \
+         {last_heartbeat_at}.\n\n\
+         Likely causes: agent process/container down, host offline or \
+         rebooting, or the heartbeat target unreachable from the host. Check \
+         `cortex action=fleet_state` and the agent service on the host.",
+        threshold_secs / 60
+    ));
+    OutboxInsertParams {
+        // Keyed on host_id, not hostname — host_id is the stable identity
+        // (hostnames can collide across agents); the display fields stay
+        // human-readable.
+        dedup_key: format!("heartbeat_silence:{host_id}:{last_heartbeat_at}"),
+        rule_id: "heartbeat_silence".to_string(),
+        severity: "critical".to_string(),
+        hostname: hostname.to_string(),
+        title,
+        body,
+        apprise_urls_json: apprise_urls_json.to_string(),
+        next_attempt_at: backoff_next_attempt_at(0),
+    }
+}
+
+/// Evaluate stream silence for one previously-active log stream.
+///
+/// The evaluator maintains `stream_last_seen` (newest row per hostname +
+/// source kind) and calls this for entries older than the threshold but
+/// inside the forget horizon, restricted to the configured kind allowlist.
+/// Same once-per-outage dedup shape as [`evaluate_heartbeat_silence`]: the
+/// stalled `last_seen_at` value keys the outage.
+pub fn evaluate_stream_silence(
+    hostname: &str,
+    source_kind: &str,
+    last_seen_at: &str,
+    age_secs: u64,
+    threshold_secs: u64,
+    apprise_urls_json: &str,
+) -> OutboxInsertParams {
+    let age_mins = age_secs / 60;
+    let title = escape_for_notification(&format!(
+        "[WARNING] cortex stream silent: {source_kind} from {hostname} stopped {age_mins} min ago"
+    ));
+    let body = escape_for_notification(&format!(
+        "**{hostname}** had been sending `{source_kind}` logs but none have \
+         arrived for {age_mins} minutes (threshold: {} min). Last row: \
+         {last_seen_at}.\n\n\
+         The host is otherwise reachable if its heartbeat is current — check \
+         the specific forwarder (docker socket access, tailed file rotation, \
+         syslog forwarding) on the host. `cortex action=filter` with \
+         host/source_kind narrows it down.",
+        threshold_secs / 60
+    ));
+    OutboxInsertParams {
+        dedup_key: format!("stream_silence:{hostname}:{source_kind}:{last_seen_at}"),
+        rule_id: "stream_silence".to_string(),
+        severity: "warning".to_string(),
+        hostname: hostname.to_string(),
+        title,
+        body,
+        apprise_urls_json: apprise_urls_json.to_string(),
+        next_attempt_at: backoff_next_attempt_at(0),
+    }
+}
+
 #[cfg(test)]
 #[path = "rules_tests.rs"]
 mod tests;

--- a/src/notifications/rules_tests.rs
+++ b/src/notifications/rules_tests.rs
@@ -292,3 +292,58 @@ fn ingest_silence_empty_db_does_not_fire() {
 fn ingest_silence_zero_threshold_does_not_fire() {
     assert!(evaluate_ingest_silence("dookie", Some(10_000), 0, "[]").is_none());
 }
+
+#[test]
+fn heartbeat_silence_builds_once_per_outage_dedup_key() {
+    let params = evaluate_heartbeat_silence(
+        "syslog_7014e4ed",
+        "shart",
+        "2026-07-14T18:34:36.613Z",
+        200_000,
+        600,
+        "[\"gotify://x\"]",
+    );
+    assert_eq!(params.rule_id, "heartbeat_silence");
+    assert_eq!(params.severity, "critical");
+    assert_eq!(params.hostname, "shart");
+    assert_eq!(
+        params.dedup_key, "heartbeat_silence:syslog_7014e4ed:2026-07-14T18:34:36.613Z",
+        "host_id plus the stalled heartbeat timestamp key the outage — same outage, same key"
+    );
+    assert!(params.title.contains("shart"));
+    assert!(params.body.contains("2026-07-14T18:34:36.613Z"));
+    assert!(params.body.contains("threshold: 10 min"));
+
+    // A recovery followed by a new outage produces a different key.
+    let next = evaluate_heartbeat_silence(
+        "syslog_7014e4ed",
+        "shart",
+        "2026-07-20T00:00:00.000Z",
+        900,
+        600,
+        "[\"gotify://x\"]",
+    );
+    assert_ne!(params.dedup_key, next.dedup_key);
+}
+
+#[test]
+fn stream_silence_builds_once_per_outage_dedup_key() {
+    let params = evaluate_stream_silence(
+        "tootie",
+        "agent-docker",
+        "2026-07-16T20:00:00.000Z",
+        7200,
+        3600,
+        "[\"gotify://x\"]",
+    );
+    assert_eq!(params.rule_id, "stream_silence");
+    assert_eq!(params.severity, "warning");
+    assert_eq!(params.hostname, "tootie");
+    assert_eq!(
+        params.dedup_key,
+        "stream_silence:tootie:agent-docker:2026-07-16T20:00:00.000Z"
+    );
+    assert!(params.title.contains("agent-docker"));
+    assert!(params.title.contains("tootie"));
+    assert!(params.body.contains("threshold: 60 min"));
+}


### PR DESCRIPTION
## What

Two configurable fleet-health alert rules through the existing evaluator → outbox → dispatcher → Apprise pipeline (gotify in prod), bead `syslog-mcp-5uqus`:

1. **`heartbeat_silence` (critical)** — fires when a host's newest accepted heartbeat is older than `CORTEX_NOTIFICATIONS_HEARTBEAT_SILENCE_SECS` (default **600s / 10 min**). Input is an O(hosts) scan of the `host_heartbeats_latest` cache with threshold and forget bounds applied in SQL.
2. **`stream_silence` (warning)** — fires when a previously-active log stream (hostname + source kind) has produced no rows for longer than `CORTEX_NOTIFICATIONS_STREAM_SILENCE_SECS` (default **3600s / 1 h**). Kinds are allowlisted via `CORTEX_NOTIFICATIONS_STREAM_SILENCE_KINDS` (default: `syslog-udp, syslog-tcp, agent-docker, docker-stream, docker-event, file-tail`) so sporadic activity-driven kinds (transcripts, shell history, agent commands) never alert.

## Design

- **`stream_last_seen` rollup (migration 43).** "Newest row per host + source kind" cannot be answered cheaply from `logs` (kind lives in `metadata_json`), so a tiny `(hostname, source_kind, last_seen_at)` table is folded forward each evaluator cycle from just the cycle window (new phase 0, permit-held, monotonic upsert), and seeded from a bounded 24h window on first run instead of a startup-blocking backfill. Kind classification reuses the exact CASE from `ingest_health.rs`. On a rollup refresh failure the stream rule is skipped that cycle rather than evaluated against stale data.
- **Once per outage.** The stalled last-seen timestamp (plus `host_id` for heartbeats — hostnames can collide) rides in the dedup key, so a continuing outage maps to one key forever and the dispatcher's firings dedup drops re-enqueues. Recovery followed by a new outage produces a fresh key and a fresh notification.
- **Forget horizon.** `CORTEX_NOTIFICATIONS_SILENCE_FORGET_SECS` (default 7d, validated > both thresholds): older outages stop alerting and rollup entries are pruned — a decommissioned host or stream cannot stay alert-eligible forever. Streams silent longer than the 24h seed window at first deploy never enter the rollup (documented tradeoff).
- **Expected streams are learned, not declared** — agents don't report their collector config, so observation is the only honest source.

## Reviewer notes

- `KNOWN_SCHEMA_VERSION` bumped 42 → 43.
- All six knobs are env-mapped (evaluator settings were previously config.toml-only, which the Docker deployment can't reach); startup validation rejects zero thresholds, blank kind lists, and forget ≤ threshold.
- Tests: rollup refresh/monotonicity/window-bounds/prune, silent-stream threshold/forget/kind bounds, stale-heartbeat bounds, dedup-key composition for both rules, and config validation. Full `cargo test` green locally; clippy clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fleet-silence alerts: a critical heartbeat-silence rule and a warning stream-silence rule. Alerts fire once per outage, and a new `stream_last_seen` rollup tracks per-host stream activity.

- **New Features**
  - Heartbeat silence (critical): alerts when a host’s newest heartbeat exceeds threshold (default 600s). O(hosts) scan of `host_heartbeats_latest`. Dedup key uses `host_id` + last heartbeat.
  - Stream silence (warning): alerts when a previously-active stream (hostname + source kind) exceeds threshold (default 3600s). Uses the `stream_last_seen` rollup; expected streams are learned from observation; kinds are allowlisted to continuous sources. Skips the rule if rollup refresh fails that cycle.
  - Forget horizon: `silence_forget_secs` (default 7d) stops paging for long-dead hosts/streams and prunes rollup entries.
  - Config (env overrides): `CORTEX_NOTIFICATIONS_HEARTBEAT_SILENCE`, `CORTEX_NOTIFICATIONS_HEARTBEAT_SILENCE_SECS`, `CORTEX_NOTIFICATIONS_STREAM_SILENCE`, `CORTEX_NOTIFICATIONS_STREAM_SILENCE_SECS`, `CORTEX_NOTIFICATIONS_STREAM_SILENCE_KINDS`, `CORTEX_NOTIFICATIONS_SILENCE_FORGET_SECS`. Validation enforces non-zero thresholds, non-empty kinds, and forget > thresholds.

- **Migration**
  - Schema 43 adds `stream_last_seen` (PRIMARY KEY: hostname + source_kind). The evaluator seeds it from a bounded 24h window on first run and refreshes each cycle. No manual backfill required.

<sup>Written for commit 07c7525b40da54e39dab0add844c6f9d13f8cce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/cortex/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

